### PR TITLE
ODR Regression for line merging.

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,6 +10,7 @@ dependencies:
   - pathlib==1.0.1
   - opencv==4.9.0
   - python-dotenv==1.0.1
+  - pytest==8.1.1
   - pip
 # dev dependencies
   - matplotlib==3.8.0

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -29,7 +29,6 @@ mlflow_tracking = os.getenv("MLFLOW_TRACKING") == "True"  # Checks whether MLFlo
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 matching_params = read_params("matching_params.yml")
 

--- a/src/stratigraphy/util/geometric_line_utilities.py
+++ b/src/stratigraphy/util/geometric_line_utilities.py
@@ -177,10 +177,12 @@ def merge_parallel_lines_neighbours(
             current_line, line, tol=tol
         ):
             merged_line = _merge_lines(current_line, line)
-            if merged_line is not None:  # no merge possible
+            if merged_line is not None:
+                # current_line and line were merged
                 current_line = merged_line
                 any_merges = True
                 continue
+        # current_line and line were not merged
         merged_lines.append(current_line)
         current_line = line
     merged_lines.append(current_line)

--- a/src/stratigraphy/util/geometric_line_utilities.py
+++ b/src/stratigraphy/util/geometric_line_utilities.py
@@ -177,14 +177,12 @@ def merge_parallel_lines_neighbours(
             current_line, line, tol=tol
         ):
             merged_line = _merge_lines(current_line, line)
-            if merged_line is None:  # no merge possible
-                merged_lines.append(line)
+            if merged_line is not None:  # no merge possible
+                current_line = merged_line
+                any_merges = True
                 continue
-            current_line = merged_line
-            any_merges = True
-        else:
-            merged_lines.append(current_line)
-            current_line = line
+        merged_lines.append(current_line)
+        current_line = line
     merged_lines.append(current_line)
     if any_merges:
         return merge_parallel_lines_neighbours(merged_lines, sorting_function=sorting_function, tol=tol)
@@ -264,22 +262,22 @@ def _odr_regression(x: ArrayLike, y: ArrayLike) -> tuple:
     return phi, r
 
 
-def _merge_lines(line1: Line, line2: Line) -> Line:
+def _merge_lines(line1: Line, line2: Line) -> Line | None:
     """Merge two lines into one.
 
-    The algorithm performes odr regression on the points of the two lines to find the best fit line.
+    The algorithm performs odr regression on the points of the two lines to find the best fit line.
     Then, it calculates the orthogonal projection of the four points onto the best fit line and takes the two points
     that are the furthest apart. These two points are then used to create the merged line.
 
-    Note: Strictly vertical lines cannot be handled. In that case the slope is nan. A warning is thrown
-    and the first line is returned.
+    Note: a few cases (e.g. the lines are sides of a perfect square) the solution is not well-defined. In such a case,
+    the method returns None.
 
     Args:
         line1 (Line): First line to merge.
         line2 (Line): Second line to merge.
 
     Returns:
-        Line: The merged line.
+        Line | None: The merged line.
     """
     x = np.array([line1.start.x, line1.end.x, line2.start.x, line2.end.x])
     y = np.array([line1.start.y, line1.end.y, line2.start.y, line2.end.y])

