### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,16 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+      with:
+        python-version: 3.10.14
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,23 @@
+name: pytest
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Create Environment and run tests
+      shell: bash
+      run: |
+        wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+        bash Miniforge3.sh -b -p "${HOME}/conda"
+        source "${HOME}/conda/etc/profile.d/conda.sh"
+        conda init --all
+        source "${HOME}/.bash_profile"
+        conda env create -f environment-dev.yml
+        conda activate boreholes-dev
+        pytest


### PR DESCRIPTION
Introduction of GitHub actions.

Two actions are defined:

1. pre-commit action: Checks whether our pre-commit hooks pass (i.e. ruff lint and ruff format)
2. pytest action: Checks whether all tests pass.

Note: As of now the pytest action is not much abstracted. We do the installation of miniforge and the execution of the test command in the same step. I did not manage to have conda work across steps as some things are not shared across steps (e.g. shell environment). Re-sourcing the bash profile in subsequent step did not help.

Note 2: It would be nice to add code coverage.