### PR TITLE
Feat: Separate blocks by short indicator lines on the left of a block.

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -1,2 +1,3 @@
 # TODO: Any thoughts on a better name?
-block_line_ratio: 0.13
+block_line_ratio: 0.19
+left_line_length_threshold: 7

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -138,7 +138,9 @@ def process_page(page: fitz.Page, ground_truth_for_file: GroundTruthForFile, tmp
                 color=fitz.utils.getColor("red"),
             )
             description_lines = get_description_lines(lines, material_description_rect)
-            description_blocks = get_description_blocks(description_lines, geometric_lines, params["block_line_ratio"])
+            description_blocks = get_description_blocks(
+                description_lines, geometric_lines, params["block_line_ratio"], params["left_line_length_threshold"]
+            )
             for index, block in enumerate(description_blocks):
                 correct = ground_truth_for_file.is_correct(block.text)
                 draw_layer(

--- a/src/stratigraphy/util/depthcolumn.py
+++ b/src/stratigraphy/util/depthcolumn.py
@@ -301,7 +301,11 @@ class BoundaryDepthColumn(DepthColumn):
         current_intervals = []
         current_blocks = []
         all_blocks = get_description_blocks(
-            description_lines, geometric_lines, params["block_line_ratio"], target_layer_count=len(depth_intervals)
+            description_lines,
+            geometric_lines,
+            params["block_line_ratio"],
+            left_line_length_threshold=params["left_line_length_threshold"],
+            target_layer_count=len(depth_intervals),
         )
 
         block_index = 0

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -21,8 +21,22 @@ def get_description_blocks(
     description_lines: list[TextLine],
     geometric_lines: list[Line],
     block_line_ratio: float,
+    left_line_length_threshold: float,
     target_layer_count: int = None,
 ) -> list[TextBlock]:
+    """Group the description lines into blocks based on the presence of geometric lines, the indentation of lines
+    and the vertical spacing between lines.
+
+    Args:
+        description_lines (list[TextLine]): The text lines to group into blocks.
+        geometric_lines (list[Line]): The geometric lines detected in the pdf page.
+        block_line_ratio (float): The relative part a line has to cross a block in order to induce a splitting.
+        left_line_length_threshold (float): The minimum length of a line segment on the left side of a block to split it.
+        target_layer_count (int, optional): Expected number of blocks. Defaults to None.
+
+    Returns:
+        list[TextBlock]: A list of blocks containing the description lines.
+    """
     distances = []
     for line_index in range(len(description_lines) - 1):
         line1rect = description_lines[line_index].rect
@@ -44,7 +58,17 @@ def get_description_blocks(
             ):
                 blocks.append(TextBlock(current_block_lines, is_terminated_by_line=True))
                 current_block_lines = []
-
+            elif _block_separated_by_lefthandside_line_segment(
+                last_line,
+                line,
+                TextBlock(current_block_lines),
+                geometric_lines,
+                length_threshold=left_line_length_threshold,
+            ):
+                blocks.append(
+                    TextBlock(current_block_lines, is_terminated_by_line=False)
+                )  # we consider a splitting due to a lefthandside line segment as weak.
+                current_block_lines = []
         current_block_lines.append(line)
     if len(current_block_lines):
         blocks.append(TextBlock(current_block_lines))
@@ -59,34 +83,73 @@ def get_description_blocks(
         # vertical spacing between text.
         min_block_count = 2 / 3 * target_layer_count
 
+    count_blocks_divided_by_line = len([block for block in blocks if block.is_terminated_by_line])
     if len(blocks) < min_block_count:
-        # No good splitting by lines found, so create blocks by looking at vertical spacing instead
-        blocks = []
-        current_block_lines = []
-        for line in description_lines:
-            if len(current_block_lines) > 0:
-                last_line = current_block_lines[-1]
-                if (
-                    line.rect.y0 > last_line.rect.y1 + 5
-                    or (  # upper boundary of line is higher up than lower boundary plus 5 points of last line.
-                        threshold and line.rect.y0 > last_line.rect.y1 and line.rect.y0 > last_line.rect.y0 + threshold
-                    )
-                ):
-                    blocks.append(TextBlock(current_block_lines))
-                    current_block_lines = []
+        # This case means that there are fewer blocks than the minimum number of blocks we expect.
+        # In this case we redo all the blocks from scratch.
+        blocks = _split_block_by_vertical_spacing(description_lines, threshold=threshold)
 
-            current_block_lines.append(line)
-        if len(current_block_lines):
-            blocks.append(TextBlock(current_block_lines))
-
+    elif count_blocks_divided_by_line < min_block_count:
+        # In this case there blocks due to line segments. However, they are mostly due to small segments
+        # on the lefthandside of the blocks. Minimum there are fewer blocks due to lines than min_block_count.
+        # Often, these lefthandside lines are only used when space is tight. If space is not tight, those
+        # indicators are dropped. That's why we have to consider vertical spacing as well.
+        _blocks = []
+        for block in blocks:
+            _blocks.extend(_split_block_by_vertical_spacing(block.lines, threshold=threshold))
+        blocks = _blocks
     blocks = [new_block for block in blocks for new_block in block.split_based_on_indentation()]
 
     return blocks
 
 
+def _split_block_by_vertical_spacing(description_lines: list[TextLine], threshold: int) -> list[TextBlock]:
+    """Split the description lines into blocks based on the vertical spacing between the text lines.
+
+    Args:
+        description_lines (list[TextLine]): The text lines to split into blocks.
+        threshold (int): The maximum vertical distance between two lines to be considered part of the same block.
+
+    Returns:
+        list[TextBlock]: List of blocks.
+    """
+    # No good splitting by lines found, so create blocks by looking at vertical spacing instead
+    blocks = []
+    current_block_lines = []
+    for line in description_lines:
+        if len(current_block_lines) > 0:
+            last_line = current_block_lines[-1]
+            if (
+                line.rect.y0 > last_line.rect.y1 + 5
+                or (  # upper boundary of line is higher up than lower boundary plus 5 points of last line.
+                    threshold and line.rect.y0 > last_line.rect.y1 and line.rect.y0 > last_line.rect.y0 + threshold
+                )
+            ):
+                blocks.append(TextBlock(current_block_lines))
+                current_block_lines = []
+
+        current_block_lines.append(line)
+    if len(current_block_lines):
+        blocks.append(TextBlock(current_block_lines))
+
+    return blocks
+
+
 def _block_separated_by_line(
-    last_line: TextLine, current_line: TextLine, block: TextBlock, geometric_lines: list[Line], threshold
+    last_line: TextLine, current_line: TextLine, block: TextBlock, geometric_lines: list[Line], threshold: float
 ) -> bool:
+    """Check if a block is separated by a line.
+
+    Args:
+        last_line (TextLine): The previous line.
+        current_line (TextLine): The current line.
+        block (TextBlock): Current block.
+        geometric_lines (list[Line]): The geometric lines detected in the pdf page.
+        threshold (float): Percentage of the block width that needs to be covered by a line.
+
+    Returns:
+        bool: True if the block is separated by a line, False otherwise.
+    """
     last_line_y_coordinate = (last_line.rect.y0 + last_line.rect.y1) / 2
     current_line_y_coordinate = (current_line.rect.y0 + current_line.rect.y1) / 2
     for line in geometric_lines:
@@ -100,5 +163,37 @@ def _block_separated_by_line(
 
         line_ends_block = last_line_y_coordinate < line_y_coordinate and line_y_coordinate < current_line_y_coordinate
         if is_line_long_enough and line_ends_block:
+            return True
+    return False
+
+
+def _block_separated_by_lefthandside_line_segment(
+    last_line: TextLine, current_line: TextLine, block: TextBlock, geometric_lines: list[Line], length_threshold: int
+) -> bool:
+    """Check if a block is separated by a line segment on the left side of the block.
+
+    Args:
+        last_line (TextLine): The previous line.
+        current_line (TextLine): The current line.
+        block (TextBlock): Current block.
+        geometric_lines (list[Line]): The geometric lines detected in the pdf page.
+        length_threshold (int): The minimum length of a line segment on the left side of a block to split it.
+
+    Returns:
+        bool: True if the block is separated by a line segment, False otherwise.
+    """
+    last_line_y_coordinate = (last_line.rect.y0 + last_line.rect.y1) / 2
+    current_line_y_coordinate = (current_line.rect.y0 + current_line.rect.y1) / 2
+
+    for line in geometric_lines:
+        line_y_coordinate = (line.start.y + line.end.y) / 2
+
+        line_cuts_lefthandside_of_block = line.start.x < block.rect.x0 and line.end.x > block.rect.x0
+        is_line_long_enough = (
+            np.abs(line.start.x - line.end.x) > length_threshold
+        )  # for the block splitting, we only care about x-extension
+
+        line_ends_block = last_line_y_coordinate < line_y_coordinate and line_y_coordinate < current_line_y_coordinate
+        if is_line_long_enough and line_ends_block and line_cuts_lefthandside_of_block:
             return True
     return False

--- a/src/stratigraphy/util/geometric_line_utilities.py
+++ b/src/stratigraphy/util/geometric_line_utilities.py
@@ -111,7 +111,7 @@ def merge_parallel_lines_approximately(
     return merged_lines
 
 
-def merge_parallel_lines_efficiently(lines: list[Line], tol: int = 8, angle_threshold: float = 0.1) -> list[Line]:
+def merge_parallel_lines_efficiently(lines: list[Line], tol: int = 8, angle_threshold: float = 2) -> list[Line]:
     """Merge parallel lines that are close to each other.
 
     This merging algorithm first sorts lines by their intercept and slope and then only compares neighbours. This
@@ -133,7 +133,7 @@ def merge_parallel_lines_efficiently(lines: list[Line], tol: int = 8, angle_thre
     Args:
         lines (list[Line]): The lines to merge.
         tol (int, optional): Tolerance to check if lines are close. Defaults to 8.
-        angle_threshold (float, optional): Acceptable difference between the slopes of two lines. Defaults to 0.1.
+        angle_threshold (float, optional): Acceptable difference between the slopes of two lines. Defaults to 2.
 
     Returns:
         list[Line]: The merged lines.

--- a/src/stratigraphy/util/interval.py
+++ b/src/stratigraphy/util/interval.py
@@ -5,7 +5,6 @@ import abc
 import fitz
 
 from stratigraphy.util.depthcolumnentry import DepthColumnEntry, LayerDepthColumnEntry
-from stratigraphy.util.find_description import get_description_blocks
 from stratigraphy.util.line import TextLine
 from stratigraphy.util.textblock import TextBlock
 


### PR DESCRIPTION
**Implementation of left line splitting of blocks**
This PR contains the code and parameter to split blocks based on small indicator lines on the lefthandside of the blocks. These lines are often used when space is tight, and come in conjunction with what we call 'splitting due to vertical distances'.
Overall, **F1 improved from 86.3% to 86.7%.** The changes are mainly driven due to a few documents where larger improvements could be made.

**Document level metric changes:**
The below table contains all documents that have a change in their F1 metric. 'left_splitting' indicates the new metrics, obtained with this PR:

There are mostly improvements, but a few cases come with a lowering in the score. Sometimes it's not so clear why (typically documents that have a low score anyways). Sometimes the worsening is due to a non recognized line split. This happens because we lowered `block_line_ratio`. It was needed to lower this parameter, as otherwise some left line splits would be recognized as complete lines. It matters, as we still look for splitting due to vertical spacing in the case of left line splits, which we don't do for complete horizontal lines. We can rethink this heuristic together.

|    | document_name    |   F1_left_splitting |   precision_left_splitting |   recall_left_splitting |   Number Elements_left_splitting |   Number wrong elements_left_splitting |        F1 |   precision |   recall |   Number Elements |   Number wrong elements |
|---:|:-----------------|--------------------:|---------------------------:|------------------------:|---------------------------------:|---------------------------------------:|----------:|------------:|---------:|------------------:|------------------------:|
|  0 | 680244005-bp.pdf |           0.285714  |                  0.315789  |                0.26087  |                               46 |                                     34 | 0.309524  |   0.342105  | 0.282609 |                46 |                      33 |
|  1 | 268124635-bp.pdf |           0.766667  |                  0.766667  |                0.766667 |                               30 |                                      7 | 0.833333  |   0.833333  | 0.833333 |                30 |                       5 |
|  2 | 267123080-bp.pdf |           0.888889  |                  0.857143  |                0.923077 |                               13 |                                      1 | 0.814815  |   0.785714  | 0.846154 |                13 |                       2 |
|  3 | 268124569-bp.pdf |           1         |                  1         |                1        |                               64 |                                      0 | 0.79646   |   0.918367  | 0.703125 |                64 |                      19 |
|  4 | 699248001-bp.pdf |           0.767857  |                  0.843137  |                0.704918 |                               61 |                                     18 | 0.621359  |   0.761905  | 0.52459  |                61 |                      29 |
|  5 | 268125447-bp.pdf |           0.363636  |                  0.4       |                0.333333 |                               18 |                                     12 | 0.424242  |   0.466667  | 0.388889 |                18 |                      11 |
|  6 | 268124125-bp.pdf |           0.0263158 |                  0.0178571 |                0.05     |                               20 |                                     19 | 0.0273973 |   0.0188679 | 0.05     |                20 |                      19 |
|  7 | 691251009-bp.pdf |           0.25      |                  0.333333  |                0.2      |                               20 |                                     16 | 0.266667  |   0.4       | 0.2      |                20 |                      16 |
|  8 | 268124307-bp.pdf |           0.862745  |                  0.846154  |                0.88     |                               25 |                                      3 | 0.923077  |   0.888889  | 0.96     |                25 |                       1 |
|  9 | 677250019-bp.pdf |           0.823529  |                  0.777778  |                0.875    |                                8 |                                      1 | 0.588235  |   0.555556  | 0.625    |                 8 |                       3 |
| 10 | 267123060-bp.pdf |           0.941176  |                  0.888889  |                1        |                                8 |                                      0 | 0.75      |   0.75      | 0.75     |                 8 |                       2 |
| 11 | 680244002-bp.pdf |           0.44      |                  0.458333  |                0.423077 |                               26 |                                     15 | 0.4       |   0.416667  | 0.384615 |                26 |                      16 |
| 12 | 268124599-bp.pdf |           0.5       |                  0.4       |                0.666667 |                                3 |                                      1 | 0.444444  |   0.333333  | 0.666667 |                 3 |                       1 |
| 13 | 267124070-bp.pdf |           0.816327  |                  0.869565  |                0.769231 |                               26 |                                      6 | 0.857143  |   0.913043  | 0.807692 |                26 |                       5 |


**Examples:** (Left before, right after)
267123060-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/4a6f3076-c0ca-48de-8b96-4f7658106a4e)
--> Dashed line recognised as a left line splitting.

677250019-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/1a7e4ef7-6513-4e76-b5a3-258088f43964)
--> All splits due to lines are now correct. We expect one block too much and that's why the last block is split into two.

268124307-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/2d4dbbb3-41df-4d18-9010-310d9f7c1da9)
Line not detected any more. This is due to lowering the `block_line_ratio` parameter. Worsening of result in this case.

699248001-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/9a9185bf-0ca2-4f18-bdb2-ea46dfee9c65)
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/c4acc132-9a60-49df-9073-e94c5ae5fb59)
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/2e5410ea-b8ae-4913-a56e-180288796fe5)
--> Overall, good improvement (+14%F1). But still untapped potential left. Not all blocks are split due to the lefthand line segments. This is mainly due to the fact, that the lines do not "cross" the block edge. And if they do, they're not horizontal, and thus cross the block "too high". --> For the future: explore the splitting condition and try to cover this case as well.

268124569-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/e699fe92-c22c-4d83-a8cd-f42e7be821d5)
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/53b49083-078c-4a0e-bbc5-96c0619c0190)
--> perfect example, with the left line splitting we reach 100% recognition rate.

268124635-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/713e09f3-0b89-4ac3-93a3-f044bf068c68)
--> not so clear what happens here. F1 drops. Seems that the lower `block_line_ratio` lead to not recognizing a line split.