### PR TITLE
Refactor/indicator line weak condition

### DIFF
--- a/config/line_detection_params.yml
+++ b/config/line_detection_params.yml
@@ -14,6 +14,6 @@ vertical_lines_threshold: 0.6
 
 line_merging_params:
   clustering_threshold: 0.08
-  merging_tolerance: 5
+  merging_tolerance: 3
   angle_threshold: 5  # maximum difference in degrees two line segments can have in order to be merged.
   use_clustering: false  # No measureable performance improvement for "true"

--- a/config/line_detection_params.yml
+++ b/config/line_detection_params.yml
@@ -14,6 +14,6 @@ vertical_lines_threshold: 0.6
 
 line_merging_params:
   clustering_threshold: 0.08
-  merging_tolerance: 3
+  merging_tolerance: 3.  # maximum distance between two lines that are merged
   angle_threshold: 5  # maximum difference in degrees two line segments can have in order to be merged.
   use_clustering: false  # No measureable performance improvement for "true"

--- a/src/stratigraphy/util/description_block_splitter.py
+++ b/src/stratigraphy/util/description_block_splitter.py
@@ -98,19 +98,17 @@ class SplitDescriptionBlockByLine(DescriptionBlockSplitter):
 class SplitDescriptionBlockByLeftHandSideSeparator(DescriptionBlockSplitter):
     """Creates blocks based on shorter lines at the left-hand side of the material description text."""
 
-    def __init__(self, length_threshold: float, geometric_lines: list[Line], material_description_rect: fitz.Rect):
+    def __init__(self, length_threshold: float, geometric_lines: list[Line]):
         """Create a new SplitDescriptionBlockByLine instance.
 
         Args:
             length_threshold (int): The minimum length of a line segment on the left side of a block to split it.
             geometric_lines (list[Line]): The geometric lines detected in the pdf page.
-            material_description_rect (fitz.Rect): The bounding box for all material descriptions.
         """
         super().__init__()
         self.length_threshold = length_threshold
         self.set_terminated_by_line_flag = False
         self.geometric_lines = geometric_lines
-        self.material_description_rect = material_description_rect
 
     def separator_condition(self, last_line: TextLine, current_line: TextLine) -> bool:
         """Check if a block is separated by a line segment on the left side of the block.
@@ -128,8 +126,8 @@ class SplitDescriptionBlockByLeftHandSideSeparator(DescriptionBlockSplitter):
         for line in self.geometric_lines:
             line_y_coordinate = (line.start.y + line.end.y) / 2
 
-            line_near_lefthandside_of_block = (
-                line.start.x - self.length_threshold < self.material_description_rect.x0 < line.end.x
+            line_cuts_lefthandside_of_text = (line.start.x < last_line.rect.x0 < line.end.x) and (
+                line.start.x < current_line.rect.x0 < line.end.x
             )
             is_line_long_enough = (
                 np.abs(line.start.x - line.end.x) > self.length_threshold
@@ -137,7 +135,7 @@ class SplitDescriptionBlockByLeftHandSideSeparator(DescriptionBlockSplitter):
 
             line_ends_block = last_line_y_coordinate < line_y_coordinate < current_line_y_coordinate
 
-            if line_ends_block and is_line_long_enough and line_near_lefthandside_of_block:
+            if line_ends_block and is_line_long_enough and line_cuts_lefthandside_of_text:
                 return True
         return False
 

--- a/src/stratigraphy/util/description_block_splitter.py
+++ b/src/stratigraphy/util/description_block_splitter.py
@@ -155,13 +155,12 @@ class SplitDescriptionBlockByVerticalSpace(DescriptionBlockSplitter):
         self.threshold = threshold
         self.set_terminated_by_line_flag = False
 
-    def separator_condition(self, last_line: TextLine, current_line: TextLine, current_block: TextBlock) -> bool:
+    def separator_condition(self, last_line: TextLine, current_line: TextLine) -> bool:
         """Check if a block is separated by sufficient vertical space.
 
         Args:
             last_line (TextLine): The previous line.
             current_line (TextLine): The current line.
-            current_block (TextBlock): Current block.
 
         Returns:
             bool: True if the block is separated by sufficient vertical space, False otherwise.

