### PR TITLE
add "Kernmaterial" to list of keywords for material description

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -19,3 +19,4 @@ material_description:
   - beton
   - kreide
   - mergel
+  - kernmaterial


### PR DESCRIPTION
Descriptions such as "Kein Kernmaterial (ungestörte Probe)" should also be considered as valid material descriptions. However, previously, these were usually not correctly recognized. This is fixed by adding "Kernmaterial" to the list of keywords that are used to find the material descriptions in the document.

The change improves the output for three documents in the validation dataset: 267125307-bp.pdf, 267125308-bp.pdf and 268124336-bp.pdf. Overall, the F1 score improves from 87.7% to 87.9%.