### PR TITLE
Feat/indicator lines v2

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -1,3 +1,3 @@
 # TODO: Any thoughts on a better name?
-block_line_ratio: 0.19
+block_line_ratio: 0.13
 left_line_length_threshold: 7

--- a/src/stratigraphy/line_detection.py
+++ b/src/stratigraphy/line_detection.py
@@ -94,6 +94,7 @@ if __name__ == "__main__":
         "675230002-bp.pdf",
         "268125592-bp.pdf",
         "267124070-bp.pdf",
+        "699248001-bp.pdf",
     ]
 
     if mlflow_tracking:

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -220,12 +220,14 @@ def _block_separated_by_lefthandside_line_segment(
 
         line_ends_block = last_line_y_coordinate < line_y_coordinate and line_y_coordinate < current_line_y_coordinate
 
-        alternative_condition = (
+        weak_condition = (
             (line.start.x - 5 < block.rect.x0 and line.end.x > block.rect.x0)
             and (np.abs(line.start.x - line.end.x) > length_threshold - 2)
             and (len(block.lines) > 1)
         )  # if block has at least three lines, we weaken the splitting condition.
+        # It is three lines because the statement means that block.lines has at least two elements.
+        # The third line is current_line
 
-        if line_ends_block and ((is_line_long_enough and line_cuts_lefthandside_of_block) or alternative_condition):
+        if line_ends_block and ((is_line_long_enough and line_cuts_lefthandside_of_block) or weak_condition):
             return True
     return False

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import fitz
 import numpy as np
 
@@ -48,30 +50,30 @@ def get_description_blocks(
     if len(distances):
         threshold = min(distances) * 1.15
 
-    blocks = []
-    current_block_lines = []
-    for line in description_lines:
-        if len(current_block_lines) > 0:
-            last_line = current_block_lines[-1]
-            if _block_separated_by_line(
-                last_line, line, TextBlock(current_block_lines), geometric_lines, threshold=block_line_ratio
-            ):
-                blocks.append(TextBlock(current_block_lines, is_terminated_by_line=True))
-                current_block_lines = []
-            elif _block_separated_by_lefthandside_line_segment(
-                last_line,
-                line,
-                TextBlock(current_block_lines),
+    # Create blocks separated by lines
+    blocks = _create_blocks_by_separator(
+        description_lines,
+        geometric_lines,
+        _block_separated_by_line,
+        {"threshold": block_line_ratio},
+        set_terminated_by_line_flag=True,
+    )
+
+    # Create blocks separated by lefthandside line segments
+    _blocks = []
+    for block in blocks:
+        _blocks.extend(
+            _create_blocks_by_separator(
+                block.lines,
                 geometric_lines,
-                length_threshold=left_line_length_threshold,
-            ):
-                blocks.append(
-                    TextBlock(current_block_lines, is_terminated_by_line=False)
-                )  # we consider a splitting due to a lefthandside line segment as weak.
-                current_block_lines = []
-        current_block_lines.append(line)
-    if len(current_block_lines):
-        blocks.append(TextBlock(current_block_lines))
+                _block_separated_by_lefthandside_line_segment,
+                {"length_threshold": left_line_length_threshold},
+                set_terminated_by_line_flag=False,
+            )
+        )
+        if block.is_terminated_by_line:  # keep the line termination if it was there
+            _blocks[-1].is_terminated_by_line = True
+    blocks = _blocks
 
     if target_layer_count is None:
         # If we have only found one splitting line, then we fall back to considering vertical spacing, as it is more
@@ -100,6 +102,29 @@ def get_description_blocks(
         blocks = _blocks
     blocks = [new_block for block in blocks for new_block in block.split_based_on_indentation()]
 
+    return blocks
+
+
+def _create_blocks_by_separator(
+    description_lines: list[TextLine],
+    geometric_lines: list[Line],
+    separator_condition: Callable,
+    separator_params,
+    set_terminated_by_line_flag: bool,
+) -> list[TextBlock]:
+    blocks = []
+    current_block_lines = []
+    for line in description_lines:
+        if len(current_block_lines) > 0:
+            last_line = current_block_lines[-1]
+            if separator_condition(
+                last_line, line, TextBlock(current_block_lines), geometric_lines, **separator_params
+            ):
+                blocks.append(TextBlock(current_block_lines, is_terminated_by_line=set_terminated_by_line_flag))
+                current_block_lines = []
+        current_block_lines.append(line)
+    if len(current_block_lines):
+        blocks.append(TextBlock(current_block_lines))
     return blocks
 
 

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -227,6 +227,9 @@ def _block_separated_by_lefthandside_line_segment(
         )  # if block has at least three lines, we weaken the splitting condition.
         # It is three lines because the statement means that block.lines has at least two elements.
         # The third line is current_line
+        # The reason for the splitting is, that if we know that a block is long, the probability for
+        # a missed splitting is higher. Therefore, we weaken the condition. The weakened condition
+        # leads to an improved score as per 21.03.2024.
 
         if line_ends_block and ((is_line_long_enough and line_cuts_lefthandside_of_block) or weak_condition):
             return True

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -219,6 +219,13 @@ def _block_separated_by_lefthandside_line_segment(
         )  # for the block splitting, we only care about x-extension
 
         line_ends_block = last_line_y_coordinate < line_y_coordinate and line_y_coordinate < current_line_y_coordinate
-        if is_line_long_enough and line_ends_block and line_cuts_lefthandside_of_block:
+
+        alternative_condition = (
+            (line.start.x - 5 < block.rect.x0 and line.end.x > block.rect.x0)
+            and (np.abs(line.start.x - line.end.x) > length_threshold - 2)
+            and (len(block.lines) > 1)
+        )  # if block has at least three lines, we weaken the splitting condition.
+
+        if line_ends_block and ((is_line_long_enough and line_cuts_lefthandside_of_block) or alternative_condition):
             return True
     return False


### PR DESCRIPTION
**Description**
Consider separation of blocks due to lines separate from block separation due to indicator lines on the left.
Included more sophisticated logic for block separation due to indicator lines.

Overall performance in F1 drops from 86.7% to 86.4%.


**Document Level Metrics Change**
|    | document_name    |   F1_new |   Number Elements_new |   Number wrong elements_new |       F1 |   Number Elements |   Number wrong elements |
|---:|:-----------------|--------------------:|---------------------------------:|---------------------------------------:|---------:|------------------:|------------------------:|
|  0 | 680244005-bp.pdf |            0.309524 |                               46 |                                     33 | 0.285714 |                46 |                      34 |
|  1 | 268124635-bp.pdf |            0.833333 |                               30 |                                      5 | 0.766667 |                30 |                       7 |
|  2 | 681246002-bp.pdf |            0.857143 |                               10 |                                      1 | 1        |                10 |                       0 |
|  3 | 699248001-bp.pdf |            0.883333 |                               61 |                                      8 | 0.767857 |                61 |                      18 |
|  4 | 677259003-bp.pdf |            0.714286 |                                7 |                                      2 | 0.857143 |                 7 |                       1 |
|  5 | 691251009-bp.pdf |            0.228571 |                               20 |                                     16 | 0.25     |                20 |                      16 |
|  6 | 268124307-bp.pdf |            0.923077 |                               25 |                                      1 | 0.862745 |                25 |                       3 |
|  7 | 680244002-bp.pdf |            0.36     |                               26 |                                     17 | 0.44     |                26 |                      15 |
|  8 | 268124599-bp.pdf |            0.2      |                                3 |                                      2 | 0.5      |                 3 |                       1 |

**Examples:**
left before | right after

268124635-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/38280ddc-44dd-429f-be2e-5bacb5f5031e)
Result improve. Two blocks correctly identified that were not before.

681246002-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/3e74f4fd-64b8-46e5-95bb-bb92df428fd6)
Result decreases. One block is falsely split.

699248001-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/4c1a9a75-f740-442e-b95a-9c4a497a691b)
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/e8a36d5a-9fa3-44ac-96c5-1eb8b58ccc14)
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/b89c39a9-7b9c-4915-8ba5-043437c0c145)
Big improvement. From previously 18 wrong recognitions we went down to 8.

677259003-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/af7ad35f-ee57-40e3-96e2-acdafc4e0813)
Decrease in performance. One Block is falsely split.

268124307-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/1cc1dab5-cb3d-4c20-8536-40fe99ed6575)
Performance improvment. We gain back what we lost due to increasing block_line_ratio.

680244002-bp.pdf
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/470aa421-3779-4239-8a84-8b01a9644eac)
Performance decrease. Two additional blocks are not recognized in this case. Not so clear why and how.

268124599-bp.pdf	
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/20eefdcc-e0a3-46db-9fde-404518f604a8)
One more block not recognized. Seems blocks are split too often in this case.

**Conclusion**
Overall, 10 mistakes less are made. However, the F1 score (as well as precision and recall) decreased. This is due to the fact, that for most documents the metrics decreased slightly, and for some documents with many blocks, we saw larger improvements. For me, fewer manual annotation are needed using the proposed changes herein, and that's why I deem them better. --> maybe we have to rethink our metrics.