--- a/src/stratigraphy/util/description_block_splitter.py
+++ b/src/stratigraphy/util/description_block_splitter.py
@@ -20,7 +20,7 @@ class DescriptionBlockSplitter(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def separator_condition(self, last_line: TextLine, current_line: TextLine, current_block: TextBlock) -> bool:  # noqa: D107
+    def separator_condition(self, last_line: TextLine, current_line: TextLine) -> bool:  # noqa: D107
         pass
 
     def create_blocks(self, description_lines: list[TextLine]) -> list[TextBlock]:
@@ -37,10 +37,10 @@ class DescriptionBlockSplitter(metaclass=abc.ABCMeta):
         for line in description_lines:
             if len(current_block_lines) > 0:
                 last_line = current_block_lines[-1]
-                current_block = TextBlock(current_block_lines)
-                if self.separator_condition(last_line, line, current_block):
-                    current_block.is_terminated_by_line = self.set_terminated_by_line_flag
-                    blocks.append(current_block)
+                if self.separator_condition(last_line, line):
+                    blocks.append(
+                        TextBlock(current_block_lines, is_terminated_by_line=self.set_terminated_by_line_flag)
+                    )
                     current_block_lines = []
             current_block_lines.append(line)
         if len(current_block_lines):
@@ -65,14 +65,13 @@ class SplitDescriptionBlockByLine(DescriptionBlockSplitter):
         self.geometric_lines = geometric_lines
         self.set_terminated_by_line_flag = True
 
-    def separator_condition(self, last_line: TextLine, current_line: TextLine, current_block: TextBlock) -> bool:
+    def separator_condition(self, last_line: TextLine, current_line: TextLine) -> bool:
         """Check if a block is separated by a line.
 
         Args:
             current_block:
             last_line (TextLine): The previous line.
             current_line (TextLine): The current line.
-            current_block (TextBlock): Current block.
 
         Returns:
             bool: True if the block is separated by a line, False otherwise.
@@ -99,25 +98,26 @@ class SplitDescriptionBlockByLine(DescriptionBlockSplitter):
 class SplitDescriptionBlockByLeftHandSideSeparator(DescriptionBlockSplitter):
     """Creates blocks based on shorter lines at the left-hand side of the material description text."""
 
-    def __init__(self, length_threshold: float, geometric_lines: list[Line]):
+    def __init__(self, length_threshold: float, geometric_lines: list[Line], material_description_rect: fitz.Rect):
         """Create a new SplitDescriptionBlockByLine instance.
 
         Args:
             length_threshold (int): The minimum length of a line segment on the left side of a block to split it.
             geometric_lines (list[Line]): The geometric lines detected in the pdf page.
+            material_description_rect (fitz.Rect): The bounding box for all material descriptions.
         """
         super().__init__()
         self.length_threshold = length_threshold
         self.set_terminated_by_line_flag = False
         self.geometric_lines = geometric_lines
+        self.material_description_rect = material_description_rect
 
-    def separator_condition(self, last_line: TextLine, current_line: TextLine, current_block: TextBlock) -> bool:
+    def separator_condition(self, last_line: TextLine, current_line: TextLine) -> bool:
         """Check if a block is separated by a line segment on the left side of the block.
 
         Args:
             last_line (TextLine): The previous line.
             current_line (TextLine): The current line.
-            current_block (TextBlock): Current block.
 
         Returns:
             bool: True if the block is separated by a line segment, False otherwise.
@@ -128,25 +128,16 @@ class SplitDescriptionBlockByLeftHandSideSeparator(DescriptionBlockSplitter):
         for line in self.geometric_lines:
             line_y_coordinate = (line.start.y + line.end.y) / 2
 
-            line_cuts_lefthandside_of_block = line.start.x < current_block.rect.x0 < line.end.x
+            line_near_lefthandside_of_block = (
+                line.start.x - self.length_threshold < self.material_description_rect.x0 < line.end.x
+            )
             is_line_long_enough = (
                 np.abs(line.start.x - line.end.x) > self.length_threshold
             )  # for the block splitting, we only care about x-extension
 
             line_ends_block = last_line_y_coordinate < line_y_coordinate < current_line_y_coordinate
 
-            weak_condition = (
-                (line.start.x - 5 < current_block.rect.x0 and line.end.x > current_block.rect.x0)
-                and (np.abs(line.start.x - line.end.x) > self.length_threshold - 2)
-                and (len(current_block.lines) > 1)
-            )  # if block has at least three lines, we weaken the splitting condition.
-            # It is three lines because the statement means that block.lines has at least two elements.
-            # The third line is current_line
-            # The reason for the splitting is, that if we know that a block is long, the probability for
-            # a missed splitting is higher. Therefore, we weaken the condition. The weakened condition
-            # leads to an improved score as per 21.03.2024.
-
-            if line_ends_block and ((is_line_long_enough and line_cuts_lefthandside_of_block) or weak_condition):
+            if line_ends_block and is_line_long_enough and line_near_lefthandside_of_block:
                 return True
         return False
 

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -80,7 +80,9 @@ def get_description_blocks(
     # Create blocks separated by lefthandside line segments
     _blocks = []
     splitter = SplitDescriptionBlockByLeftHandSideSeparator(
-        length_threshold=left_line_length_threshold, geometric_lines=geometric_lines
+        length_threshold=left_line_length_threshold,
+        geometric_lines=geometric_lines,
+        material_description_rect=material_description_rect,
     )
     for block in blocks:
         _blocks.extend(splitter.create_blocks(block.lines))

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -80,9 +80,7 @@ def get_description_blocks(
     # Create blocks separated by lefthandside line segments
     _blocks = []
     splitter = SplitDescriptionBlockByLeftHandSideSeparator(
-        length_threshold=left_line_length_threshold,
-        geometric_lines=geometric_lines,
-        material_description_rect=material_description_rect,
+        length_threshold=left_line_length_threshold, geometric_lines=geometric_lines
     )
     for block in blocks:
         _blocks.extend(splitter.create_blocks(block.lines))

--- a/src/stratigraphy/util/geometric_line_utilities.py
+++ b/src/stratigraphy/util/geometric_line_utilities.py
@@ -115,7 +115,7 @@ def merge_parallel_lines_approximately(
     return merged_lines
 
 
-def merge_parallel_lines_efficiently(lines: list[Line], tol: int = 8, angle_threshold: float = 2) -> list[Line]:
+def merge_parallel_lines_efficiently(lines: list[Line], tol: int, angle_threshold: float) -> list[Line]:
     """Merge parallel lines that are close to each other.
 
     This merging algorithm first sorts lines by their intercept and slope and then only compares neighbours. This
@@ -136,8 +136,8 @@ def merge_parallel_lines_efficiently(lines: list[Line], tol: int = 8, angle_thre
 
     Args:
         lines (list[Line]): The lines to merge.
-        tol (int, optional): Tolerance to check if lines are close. Defaults to 8.
-        angle_threshold (float, optional): Acceptable difference between the slopes of two lines. Defaults to 2.
+        tol (int, optional): Tolerance to check if lines are close.
+        angle_threshold (float, optional): Acceptable difference between the slopes of two lines.
 
     Returns:
         list[Line]: The merged lines.
@@ -155,15 +155,15 @@ def merge_parallel_lines_efficiently(lines: list[Line], tol: int = 8, angle_thre
 
 
 def merge_parallel_lines_neighbours(
-    lines: list[Line], sorting_function: callable, tol: int = 8, angle_threshold: float = 2
+    lines: list[Line], sorting_function: callable, tol: int, angle_threshold: float
 ) -> list[Line]:
     """Merge parallel lines by comparing neighbours in the sorted list of lines.
 
     Args:
         lines (list[Line]): The lines to merge.
         sorting_function (callable): The function to sort the lines by.
-        tol (int, optional): Tolerance to check if lines are close. Defaults to 8.
-        angle_threshold (float, optional): Acceptable difference between the slopes of two lines. Defaults to 2.
+        tol (int, optional): Tolerance to check if lines are close.
+        angle_threshold (float, optional): Acceptable difference between the slopes of two lines.
 
     Returns:
         list[Line]: The merged lines.
@@ -187,12 +187,14 @@ def merge_parallel_lines_neighbours(
         current_line = line
     merged_lines.append(current_line)
     if any_merges:
-        return merge_parallel_lines_neighbours(merged_lines, sorting_function=sorting_function, tol=tol)
+        return merge_parallel_lines_neighbours(
+            merged_lines, sorting_function=sorting_function, tol=tol, angle_threshold=angle_threshold
+        )
     else:
         return merged_lines
 
 
-def merge_parallel_lines(lines: list[Line], tol: int = 8, angle_threshold: float = 2) -> list[Line]:
+def merge_parallel_lines(lines: list[Line], tol: int, angle_threshold: float) -> list[Line]:
     """Merge parallel lines that are close to each other.
 
     NOTE: This function can likely be dropped. It is kept here for reference until the line functions
@@ -203,8 +205,8 @@ def merge_parallel_lines(lines: list[Line], tol: int = 8, angle_threshold: float
 
     Args:
         lines (list[Line]): The lines to merge.
-        tol (int, optional): Tolerance to check if lines are close. Defaults to 8.
-        angle_threshold (float, optional): Acceptable difference between the slopes of two lines. Defaults to 2.
+        tol (int, optional): Tolerance to check if lines are close.
+        angle_threshold (float, optional): Acceptable difference between the slopes of two lines.
 
     Returns:
         list[Line]: The merged lines.
@@ -216,7 +218,7 @@ def merge_parallel_lines(lines: list[Line], tol: int = 8, angle_threshold: float
         line = line_queue.popleft()
         merged = False
         for merge_candidate in merged_lines:
-            if _are_parallel(line, merge_candidate, threshold=angle_threshold) and _are_close(
+            if _are_parallel(line, merge_candidate, angle_threshold=angle_threshold) and _are_close(
                 line, merge_candidate, tol=tol
             ):
                 line = _merge_lines(line, merge_candidate)
@@ -230,7 +232,7 @@ def merge_parallel_lines(lines: list[Line], tol: int = 8, angle_threshold: float
         if not merged:
             merged_lines.append(line)
     if merged_any:
-        return merge_parallel_lines(merged_lines, tol=tol)
+        return merge_parallel_lines(merged_lines, tol=tol, angle_threshold=angle_threshold)
     else:
         return merged_lines
 
@@ -336,13 +338,13 @@ def _get_orthogonal_projection_to_line(point: Point, phi: float, r: float) -> Po
     return Point(x, y)
 
 
-def _are_close(line1: Line, line2: Line, tol: int = 5) -> bool:
+def _are_close(line1: Line, line2: Line, tol: int) -> bool:
     """Check if two lines are close to each other.
 
     Args:
         line1 (Line): The first line.
         line2 (Line): The second line.
-        tol (int, optional): The tolerance to check if the lines are close. Defaults to 10.
+        tol (int, optional): The tolerance to check if the lines are close.
 
     Returns:
         bool: True if the lines are close, False otherwise.
@@ -350,13 +352,13 @@ def _are_close(line1: Line, line2: Line, tol: int = 5) -> bool:
     return is_point_on_line(line1, line2.start, tol=tol) or is_point_on_line(line1, line2.end, tol=tol)
 
 
-def _are_parallel(line1: Line, line2: Line, angle_threshold: float = 2) -> bool:
+def _are_parallel(line1: Line, line2: Line, angle_threshold: float) -> bool:
     """Check if two lines are parallel.
 
     Args:
         line1 (Line): The first line.
         line2 (Line): The second line.
-        angle_threshold (float, optional): The acceptable difference between the slopes of the lines. Defaults to 2.
+        angle_threshold (float, optional): The acceptable difference between the slopes of the lines.
 
     Returns:
         bool: True if the lines are parallel, False otherwise.


### PR DESCRIPTION
- Decrease the `merging_tolerance` value from 5 to 3, to avoid longer lines being merged across different adjacent letters (see screenshot below: the line along "du" and the one along "mi" happens with the old value, but no longer with the new value)
- Remove default values for parameters in the individual methods, to avoid having (potentially inconsistent) default values across many different files and methods, and to ensure that the values from the yml files are always used and passed along.
- Simplify logic related to short indicator lines
  - Remove dependency on `current_block`, use the coordinates of `last_line` and `current_line` as a reference instead
  - Remove special case for blocks with at least three text lines, as I don't see this bringing any advantage anymore

![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/144008419/e9301b3d-82ef-440e-a40e-ce97726b957e)

Overall F1 score improves with +0.1% (86.6% -> 86.7%).

Individual files with changed F1 scores:
- 681246002-bp.pdf (86% -> 100%)
- 268124125-bp.pdf (2.6% -> 2.7%)
- 268124635-bp.pdf (83% -> 77%; bounding box from OCR is not accurate, and therefore the indicator line is not recognised, as it does not intersect the left-hand-side of the text line)
- 699248001-bp.pdf (85% -> 74%, only very short horizontal indicator lines, would work better if we would also be able to consider connected diagonal line segments)
- 268124599-bp.pdf (22% -> 57%)
- 267123060-bp.pdf (94% -> 75%; dashed lined no longer recognized as a single merged line)
- 691251009-bp.pdf (23% -> 25%)
- 268124391-bp.pdf (92% -> 94%)
- 268125447-bp.pdf (36% -> 42%)
- 268124307-bp.pdf (92% -> 94%)