### PR TITLE
Refactor: Decouple inference from evaluation.

### DIFF
--- a/src/stratigraphy/benchmark/ground_truth.py
+++ b/src/stratigraphy/benchmark/ground_truth.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from pathlib import Path
 
 import Levenshtein
 from stratigraphy.util.util import parse_text
@@ -21,26 +22,31 @@ class GroundTruthForFile:
         self.descriptions = descriptions
         self.unmatched_descriptions = descriptions.copy()
 
-    def is_correct(self, prediction: str) -> bool:
-        parsed_prediction = parse_text(prediction)
-        if len(self.unmatched_descriptions):
-            best_match = max(self.unmatched_descriptions, key=lambda ref: Levenshtein.ratio(parsed_prediction, ref))
-            if Levenshtein.ratio(parsed_prediction, best_match) > 0.9:
-                # ensure every ground truth entry is only matched at most once
-                self.unmatched_descriptions.remove(best_match)
-                return True
-            else:
-                return False
+    def is_correct(self, prediction: str) -> bool | None:
+        if len(self.descriptions):
+            if len(self.unmatched_descriptions):
+                parsed_prediction = parse_text(prediction)
+                best_match = max(
+                    self.unmatched_descriptions, key=lambda ref: Levenshtein.ratio(parsed_prediction, ref)
+                )
+                if Levenshtein.ratio(parsed_prediction, best_match) > 0.9:
+                    # ensure every ground truth entry is only matched at most once
+                    self.unmatched_descriptions.remove(best_match)
+                    return True
+            return False
+        else:
+            # Return None if we don't have a ground truth for the file
+            return None
 
 
 class GroundTruth:
     """Ground truth data for the stratigraphy benchmark."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: Path):
         """Ground truth data for the stratigraphy benchmark.
 
         Args:
-            path (str): Path to the ground truth data.
+            path (Path): Path to the ground truth data.
         """
         with open(path) as in_file:
             ground_truth = json.load(in_file)

--- a/src/stratigraphy/benchmark/score.py
+++ b/src/stratigraphy/benchmark/score.py
@@ -118,20 +118,15 @@ def evaluate_matching(
     if len(document_level_metrics["precision"]):
         overall_precision = sum(document_level_metrics["precision"]) / len(document_level_metrics["precision"])
         overall_recall = sum(document_level_metrics["recall"]) / len(document_level_metrics["recall"])
-        logging.info("Macro avg:")
-        logging.info(
-            f"F1: {f1(overall_precision, overall_recall):.1%},"
-            f"precision: {overall_precision:.1%}, recall: {overall_recall:.1%}"
-        )
+    else:
+        overall_precision = 0
+        overall_recall = 0
 
-    worst_count = 5
-    if len(document_level_metrics["precision"]) > worst_count:
-        best_precisions = sorted(document_level_metrics["precision"])[worst_count:]
-        best_recalls = sorted(document_level_metrics["recall"])[worst_count:]
-        precision = sum(best_precisions) / len(best_precisions)
-        recall = sum(best_recalls) / len(best_recalls)
-        logger.info(f"Ignoring worst {worst_count}:")
-        logger.info(f"F1: {f1(precision, recall):.1%}, precision: {precision:.1%}, recall: {recall:.1%}")
+    logging.info("Macro avg:")
+    logging.info(
+        f"F1: {f1(overall_precision, overall_recall):.1%},"
+        f"precision: {overall_precision:.1%}, recall: {overall_recall:.1%}"
+    )
 
     return {
         "F1": f1(overall_precision, overall_recall),
@@ -140,7 +135,7 @@ def evaluate_matching(
     }, pd.DataFrame(document_level_metrics)
 
 
-def _add_ground_truth_to_predictions(predictions: dict, ground_truth: GroundTruth) -> tuple[dict]:
+def _add_ground_truth_to_predictions(predictions: dict, ground_truth: GroundTruth) -> (dict, dict):
     """Add the ground truth to the predictions.
 
     Args:
