### PR TITLE
Use material_description_block to determine if line is long enough fo…

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -1,3 +1,3 @@
 # TODO: Any thoughts on a better name?
-block_line_ratio: 0.13
+block_line_ratio: 0.20
 left_line_length_threshold: 7

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -117,7 +117,9 @@ def process_page(page: fitz.Page, ground_truth_for_file: GroundTruthForFile, tmp
                     fitz.utils.draw_rect(  # this affects the line detection
                         page, rect * page.derotation_matrix, color=fitz.utils.getColor("purple")
                     )
-                new_groups = match_columns(depth_column, description_lines, geometric_lines, **params)
+                new_groups = match_columns(
+                    depth_column, description_lines, geometric_lines, material_description_rect, **params
+                )
                 for index, group in enumerate(new_groups):
                     correct = ground_truth_for_file.is_correct(group["block"].text)
                     draw_layer(
@@ -139,7 +141,11 @@ def process_page(page: fitz.Page, ground_truth_for_file: GroundTruthForFile, tmp
             )
             description_lines = get_description_lines(lines, material_description_rect)
             description_blocks = get_description_blocks(
-                description_lines, geometric_lines, params["block_line_ratio"], params["left_line_length_threshold"]
+                description_lines,
+                geometric_lines,
+                material_description_rect,
+                params["block_line_ratio"],
+                params["left_line_length_threshold"],
             )
             for index, block in enumerate(description_blocks):
                 correct = ground_truth_for_file.is_correct(block.text)
@@ -203,11 +209,14 @@ def match_columns(
     depth_column: DepthColumn,
     description_lines: list[TextLine],
     geometric_lines: list[Line],
+    material_description_rect: fitz.Rect,
     **params,
 ):
     return [
         element
-        for group in depth_column.identify_groups(description_lines, geometric_lines, **params)
+        for group in depth_column.identify_groups(
+            description_lines, geometric_lines, material_description_rect, **params
+        )
         for element in transform_groups(group["depth_intervals"], group["blocks"], **params)
     ]
 

--- a/src/stratigraphy/util/depthcolumn.py
+++ b/src/stratigraphy/util/depthcolumn.py
@@ -113,7 +113,13 @@ class LayerDepthColumn(DepthColumn):
 
         return sequence_matches_count / (len(self.entries) - 1) > 0.5
 
-    def identify_groups(self, description_lines: list[TextLine], geometric_lines: list[Line], **params) -> list[dict]:
+    def identify_groups(
+        self,
+        description_lines: list[TextLine],
+        geometric_lines: list[Line],
+        material_description_rect: fitz.Rect,
+        **params,
+    ) -> list[dict]:
         depth_intervals = self.depth_intervals()
 
         groups = []
@@ -293,7 +299,9 @@ class BoundaryDepthColumn(DepthColumn):
 
         return [BoundaryDepthColumn(segment) for segment in segments]
 
-    def identify_groups(self, description_lines: list[TextLine], geometric_lines: list[Line], **params) -> list[dict]:
+    def identify_groups(
+        self, description_lines: list[TextLine], geometric_lines: list[Line], material_description_rect, **params
+    ) -> list[dict]:
         depth_intervals = self.depth_intervals()
 
         groups = []
@@ -303,6 +311,7 @@ class BoundaryDepthColumn(DepthColumn):
         all_blocks = get_description_blocks(
             description_lines,
             geometric_lines,
+            material_description_rect,
             params["block_line_ratio"],
             left_line_length_threshold=params["left_line_length_threshold"],
             target_layer_count=len(depth_intervals),

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -22,6 +22,7 @@ def get_description_lines(lines: list[TextLine], material_description_rect: fitz
 def get_description_blocks(
     description_lines: list[TextLine],
     geometric_lines: list[Line],
+    material_description_rect: fitz.Rect,
     block_line_ratio: float,
     left_line_length_threshold: float,
     target_layer_count: int = None,
@@ -55,7 +56,7 @@ def get_description_blocks(
         description_lines,
         geometric_lines,
         _block_separated_by_line,
-        {"threshold": block_line_ratio},
+        {"threshold": block_line_ratio, "material_description_rect": material_description_rect},
         set_terminated_by_line_flag=True,
     )
 
@@ -161,7 +162,12 @@ def _split_block_by_vertical_spacing(description_lines: list[TextLine], threshol
 
 
 def _block_separated_by_line(
-    last_line: TextLine, current_line: TextLine, block: TextBlock, geometric_lines: list[Line], threshold: float
+    last_line: TextLine,
+    current_line: TextLine,
+    block: TextBlock,
+    geometric_lines: list[Line],
+    material_description_rect: fitz.Rect,
+    threshold: float,
 ) -> bool:
     """Check if a block is separated by a line.
 
@@ -183,7 +189,8 @@ def _block_separated_by_line(
         line_y_coordinate = (line.start.y + line.end.y) / 2
 
         is_line_long_enough = (
-            np.min([block.rect.x1, line_right_x]) - np.max([block.rect.x0, line_left_x]) > threshold * block.rect.width
+            np.min([material_description_rect.x1, line_right_x]) - np.max([material_description_rect.x0, line_left_x])
+            > threshold * material_description_rect.width
         )
 
         line_ends_block = last_line_y_coordinate < line_y_coordinate and line_y_coordinate < current_line_y_coordinate


### PR DESCRIPTION
…r a split.

**Description**
Used material_description_rec to determine if a line is long enough to consider it as a split condition for a block.
While doing so, I once again optimized for the `block_line_ratio` parameter.

F1 increases from 86.4% - 86.6%.

**Document Level Changes**
The changes (almost) exclusively improve the scores on all documents.

|    | document_name    |   F1_new |   Number Elements_new |   Number wrong elements_new |        F1 |   Number Elements |   Number wrong elements |
|---:|:-----------------|---------:|----------------------:|----------------------------:|----------:|------------------:|------------------------:|
|  0 | 680244005-bp.pdf | 0.380952 |                    46 |                          30 | 0.309524  |                46 |                      33 |
|  1 | 677259003-bp.pdf | 0.857143 |                     7 |                           1 | 0.714286  |                 7 |                       2 |
|  2 | 268124125-bp.pdf | 0.025    |                    20 |                          19 | 0.0263158 |                20 |                      19 |
|  3 | 680244002-bp.pdf | 0.44     |                    26 |                          15 | 0.36      |                26 |                      17 |
|  4 | 268124391-bp.pdf | 0.901961 |                    23 |                           0 | 0.92      |                23 |                       0 |

Visual inspection show a (very small) qualitative improvement.
