### PR TITLE
Remove merging of blocks in transform groups.

### DIFF
--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -264,8 +264,8 @@ def transform_groups(
         if len(blocks) < len(depth_intervals):
             blocks = split_blocks_by_textline_length(blocks, target_split_count=len(depth_intervals) - len(blocks))
 
-        if len(blocks) > len(depth_intervals):
-            blocks = merge_blocks_by_vertical_spacing(blocks, target_merge_count=len(blocks) - len(depth_intervals))
+        # if len(blocks) > len(depth_intervals):
+        #     blocks = merge_blocks_by_vertical_spacing(blocks, target_merge_count=len(blocks) - len(depth_intervals))
 
         return [
             {"depth_interval": depth_interval, "block": block}


### PR DESCRIPTION
I would like to open the discussion about block merging in transform groups.

If I comment out the merging of blocks, the F1 score jumps from **86.7% to 87.3%.** Not a single document shows a reduced F1 score.

However, in some cases text that belongs to a block is not recognized as such any more.

E.g. 
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/c3d7667d-9f26-4e19-bd1c-8b93cb1be423)
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/efdb13f9-5556-454f-b96c-6900dcc5cee5)
![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/43504052/71071c43-d9f8-4673-8a6a-22efb44c2069)


**Document Level Metrics**
|    | document_name    |   F1_new |   Number Elements_new |   Number wrong elements_new |       F1 |   Number Elements |   Number wrong elements |
|---:|:-----------------|---------:|----------------------:|----------------------------:|---------:|------------------:|------------------------:|
|  0 | 677229003-bp.pdf | 0.844444 |                    24 |                           7 | 0.8      |                24 |                       9 |
|  1 | 695265009-bp.pdf | 0.634146 |                    21 |                          15 | 0.439024 |                21 |                      23 |
|  2 | 701241001-bp.pdf | 0.851852 |                    28 |                           8 | 0.777778 |                28 |                      12 |
|  3 | 268124571-bp.pdf | 0.938776 |                    51 |                           6 | 0.918367 |                51 |                       8 |
|  4 | 269124191-bp.pdf | 0.763636 |                    31 |                          13 | 0.690909 |                31 |                      17 |
|  5 | 699243001-bp.pdf | 0.870588 |                    44 |                          11 | 0.847059 |                44 |                      13 |
|  6 | 268125447-bp.pdf | 0.4375   |                    18 |                          18 | 0.375    |                18 |                      20 |
|  7 | 267125058-bp.pdf | 0.962963 |                    41 |                           3 | 0.938272 |                41 |                       5 |
|  8 | 675244002-bp.pdf | 0.162162 |                    30 |                          31 | 0.108108 |                30 |                      33 |
|  9 | 678249002-bp.pdf | 0.952381 |                    11 |                           1 | 0.857143 |                11 |                       3 |
| 10 | 700246002-bp.pdf | 0.941176 |                    34 |                           4 | 0.911765 |                34 |                       6 |
| 11 | 267124070-bp.pdf | 0.938776 |                    26 |                           3 | 0.816327 |                26 |                       9 | 