@@ -148,7 +143,7 @@ def _add_ground_truth_to_predictions(predictions: dict, ground_truth: GroundTrut
         ground_truth (GroundTruth): The ground truth.
 
     Returns:
-        dict: The predictions with the ground truth added.
+        (dict, dict): The predictions with the ground truth added, and the number of ground truth values per file.
     """
     number_of_truth_values = {}
     for file, file_predictions in predictions.items():

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -10,13 +10,11 @@ import fitz
 from dotenv import load_dotenv
 
 from stratigraphy import DATAPATH
-from stratigraphy.benchmark.ground_truth import GroundTruth, GroundTruthForFile
 from stratigraphy.benchmark.score import evaluate_matching
 from stratigraphy.line_detection import extract_lines, line_detection_params
 from stratigraphy.util import find_depth_columns
 from stratigraphy.util.dataclasses import Line
 from stratigraphy.util.depthcolumn import DepthColumn
-from stratigraphy.util.draw import draw_layer
 from stratigraphy.util.find_description import get_description_blocks, get_description_lines
 from stratigraphy.util.interval import Interval
 from stratigraphy.util.line import DepthInterval, TextLine
@@ -29,23 +27,18 @@ mlflow_tracking = os.getenv("MLFLOW_TRACKING") == "True"  # Checks whether MLFlo
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 matching_params = read_params("matching_params.yml")
 
 
-def process_page(
-    page: fitz.Page, ground_truth_for_file: GroundTruthForFile, tmp_file_path: str, **params
-) -> list[dict]:
+def process_page(page: fitz.Page, **params: dict) -> list[dict]:
     """Process a single page of a pdf.
 
     Finds all descriptions and depth intervals on the page and matches them.
 
     Args:
         page (fitz.Page): The page to process.
-        ground_truth_for_file (GroundTruthForFile): The ground truth, used to create plots.
-        tmp_file_path (str): The path to save the temporary file.
-        **params: Additional parameters for the matching pipeline.
+        **params (dict): Additional parameters for the matching pipeline.
 
     Returns:
         list[dict]: All list of the text of all description blocks.
@@ -93,13 +86,6 @@ def process_page(
     depth_columns: list[DepthColumn] = layer_depth_columns
     depth_columns.extend(find_depth_columns.find_depth_columns(depth_column_entries, words))
 
-    for column in depth_columns:  # This adjusts the page object. This is a problem for subsequent line detection.
-        fitz.utils.draw_rect(
-            page,
-            column.rect() * page.derotation_matrix,
-            color=fitz.utils.getColor("green"),
-        )
-
     pairs = []
     for depth_column in depth_columns:
         material_description_rect = find_material_description_column(lines, depth_column)
@@ -122,39 +108,30 @@ def process_page(
     groups = []
     if len(filtered_pairs):
         for depth_column, material_description_rect in filtered_pairs:
-            fitz.utils.draw_rect(  # This adjusts the page object. This is a problem for subsequent line detection.
-                page,
-                material_description_rect * page.derotation_matrix,
-                color=fitz.utils.getColor("red"),
-            )
             description_lines = get_description_lines(lines, material_description_rect)
             if len(description_lines) > 1:
-                for rect in depth_column.rects():
-                    fitz.utils.draw_rect(  # this affects the line detection
-                        page, rect * page.derotation_matrix, color=fitz.utils.getColor("purple")
-                    )
                 new_groups = match_columns(
                     depth_column, description_lines, geometric_lines, material_description_rect, **params
                 )
-                for index, group in enumerate(new_groups):
-                    correct = ground_truth_for_file.is_correct(group["block"].text)
-                    draw_layer(
-                        page=page,
-                        interval=group["depth_interval"],
-                        block=group["block"],
-                        index=index,
-                        is_correct=correct,
-                    )
                 groups.extend(new_groups)
+        json_filtered_pairs = [
+            {
+                "depth_column": depth_column.to_json(),
+                "material_description_rect": [
+                    material_description_rect.x0,
+                    material_description_rect.y0,
+                    material_description_rect.x1,
+                    material_description_rect.y1,
+                ],
+            }
+            for depth_column, material_description_rect in filtered_pairs
+        ]
+
     else:
+        json_filtered_pairs = []
         # Fallback when no depth column was found
         material_description_rect = find_material_description_column(lines, depth_column=None)
         if material_description_rect:
-            fitz.utils.draw_rect(
-                page,
-                material_description_rect * page.derotation_matrix,
-                color=fitz.utils.getColor("red"),
-            )
             description_lines = get_description_lines(lines, material_description_rect)
             description_blocks = get_description_blocks(
                 description_lines,
@@ -163,43 +140,34 @@ def process_page(
                 params["block_line_ratio"],
                 params["left_line_length_threshold"],
             )
-            for index, block in enumerate(description_blocks):
-                correct = ground_truth_for_file.is_correct(block.text)
-                draw_layer(
-                    page=page,
-                    interval=None,
-                    block=block,
-                    index=index,
-                    is_correct=correct,
-                )
             groups.extend([{"block": block} for block in description_blocks])
-
-    for group in groups:
-        block = group["block"]
-        if block.rect is None:
-            logger.info("Block is None.")
-            continue
-        fitz.utils.draw_rect(
-            page,
-            block.rect * page.derotation_matrix,
-            color=fitz.utils.getColor("orange"),
-        )
-
-    fitz.utils.get_pixmap(page, matrix=fitz.Matrix(2, 2), clip=page.rect).save(tmp_file_path)
-    if mlflow_tracking:  # This is only executed if MLFlow tracking is enabled
-        try:
-            mlflow.log_artifact(tmp_file_path, artifact_path="pages")
-        except NameError:
-            logger.info("MLFlow not enabled. Skipping logging of artifact.")
-
-    return [{"description": group["block"].text} for group in groups]
+            json_filtered_pairs.extend(
+                [
+                    {
+                        "depth_column": None,
+                        "material_description_rect": [
+                            material_description_rect.x0,
+                            material_description_rect.y0,
+                            material_description_rect.x1,
+                            material_description_rect.y1,
+                        ],
+                    }
+                ]
+            )
+    predictions = [
+        {"material_description": group["block"].to_json(), "depth_interval": group["depth_interval"].to_json()}
+        if "depth_interval" in group
+        else {"material_description": group["block"].to_json()}
+        for group in groups
+    ]
+    return predictions, json_filtered_pairs
 
 
 def score_column_match(
     depth_column: DepthColumn,
     material_description_rect: fitz.Rect,
     all_words: list[TextLine] | None = None,
-    **params,
+    **params: dict,
 ) -> float:
     """Scores the match between a depth column and a material description.
 
@@ -207,7 +175,7 @@ def score_column_match(
         depth_column (DepthColumn): The depth column.
         material_description_rect (fitz.Rect): The material description rectangle.
         all_words (list[TextLine] | None, optional): List of the available textlines. Defaults to None.
-        **params: Additional parameters for the matching pipeline. Kept here for compatibility with the pipeline.
+        **params (dict): Additional parameters for the matching pipeline. Kept for compatibility with the pipeline.
 
     Returns:
         float: The score of the match.
@@ -234,7 +202,7 @@ def match_columns(
     description_lines: list[TextLine],
     geometric_lines: list[Line],
     material_description_rect: fitz.Rect,
-    **params,
+    **params: dict,
 ) -> list:
     """Match the depth column with the description lines.
 
@@ -246,7 +214,8 @@ def match_columns(
         depth_column (DepthColumn): The depth column.
         description_lines (list[TextLine]): The description lines.
         geometric_lines (list[Line]): The geometric lines.
-        **params: Additional parameters for the matching pipeline.
+        material_description_rect (fitz.Rect): The material description rectangle.
+        **params (dict): Additional parameters for the matching pipeline.
 
     Returns:
         list: The matched depth intervals and text blocks.
@@ -261,7 +230,7 @@ def match_columns(
 
 
 def transform_groups(
-    depth_intervals: list[Interval], blocks: list[TextBlock], **params
+    depth_intervals: list[Interval], blocks: list[TextBlock], **params: dict
 ) -> list[dict[str, Interval | TextBlock]]:
     """Transforms the text blocks such that their number equals the number of depth intervals.
 
@@ -272,7 +241,7 @@ def transform_groups(
     Args:
         depth_intervals (List[Interval]): The depth intervals from the pdf.
         blocks (List[TextBlock]): Found textblocks from the pdf.
-        **params: Additional parameters for the matching pipeline.
+        **params (dict): Additional parameters for the matching pipeline.
 
     Returns:
         List[Dict[str, Union[Interval, TextBlock]]]: Pairing of text blocks and depth intervals.
@@ -383,7 +352,7 @@ def find_material_description_column(
     Args:
         lines (list[TextLine]): The text lines of the page.
         depth_column (DepthColumn): The depth column.
-        **params: Additional parameters for the matching pipeline.
+        **params (dict): Additional parameters for the matching pipeline.
 
     Returns:
         fitz.Rect | None: The material description column.
@@ -491,52 +460,41 @@ def find_material_description_column(
         return candidate_rects[0]
 
 
-def perform_matching(directory: Path, ground_truth: GroundTruth, **params) -> None:
+def perform_matching(directory: Path, **params: dict) -> dict:
     """Perform the matching of text blocks with depth intervals.
-
-    TODO: Decouple the evaluation from the matching. In the future
-    `ground_truth` should not be an argument to this function any more.
 
     Args:
         directory (Path): Path to the directory that contains the pdfs.
-        ground_truth (GroundTruth): The ground truth matchings.
-        **params: Additional parameters for the matching pipeline.
+        **params (dict): Additional parameters for the matching pipeline.
 
     Returns:
-        None
+        dict: The predictions.
     """
     for root, _dirs, files in os.walk(directory):
         output = {}
         for filename in files:
             if filename.endswith(".pdf"):
                 in_path = os.path.join(root, filename)
-                ground_truth_for_file = ground_truth.for_file(filename)
                 logger.info("Processing file: %s", in_path)
+                output[filename] = {}
 
                 with fitz.Document(in_path) as doc:
-                    predictions = []
                     for page_index, page in enumerate(doc):
                         page_number = page_index + 1
                         logger.info("Processing page %s", page_number)
-                        tmp_file_path = os.path.join(
-                            root,
-                            "extract",
-                            f"{filename}_page{page_number}.png",
-                        )
-                        predictions.extend(process_page(page, ground_truth_for_file, tmp_file_path, **params))
-                    output[filename] = {"layers": predictions}
 
-        with open(os.path.join(root, "extract", "predictions.json"), "w") as file:
-            file.write(json.dumps(output))
-        break
+                        predictions, depths_materials_column_pairs = process_page(page, **params)
+
+                        output[filename][f"page_{page_number}"] = {
+                            "layers": predictions,
+                            "depths_materials_column_pairs": depths_materials_column_pairs,
+                        }
+        return output
 
 
 if __name__ == "__main__":
-    directory = DATAPATH / "Benchmark"
-    ground_truth = GroundTruth(
-        DATAPATH / "Benchmark" / "ground_truth.json"
-    )  # TODO: unify ground_truth and ground_truth_path
-
+    # setup mlflow tracking; should be started before any other code
+    # such that tracking is enabled in other parts of the code.
     if mlflow_tracking:
         import mlflow
 
@@ -545,18 +503,28 @@ if __name__ == "__main__":
         mlflow.log_params(flatten(line_detection_params))
         mlflow.log_params(flatten(matching_params))
 
-    perform_matching(directory, ground_truth, **matching_params)  # TODO: specify parameters for mlflow
-    predictions_path = DATAPATH / "Benchmark" / "extract" / "predictions.json"
-    ground_truth_path = DATAPATH / "Benchmark" / "ground_truth.json"
+    # instantiate all paths
+    input_directory = DATAPATH / "Benchmark"
+    ground_truth_path = input_directory / "ground_truth.json"
+    out_directory = input_directory / "evaluation"
+    predictions_path = input_directory / "extract" / "predictions.json"
+    temp_directory = DATAPATH / "_temp"  # temporary directory to dump files for mlflow artifact logging
 
-    metrics, document_level_metrics = evaluate_matching(predictions_path, ground_truth_path)
-    if not (
-        DATAPATH / "_temp"
-    ).exists():  # _temp is a temporary directory containing data that is frequently overwritten
-        (DATAPATH / "_temp").mkdir()
-    document_level_metrics.to_csv(
-        DATAPATH / "_temp" / "document_level_metrics.csv"
-    )  # mlflow.log_artifact expects a file
+    # check if directories exist and create them when neccessary
+    out_directory.mkdir(parents=True, exist_ok=True)
+    temp_directory.mkdir(parents=True, exist_ok=True)
+
+    # run the matching pipeline and save the result
+    predictions = perform_matching(input_directory, **matching_params)
+    with open(predictions_path, "w") as file:
+        file.write(json.dumps(predictions))
+
+    # evaluate the predictions
+    metrics, document_level_metrics = evaluate_matching(
+        predictions_path, ground_truth_path, input_directory, out_directory
+    )
+    document_level_metrics.to_csv(temp_directory / "document_level_metrics.csv")  # mlflow.log_artifact expects a file
+
     if mlflow_tracking:
         mlflow.log_metrics(metrics)
-        mlflow.log_artifact(DATAPATH / "_temp" / "document_level_metrics.csv")
+        mlflow.log_artifact(temp_directory / "document_level_metrics.csv")

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -19,7 +19,13 @@ from stratigraphy.util.find_description import get_description_blocks, get_descr
 from stratigraphy.util.interval import Interval
 from stratigraphy.util.line import DepthInterval, TextLine
 from stratigraphy.util.textblock import TextBlock, block_distance
-from stratigraphy.util.util import flatten, read_params, x_overlap, x_overlap_significant_smallest
+from stratigraphy.util.util import (
+    flatten,
+    parse_and_remove_empty_predictions,
+    read_params,
+    x_overlap,
+    x_overlap_significant_smallest,
+)
 
 load_dotenv()
 
@@ -160,6 +166,7 @@ def process_page(page: fitz.Page, **params: dict) -> list[dict]:
         else {"material_description": group["block"].to_json()}
         for group in groups
     ]
+    predictions = parse_and_remove_empty_predictions(predictions)
     return predictions, json_filtered_pairs
 
 

--- a/src/stratigraphy/util/depthcolumn.py
+++ b/src/stratigraphy/util/depthcolumn.py
@@ -54,6 +54,13 @@ class DepthColumn(metaclass=abc.ABCMeta):
     def identify_groups(self, description_lines: list[TextLine], geometric_lines: list[Line]) -> list[dict]:
         pass
 
+    def to_json(self):
+        rect = self.rect()
+        return {
+            "rect": [rect.x0, rect.y0, rect.x1, rect.y1],
+            "entries": [entry.to_json() for entry in self.entries],
+        }
+
 
 class LayerDepthColumn(DepthColumn):
     """Represents a depth column where the upper and lower depths of each layer are explicitly specified.

--- a/src/stratigraphy/util/depthcolumnentry.py
+++ b/src/stratigraphy/util/depthcolumnentry.py
@@ -11,6 +11,12 @@ class DepthColumnEntry:  # noqa: D101
     def __repr__(self):
         return str(self.value)
 
+    def to_json(self):
+        return {
+            "value": self.value,
+            "rect": [self.rect.x0, self.rect.y0, self.rect.x1, self.rect.y1],
+        }
+
 
 class LayerDepthColumnEntry:  # noqa: D101
     def __init__(self, start: DepthColumnEntry, end: DepthColumnEntry):
@@ -23,3 +29,10 @@ class LayerDepthColumnEntry:  # noqa: D101
     @property
     def rect(self):
         return fitz.Rect(self.start.rect).include_rect(self.end.rect)
+
+    def to_json(self):
+        return {
+            "start": self.start.to_json(),
+            "end": self.end.to_json(),
+            "rect": [self.rect.x0, self.rect.y0, self.rect.x1, self.rect.y1],
+        }

--- a/src/stratigraphy/util/draw.py
+++ b/src/stratigraphy/util/draw.py
@@ -1,42 +1,165 @@
 """This module contains functionalities to draw on pdf pages."""
 
-import fitz
+import logging
+import os
+from pathlib import Path
 
-from stratigraphy.util.interval import Interval
-from stratigraphy.util.textblock import TextBlock
+import fitz
+from dotenv import load_dotenv
+
+from stratigraphy.benchmark.ground_truth import GroundTruth, GroundTruthForFile
+
+load_dotenv()
+
+mlflow_tracking = os.getenv("MLFLOW_TRACKING") == "True"  # Checks whether MLFlow tracking is enabled
 
 colors = ["purple", "blue"]
 
+logger = logging.getLogger(__name__)
 
-def draw_layer(
-    page: fitz.Page, interval: Interval | None, block: TextBlock, index: int, is_correct: bool | None
-) -> None:
-    """Draw layers on a pdf page.
+
+def draw_predictions(predictions: dict, ground_truth: GroundTruth, directory: Path, out_directory: Path) -> None:
+    """Draw predictions on pdf pages.
+
+    Draws various recognized information on the pdf pages present at directory and saves
+    them as images in the out_directory.
+
+    The drawn information includes:
+        - Depth columns (if available)
+        - Depth column entries (if available)
+        - Material description columns
+        - Material description text blocks
+        - Color-coded correctness of the material description text blocks
+        - Assignments of material description text blocks to depth intervals (if available)
+
+    Args:
+        predictions (dict): Content of the predictions.json file..
+        ground_truth (GroundTruth): Path to the ground truth annotated data.
+        directory (Path): Path to the directory containing the pdf files.
+        out_directory (Path): Path to the output directory where the images are saved.
+    """
+    for file in predictions:
+        logger.info(f"Evaluating {file}.")
+        with fitz.Document(directory / file) as doc:
+            for page_index, page in enumerate(doc):
+                page_number = page_index + 1
+                layers = predictions[file][f"page_{page_number}"]["layers"]
+                depths_materials_column_pairs = predictions[file][f"page_{page_number}"][
+                    "depths_materials_column_pairs"
+                ]
+                draw_depth_columns_and_material_rect(page, depths_materials_column_pairs)
+                draw_material_descriptions(page, layers, ground_truth.for_file(file))
+
+                tmp_file_path = out_directory / f"{file}_page{page_number}.png"
+                fitz.utils.get_pixmap(page, matrix=fitz.Matrix(2, 2), clip=page.rect).save(tmp_file_path)
+                if mlflow_tracking:  # This is only executed if MLFlow tracking is enabled
+                    try:
+                        import mlflow
+
+                        mlflow.log_artifact(tmp_file_path, artifact_path="pages")
+                    except NameError:
+                        logger.warning("MLFlow could not be imported. Skipping logging of artifact.")
+
+
+def draw_material_descriptions(page: fitz.Page, layers: dict, ground_truth: GroundTruthForFile) -> None:
+    """Draw information about material descriptions on a pdf page.
+
+    In particular, this function:
+        - draws rectangles around the material description text blocks,
+        - draws lines connecting the material description text blocks to the depth intervals,
+        - colors the lines of the material description text blocks based on whether they were correctly identified.
 
     Args:
         page (fitz.Page): The page to draw on.
-        interval (Interval | None): The depth interval for the layer.
-        block (TextBlock): The text block for the layer.
-        index (int): The index of the layer.
-        is_correct (bool | None): Whether the text block and depth interval were correctly identified.
+        layers (dict): The predictions for the page.
+        ground_truth (GroundTruth): The ground truth data for the page.
+    """
+    for index, block in enumerate(layers):
+        material_description_block = block["material_description"]
+        if material_description_block["rect"] is not None:
+            fitz.utils.draw_rect(
+                page,
+                fitz.Rect(material_description_block["rect"]) * page.derotation_matrix,
+                color=fitz.utils.getColor("orange"),
+            )
+        correct = ground_truth.is_correct(material_description_block["text"])
+        draw_layer(
+            page=page,
+            interval=block.get("depth_interval"),  # None if no depth interval
+            block=material_description_block,
+            index=index,
+            is_correct=correct,
+        )
+
+
+def draw_depth_columns_and_material_rect(page: fitz.Page, depths_materials_column_pairs: list) -> fitz.Page:
+    """Draw depth columns as well as the material rects on a pdf page.
+
+    In particular, this function:
+        - draws rectangles around the depth columns,
+        - draws rectangles around the depth column entries,
+        - draws rectangles around the material description columns.
+
+    Args:
+        page (fitz.Page): The page to draw on.
+        depths_materials_column_pairs (list): List of depth column entries.
 
     Returns:
-        None
+        fitz.Page: The page with the drawn depth columns and material rects.
     """
-    if len(block.lines):
-        block_rect = block.rect
+    for pair in depths_materials_column_pairs:
+        depth_column = pair["depth_column"]
+        material_description_rect = pair["material_description_rect"]
+        if depth_column is not None:  # draw rectangle for depth columns
+            page.draw_rect(
+                fitz.Rect(depth_column["rect"]) * page.derotation_matrix,
+                color=fitz.utils.getColor("green"),
+            )
+            for depth_column_entry in depth_column["entries"]:  # draw rectangle for depth column entries
+                fitz.utils.draw_rect(
+                    page,
+                    fitz.Rect(depth_column_entry["rect"]) * page.derotation_matrix,
+                    color=fitz.utils.getColor("purple"),
+                )
+
+        fitz.utils.draw_rect(  # draw rectangle for material description column
+            page,
+            fitz.Rect(material_description_rect) * page.derotation_matrix,
+            color=fitz.utils.getColor("red"),
+        )
+
+    return page
+
+
+def draw_layer(page: fitz.Page, interval: dict | None, block: dict, index: int, is_correct: bool):
+    """Draw layers on a pdf page.
+
+    In particular, this function:
+        - draws lines connecting the material description text blocks to the depth intervals,
+        - colors the lines of the material description text blocks based on whether they were correctly identified.
+
+    Args:
+        page (fitz.Page): The page to draw on.
+        interval (dict | None): Depth interval for the layer.
+        block (dict): Material description block for the layer.
+        index (int): Index of the layer.
+        is_correct (bool): Whether the text block was correctly identified.
+    """
+    if len(block["lines"]):
+        block_rect = fitz.Rect(block["rect"])
         color = colors[index % len(colors)]
 
         # background color for material description
-        for line in [line for line in block.lines]:
+        for line in [line for line in block["lines"]]:
+            line_rect = fitz.Rect(line["rect"])
             page.draw_rect(
-                line.rect * page.derotation_matrix, width=0, fill=fitz.utils.getColor(color), fill_opacity=0.2
+                line_rect * page.derotation_matrix, width=0, fill=fitz.utils.getColor(color), fill_opacity=0.2
             )
             if is_correct is not None:
                 correct_color = "green" if is_correct else "red"
                 page.draw_line(
-                    line.rect.top_left * page.derotation_matrix,
-                    line.rect.bottom_left * page.derotation_matrix,
+                    line_rect.top_left * page.derotation_matrix,
+                    line_rect.bottom_left * page.derotation_matrix,
                     color=fitz.utils.getColor(correct_color),
                     width=6,
                     stroke_opacity=0.5,
@@ -44,7 +167,7 @@ def draw_layer(
 
         if interval:
             # background color for depth interval
-            background_rect = interval.background_rect
+            background_rect = _background_rect(interval)
             if background_rect is not None:
                 page.draw_rect(
                     background_rect * page.derotation_matrix,
@@ -54,10 +177,31 @@ def draw_layer(
                 )
 
             # line from depth interval to material description
-            line_anchor = interval.line_anchor
+            line_anchor = _get_line_anchor(interval)
             if line_anchor:
                 page.draw_line(
                     line_anchor * page.derotation_matrix,
                     fitz.Point(block_rect.x0, (block_rect.y0 + block_rect.y1) / 2) * page.derotation_matrix,
                     color=fitz.utils.getColor(color),
                 )
+
+
+def _get_line_anchor(interval):
+    if interval["start"] and interval["end"]:
+        return fitz.Point(
+            interval["start"]["rect"][2], (interval["start"]["rect"][1] + interval["end"]["rect"][3]) / 2
+        )
+    elif interval["start"]:
+        return fitz.Point(interval["start"]["rect"][2], interval["start"]["rect"][3])
+    elif interval["end"]:
+        return fitz.Point(interval["end"]["rect"][2], interval["end"]["rect"][1])
+
+
+def _background_rect(interval) -> fitz.Rect | None:
+    if interval["start"] and interval["end"]:
+        return fitz.Rect(
+            interval["start"]["rect"][0],
+            interval["start"]["rect"][3],
+            interval["start"]["rect"][2],
+            interval["end"]["rect"][1],
+        )

--- a/src/stratigraphy/util/draw.py
+++ b/src/stratigraphy/util/draw.py
@@ -187,14 +187,15 @@ def draw_layer(page: fitz.Page, interval: dict | None, block: dict, index: int, 
 
 
 def _get_line_anchor(interval):
-    if interval["start"] and interval["end"]:
-        return fitz.Point(
-            interval["start"]["rect"][2], (interval["start"]["rect"][1] + interval["end"]["rect"][3]) / 2
-        )
-    elif interval["start"]:
-        return fitz.Point(interval["start"]["rect"][2], interval["start"]["rect"][3])
-    elif interval["end"]:
-        return fitz.Point(interval["end"]["rect"][2], interval["end"]["rect"][1])
+    interval_start_rect = fitz.Rect(interval["start"]["rect"]) if interval["start"] else None
+    interval_end_rect = fitz.Rect(interval["end"]["rect"]) if interval["end"] else None
+
+    if interval_start_rect and interval_end_rect:
+        return fitz.Point(interval_start_rect.x1, (interval_start_rect.y0 + interval_end_rect.y1) / 2)
+    elif interval_start_rect:
+        return fitz.Point(interval_start_rect.x1, interval_start_rect.y1)
+    elif interval_end_rect:
+        return fitz.Point(interval_end_rect.x1, interval_end_rect.y0)
 
 
 def _background_rect(interval) -> fitz.Rect | None:

--- a/src/stratigraphy/util/interval.py
+++ b/src/stratigraphy/util/interval.py
@@ -43,6 +43,12 @@ class Interval(metaclass=abc.ABCMeta):
     def background_rect(self) -> fitz.Rect | None:
         pass
 
+    def to_json(self):
+        return {
+            "start": self.start.to_json() if self.start else None,
+            "end": self.end.to_json() if self.end else None,
+        }
+
 
 class BoundaryInterval(Interval):
     """Class for boundary intervals.

--- a/src/stratigraphy/util/line.py
+++ b/src/stratigraphy/util/line.py
@@ -106,3 +106,9 @@ class TextLine:
         indentation_points = indentation_points_1 + indentation_points_2
 
         return exact_points >= 3 or (exact_points >= 2 and indentation_points >= 1)
+
+    def to_json(self):
+        return {
+            "text": self.text,
+            "rect": [self.rect.x0, self.rect.y0, self.rect.x1, self.rect.y1],
+        }

--- a/src/stratigraphy/util/textblock.py
+++ b/src/stratigraphy/util/textblock.py
@@ -78,6 +78,13 @@ class TextBlock:
             blocks[-1].is_terminated_by_line = True
         return blocks
 
+    def to_json(self):
+        return {
+            "text": self.text,
+            "rect": [self.rect.x0, self.rect.y0, self.rect.x1, self.rect.y1],
+            "lines": [line.to_json() for line in self.lines],
+        }
+
 
 def block_distance(block1: TextBlock, block2: TextBlock) -> float:
     """Calculate the distance between two text blocks.

--- a/src/stratigraphy/util/util.py
+++ b/src/stratigraphy/util/util.py
@@ -1,5 +1,6 @@
 """This module contains general utility functions for the stratigraphy module."""
 
+import re
 from collections.abc import MutableMapping
 
 import fitz
@@ -72,3 +73,33 @@ def read_params(params_name: str) -> dict:
         params = yaml.safe_load(f)
 
     return params
+
+
+def parse_text(text: str) -> str:
+    """Parse text by removing non-alphanumeric characters and converting to lowercase.
+
+    Args:
+        text (str): Text to parse.
+
+    Returns:
+        str: Parsed text.
+    """
+    not_alphanum = re.compile(r"[^\w\d]", re.U)
+    return not_alphanum.sub("", text).lower()
+
+
+def parse_and_remove_empty_predictions(predictions: dict) -> dict:
+    """Remove empty predictions from the predictions dictionary.
+
+    Args:
+        predictions (dict): Predictions dictionary.
+
+    Returns:
+        dict: Predictions dictionary without empty predictions.
+    """
+    for layer in predictions:
+        layer["material_description"]["text"] = parse_text(layer["material_description"]["text"])
+        if layer["material_description"]["text"] == "":
+            predictions.remove(layer)
+
+    return predictions


### PR DESCRIPTION
**Content**
Previously, inference (i.e. perform_matching) was dependent on ground_truth information. Furthermore, various validation steps in form of drawing onto pdf pages was done in perform matching. This commit moves all evaluation steps to evaluate_matching.

The file predictions.json is adjusted and now contains much more information. The information is sufficient to reconstruct all drawings in the pdf pages, without the need of the python objects.

In particular, predictions.json now contains:
  - information about material_description and depth_column pairs (bounding boxes & values)
  - more information about the identified material description blocks (bounding boxes as well as lines)

Also comes with some refactoring of the main.py script.

Scores are not affected.

**Discussion**
Let me know what you think about the interface of predictions.json. I believe we'll require something like this in the future anyways.

Most classes for our stratigraphy module now have a `.to_json() `method. We could think of a `create_from_json()` init method, but that would require a bit more thought. I would only attempt this, if the frontend would make use of our classes - or if there are further downstream pipelines that could benefit from the initial objects (e.g. classification of material description texts).

With this PR, some class methods become obsolete. They are kept for the moment until we have a final decision on how to define the interfaces.

Happy to receive your thoughts on this.