--- a/src/stratigraphy/util/geometric_line_utilities.py
+++ b/src/stratigraphy/util/geometric_line_utilities.py
@@ -236,7 +236,7 @@ def merge_parallel_lines(lines: list[Line], tol: int = 8, angle_threshold: float
 def _odr_regression(x: ArrayLike, y: ArrayLike) -> tuple:
     """Perform orthogonal distance regression on the given data.
 
-    Note: If the problem is ill defined (i.e. denominator == nominator == 0),
+    Note: If the problem is ill-defined (i.e. denominator == nominator == 0),
     then the function will return phi=np.nan and r=np.nan.
 
     Args:
@@ -258,6 +258,10 @@ def _odr_regression(x: ArrayLike, y: ArrayLike) -> tuple:
         return np.nan, np.nan
     phi = 0.5 * np.arctan2(nominator, denominator)  # np.arctan2 can deal with np.inf due to zero division.
     r = x_mean * cos(phi) + y_mean * sin(phi)
+
+    if r < 0:
+        r = -r
+        phi = phi + np.pi
 
     return phi, r
 

--- a/src/stratigraphy/util/geometric_line_utilities.py
+++ b/src/stratigraphy/util/geometric_line_utilities.py
@@ -329,7 +329,7 @@ def _get_orthogonal_projection_to_line(point: Point, phi: float, r: float) -> Po
     # We now need to move towards the line by d in the direction defined by phi.
     x = point.x - d * cos(phi)
     y = point.y - d * sin(phi)
-    return Point(int(np.round(x, 0)), int(np.round(y, 0)))
+    return Point(x, y)
 
 
 def _are_close(line1: Line, line2: Line, tol: int = 5) -> bool:

--- a/src/stratigraphy/util/geometric_line_utilities.py
+++ b/src/stratigraphy/util/geometric_line_utilities.py
@@ -253,7 +253,10 @@ def _odr_regression(x: ArrayLike, y: ArrayLike) -> tuple:
     nominator = -2 * np.sum((x - x_mean) * (y - y_mean))
     denominator = np.sum((y - y_mean) ** 2 - (x - x_mean) ** 2)
     if nominator == 0 and denominator == 0:
-        logger.warning("The data is constant. The slope is undefined. We return phi=np.nan and r=np.nan.")
+        logger.warning(
+            "The problem is ill defined as both nominator and denominator for arctan are 0."
+            "We return phi=np.nan and r=np.nan."
+        )
         return np.nan, np.nan
     phi = 0.5 * np.arctan2(nominator, denominator)  # np.arctan2 can deal with np.inf due to zero division.
     r = x_mean * cos(phi) + y_mean * sin(phi)

--- a/src/stratigraphy/util/geometric_line_utilities.py
+++ b/src/stratigraphy/util/geometric_line_utilities.py
@@ -254,7 +254,7 @@ def _odr_regression(x: ArrayLike, y: ArrayLike) -> tuple:
     denominator = np.sum((y - y_mean) ** 2 - (x - x_mean) ** 2)
     if nominator == 0 and denominator == 0:
         logger.warning(
-            "The problem is ill defined as both nominator and denominator for arctan are 0."
+            "The problem is ill defined as both nominator and denominator for arctan are 0. "
             "We return phi=np.nan and r=np.nan."
         )
         return np.nan, np.nan

--- a/src/stratigraphy/util/plot_utils.py
+++ b/src/stratigraphy/util/plot_utils.py
@@ -15,15 +15,22 @@ def _draw_lines(open_cv_img, lines, scale_factor=1):
             (5 * line_count) % 255,
             (10 * line_count) % 255,
         )
-        cv2.line(
-            open_cv_img,
-            np.dot(scale_factor, line.start.tuple),
-            np.dot(scale_factor, line.end.tuple),
-            color,
-            1,
-        )
-        cv2.circle(open_cv_img, np.dot(scale_factor, line.start.tuple), radius=1, color=(0, 0, 255), thickness=-1)
-        cv2.circle(open_cv_img, np.dot(scale_factor, line.end.tuple), radius=1, color=(0, 0, 255), thickness=-1)
+        try:
+            cv2.line(
+                open_cv_img,
+                np.dot(scale_factor, line.start.tuple),
+                np.dot(scale_factor, line.end.tuple),
+                color,
+                1,
+            )
+            cv2.circle(open_cv_img, np.dot(scale_factor, line.start.tuple), radius=1, color=(0, 0, 255), thickness=-1)
+            cv2.circle(open_cv_img, np.dot(scale_factor, line.end.tuple), radius=1, color=(0, 0, 255), thickness=-1)
+
+        except cv2.error as e:
+            print("Error drawing line")
+            print(f"Line points: {line.start.tuple}, {line.end.tuple}")
+            print(e)
+            print()
     return open_cv_img
 
 

--- a/src/stratigraphy/util/plot_utils.py
+++ b/src/stratigraphy/util/plot_utils.py
@@ -1,11 +1,16 @@
 """Contains utility functions for plotting stratigraphic data."""
 
+import logging
+
 import cv2
 import fitz
 import numpy as np
 
 from stratigraphy.util.dataclasses import Line
 from stratigraphy.util.textblock import TextBlock
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def _draw_lines(open_cv_img, lines, scale_factor=1):
@@ -27,10 +32,8 @@ def _draw_lines(open_cv_img, lines, scale_factor=1):
             cv2.circle(open_cv_img, np.dot(scale_factor, line.end.tuple), radius=1, color=(0, 0, 255), thickness=-1)
 
         except cv2.error as e:
-            print("Error drawing line")
-            print(f"Line points: {line.start.tuple}, {line.end.tuple}")
-            print(e)
-            print()
+            logging.warning(f"Error drawing line. Exception: {e}. Skipping to draw the line.")
+
     return open_cv_img
 
 

--- a/src/stratigraphy/util/plot_utils.py
+++ b/src/stratigraphy/util/plot_utils.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def _draw_lines(open_cv_img, lines, scale_factor=1):
-    grid_lines = _convert_lines_to_grid(lines, scale_factor=scale_factor)
+    grid_lines = [_convert_line_to_grid(line, scale_factor=scale_factor) for line in lines]
     for line_count, line in enumerate(grid_lines):
         color = (
             (255 - 5 * line_count) % 255,
@@ -45,31 +45,27 @@ def _convert_page_to_opencv_img(page, scale_factor):
     return open_cv_img
 
 
-def _convert_lines_to_grid(lines: list[Line], scale_factor: float) -> list[Line]:
-    """Convert the lines to a grid.
+def _convert_line_to_grid(line: Line, scale_factor: float) -> Line:
+    """Convert the line to a grid.
 
     Note: OpenCV uses a pixel grid system as a coordinate system, and as such only allows
     integer values for the coordinates. This function converts the lines to a grid by
     applying the right scale factor and then rounding the coordinates to the nearest integer.
 
     Args:
-        lines (list[Line]): The lines to convert to a grid.
+        line (Line): The line to convert to a grid.
         scale_factor (float): The scale factor to apply to the lines.
 
     Returns:
-        list[Line]: The lines converted to a grid.
+        Line: The lines converted to a grid.
     """
-    grid_lines = []
-    for line in lines:
-        start = line.start
-        start.x = int(np.round(scale_factor * start.x, 0))
-        start.y = int(np.round(scale_factor * start.y, 0))
-        end = line.end
-        end.x = int(np.round(scale_factor * end.x, 0))
-        end.y = int(np.round(scale_factor * end.y, 0))
-        grid_lines.append(Line(start, end))
-
-    return grid_lines
+    start = line.start
+    start.x = int(np.round(scale_factor * start.x, 0))
+    start.y = int(np.round(scale_factor * start.y, 0))
+    end = line.end
+    end.x = int(np.round(scale_factor * end.x, 0))
+    end.y = int(np.round(scale_factor * end.y, 0))
+    return Line(start, end)
 
 
 def plot_lines(page: fitz.Page, lines: list[Line], scale_factor: float = 2) -> cv2.COLOR_RGB2BGR:

--- a/tests/test_geometric_line_utilities.py
+++ b/tests/test_geometric_line_utilities.py
@@ -14,7 +14,7 @@ from stratigraphy.util.geometric_line_utilities import (
 # The way phi is defined is a bit counterintuitive, but it seems consistent all along.
 @pytest.fixture(
     params=[
-        (np.array([0, 1, 2, 3]), np.array([1, 1, 1, 1]), -np.pi / 2, 1),  # Test case 1 horizontal line at y=0
+        (np.array([0, 1, 2, 3]), np.array([1, 1, 1, 1]), np.pi / 2, 1),  # Test case 1 horizontal line at y=1
         (np.array([0, 1, 2, 3]), np.array([0, 1, 2, 3]), -np.pi / 4, 0),  # Test case 2 45 degrees through zero
         (np.array([2, 2, 2, 2]), np.array([0, 1, 2, 3]), 0, 2),  # Test case 3 vertical line at x=2
         # Add more test cases here as needed
@@ -28,8 +28,8 @@ def odr_regression_case(request):  # noqa: D103
 def test_odr_regression(odr_regression_case):  # noqa: D103
     x, y, expected_phi, expected_r = odr_regression_case
     phi, r = _odr_regression(x, y)
-    assert pytest.approx(np.sin(expected_phi)) == np.sin(phi)
-    assert pytest.approx(np.abs(expected_r)) == np.abs(r)
+    assert pytest.approx(expected_phi) == phi
+    assert pytest.approx(expected_r) == r
 
 
 @pytest.fixture(
@@ -55,6 +55,10 @@ def test_odr_regression_with_zeroes(odr_regression_with_zeroes_case):  # noqa: D
     params=[
         (Point(1, 1), 3 * np.pi / 4, 0, Point(1, 1)),  # Test case 1
         (Point(1, 0), 0, 0, Point(0, 0)),  # Test case 2
+        (Point(1, 1), 0, 0, Point(0, 1)),  # Test case 3
+        (Point(1, 1), np.pi / 2, 0, Point(1, 0)),  # Test case 4
+        (Point(1, 1), np.pi / 2, 1, Point(1, 1)),  # Test case 5
+        (Point(1, 1), np.pi / 2, -1, Point(1, -1)),  # Test case 5
         # Add more test cases here as needed
     ]
 )
@@ -65,7 +69,7 @@ def orthogonal_projection_case(request):  # noqa: D103
 def test_get_orthogonal_projection_to_line(orthogonal_projection_case):  # noqa: D103
     point, phi, r, expected_projection = orthogonal_projection_case
     projection = _get_orthogonal_projection_to_line(point, phi, r)
-    assert pytest.approx(projection) == expected_projection
+    assert pytest.approx(projection.tuple) == expected_projection.tuple
 
 
 @pytest.fixture(

--- a/tests/test_geometric_line_utilities.py
+++ b/tests/test_geometric_line_utilities.py
@@ -32,9 +32,18 @@ def test_odr_regression(odr_regression_case):  # noqa: D103
     assert pytest.approx(np.abs(expected_r)) == np.abs(r)
 
 
-def test_odr_regression_with_zeroes():  # noqa: D103
-    x = np.array([0, 0, 0, 0])
-    y = np.array([0, 0, 0, 0])
+@pytest.fixture(
+    params=[
+        (np.array([0, 0, 0, 0]), np.array([0, 0, 0, 0])),  # Test case 1 all zeroes
+        (np.array([1, 1, -1, -1]), np.array([1, -1, 1, -1])),  # Test case square
+    ]
+)
+def odr_regression_with_zeroes_case(request):  # noqa: D103
+    return request.param
+
+
+def test_odr_regression_with_zeroes(odr_regression_with_zeroes_case):  # noqa: D103
+    x, y = odr_regression_with_zeroes_case
     phi, r = _odr_regression(x, y)
     print(f"phi: {phi}, r: {r}")
     assert np.isnan(phi)  # Expected value

--- a/tests/test_geometric_line_utilities.py
+++ b/tests/test_geometric_line_utilities.py
@@ -11,13 +11,18 @@ from stratigraphy.util.geometric_line_utilities import (
 
 
 # Remember, phi is orthogonal to the line we are to parameterize
-# The way phi is defined is a bit counterintuitive, but it seems consistent all along.
 @pytest.fixture(
     params=[
-        (np.array([0, 1, 2, 3]), np.array([1, 1, 1, 1]), np.pi / 2, 1),  # Test case 1 horizontal line at y=1
-        (np.array([0, 1, 2, 3]), np.array([0, 1, 2, 3]), -np.pi / 4, 0),  # Test case 2 45 degrees through zero
-        (np.array([2, 2, 2, 2]), np.array([0, 1, 2, 3]), 0, 2),  # Test case 3 vertical line at x=2
-        # Add more test cases here as needed
+        # Test case 1: horizontal line at y=1
+        (np.array([0, 1, 2, 3]), np.array([1, 1, 1, 1]), np.pi / 2, 1),
+        # Test case 2: 45 degrees through zero
+        (np.array([0, 1, 2, 3]), np.array([0, 1, 2, 3]), -np.pi / 4, 0),
+        # Test case 3: vertical line at x=2
+        (np.array([2, 2, 2, 2]), np.array([0, 1, 2, 3]), 0, 2),
+        # Test case 4: best fix is a horizontal line at y=0.5
+        (np.array([0, 0, 2, 2]), np.array([0, 1, 0, 1]), np.pi / 2, 0.5),
+        # Test case 4: best fix is a vertical line at x=0.5
+        (np.array([0, 1, 0, 1]), np.array([0, 0, 2, 2]), 0, 0.5),
     ]
 )
 def odr_regression_case(request):  # noqa: D103
@@ -90,7 +95,21 @@ def test_get_orthogonal_projection_to_line(orthogonal_projection_case):  # noqa:
             Line(Point(2, 1), Point(2, 2)),
             Line(Point(2, 0), Point(2, 2)),
         ),  # vertical line
-        # Add more test cases here as needed
+        (
+            Line(Point(0, 0), Point(2, 0)),
+            Line(Point(1, 0), Point(3, 0)),
+            Line(Point(0, 0), Point(3, 0)),
+        ),  # horizontal line; lines partially overlap
+        (
+            Line(Point(0, 0), Point(3, 0)),
+            Line(Point(1, 0), Point(2, 0)),
+            Line(Point(0, 0), Point(3, 0)),
+        ),  # horizontal line; one line is contained in the other
+        (
+            Line(Point(1, 0), Point(2, 0)),
+            Line(Point(0, 0), Point(3, 0)),
+            Line(Point(0, 0), Point(3, 0)),
+        ),  # horizontal line; one line is contained in the other (reversed)
     ]
 )
 def merge_lines_case(request):  # noqa: D103
@@ -100,4 +119,5 @@ def merge_lines_case(request):  # noqa: D103
 def test_merge_lines(merge_lines_case):  # noqa: D103
     line1, line2, expected_merged_line = merge_lines_case
     merged_line = _merge_lines(line1, line2)
-    assert merged_line == expected_merged_line  # Adjust this line if Line objects can't be compared directly
+    assert pytest.approx(merged_line.start.tuple) == expected_merged_line.start.tuple
+    assert pytest.approx(merged_line.end.tuple) == expected_merged_line.end.tuple

--- a/tests/test_geometric_line_utilities.py
+++ b/tests/test_geometric_line_utilities.py
@@ -1,0 +1,90 @@
+"""Test suite for the geometric_line_utilities module."""
+
+import numpy as np
+import pytest
+from stratigraphy.util.dataclasses import Line, Point
+from stratigraphy.util.geometric_line_utilities import (
+    _get_orthogonal_projection_to_line,
+    _merge_lines,
+    _odr_regression,
+)
+
+
+# Remember, phi is orthogonal to the line we are to parameterize
+# The way phi is defined is a bit counterintuitive, but it seems consistent all along.
+@pytest.fixture(
+    params=[
+        (np.array([0, 1, 2, 3]), np.array([1, 1, 1, 1]), -np.pi / 2, 1),  # Test case 1 horizontal line at y=0
+        (np.array([0, 1, 2, 3]), np.array([0, 1, 2, 3]), -np.pi / 4, 0),  # Test case 2 45 degrees through zero
+        (np.array([2, 2, 2, 2]), np.array([0, 1, 2, 3]), 0, 2),  # Test case 3 vertical line at x=2
+        # Add more test cases here as needed
+    ]
+)
+def odr_regression_case(request):  # noqa: D103
+    return request.param
+
+
+# Use the fixture in the test function
+def test_odr_regression(odr_regression_case):  # noqa: D103
+    x, y, expected_phi, expected_r = odr_regression_case
+    phi, r = _odr_regression(x, y)
+    assert pytest.approx(np.sin(expected_phi)) == np.sin(phi)
+    assert pytest.approx(np.abs(expected_r)) == np.abs(r)
+
+
+def test_odr_regression_with_zeroes():  # noqa: D103
+    x = np.array([0, 0, 0, 0])
+    y = np.array([0, 0, 0, 0])
+    phi, r = _odr_regression(x, y)
+    print(f"phi: {phi}, r: {r}")
+    assert np.isnan(phi)  # Expected value
+    assert np.isnan(r)  # Expected value
+
+
+# Tests for the _get_orhtogonal_projection_to_line function
+@pytest.fixture(
+    params=[
+        (Point(1, 1), 3 * np.pi / 4, 0, Point(1, 1)),  # Test case 1
+        (Point(1, 0), 0, 0, Point(0, 0)),  # Test case 2
+        # Add more test cases here as needed
+    ]
+)
+def orthogonal_projection_case(request):  # noqa: D103
+    return request.param
+
+
+def test_get_orthogonal_projection_to_line(orthogonal_projection_case):  # noqa: D103
+    point, phi, r, expected_projection = orthogonal_projection_case
+    projection = _get_orthogonal_projection_to_line(point, phi, r)
+    assert pytest.approx(projection) == expected_projection
+
+
+@pytest.fixture(
+    params=[
+        # Assuming Line takes two points as arguments
+        (
+            Line(Point(0, 0), Point(1, 1)),
+            Line(Point(1, 1), Point(2, 2)),
+            Line(Point(0, 0), Point(2, 2)),
+        ),  # 45 degrees line
+        (
+            Line(Point(0, 0), Point(1, 0)),
+            Line(Point(1, 0), Point(2, 0)),
+            Line(Point(0, 0), Point(2, 0)),
+        ),  # horizontal line
+        (
+            Line(Point(2, 0), Point(2, 1)),
+            Line(Point(2, 1), Point(2, 2)),
+            Line(Point(2, 0), Point(2, 2)),
+        ),  # vertical line
+        # Add more test cases here as needed
+    ]
+)
+def merge_lines_case(request):  # noqa: D103
+    return request.param
+
+
+def test_merge_lines(merge_lines_case):  # noqa: D103
+    line1, line2, expected_merged_line = merge_lines_case
+    merged_line = _merge_lines(line1, line2)
+    assert merged_line == expected_merged_line  # Adjust this line if Line objects can't be compared directly


### PR DESCRIPTION
Implementation of ODR regression for line merging. 

Results slightly improve.

The only document that changes is:
|    | document_name    |   F1_new |   Number Elements_new |   Number wrong elements_new |       F1 |   Number Elements |   Number wrong elements |
|---:|:-----------------|---------:|----------------------:|----------------------------:|---------:|------------------:|------------------------:|
|  0 | 699240002-bp.pdf | 0.468085 |                    27 |                          16 | 0.425532 |                27 |                      17 |


Vertical lines are still not dealt with, but the code at least throws a warning and does not do unintentional behavior.