### PR TITLE
Improve Depth Intervals

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -3,6 +3,10 @@ block_line_ratio: 0.20
 left_line_length_threshold: 7
 img_template_probability_threshold: 0.62
 
+depth_column_params:
+  noise_count_threshold: 1.25
+  noise_count_offset: 0
+
 material_description:
   de:
     including_expressions:

--- a/src/stratigraphy/benchmark/score.py
+++ b/src/stratigraphy/benchmark/score.py
@@ -113,6 +113,9 @@ def get_scores(
         overall_precision = 0
         overall_recall = 0
 
+    if overall_depth_interval_accuracy is None:
+        overall_depth_interval_accuracy = 0
+
     if return_document_level_metrics:
         return {
             "F1": f1(overall_precision, overall_recall),
@@ -165,7 +168,7 @@ def evaluate_matching(predictions: dict, number_of_truth_values: dict) -> tuple[
     logging.info(
         f"F1: {metrics['all']['F1']:.1%}, "
         f"precision: {metrics['all']['precision']:.1%}, recall: {metrics['all']['recall']:.1%}, "
-        f"depth_interval_accuracy: {metrics['all']['depth_interval_accuracy']:.1%}"
+        # f"depth_interval_accuracy: {metrics['all']['depth_interval_accuracy']:.1%}"
     )
 
     _metrics = {}

--- a/src/stratigraphy/benchmark/score.py
+++ b/src/stratigraphy/benchmark/score.py
@@ -168,7 +168,7 @@ def evaluate_matching(predictions: dict, number_of_truth_values: dict) -> tuple[
     logging.info(
         f"F1: {metrics['all']['F1']:.1%}, "
         f"precision: {metrics['all']['precision']:.1%}, recall: {metrics['all']['recall']:.1%}, "
-        # f"depth_interval_accuracy: {metrics['all']['depth_interval_accuracy']:.1%}"
+        f"depth_interval_accuracy: {metrics['all']['depth_interval_accuracy']:.1%}"
     )
 
     _metrics = {}

--- a/src/stratigraphy/extract.py
+++ b/src/stratigraphy/extract.py
@@ -75,10 +75,12 @@ def process_page(page: fitz.Page, geometric_lines, language: str, **params: dict
         for entry in find_depth_columns.depth_column_entries(words, include_splits=False)
         if entry.rect not in used_entry_rects
     ]
-
     depth_columns: list[DepthColumn] = layer_depth_columns
-    depth_columns.extend(find_depth_columns.find_depth_columns(depth_column_entries, words))
-
+    depth_columns.extend(
+        find_depth_columns.find_depth_columns(
+            depth_column_entries, words, depth_column_params=params["depth_column_params"]
+        )
+    )
     pairs = []
     for depth_column in depth_columns:
         material_description_rect = find_material_description_column(

--- a/src/stratigraphy/util/depthcolumn.py
+++ b/src/stratigraphy/util/depthcolumn.py
@@ -172,8 +172,20 @@ class BoundaryDepthColumn(DepthColumn):
 
     entries: list[DepthColumnEntry]
 
-    def __init__(self, entries=None):
+    def __init__(self, noise_count_threshold: float, noise_count_offset: int, entries: list = None):
+        """Initializes a BoundaryDepthColumn object.
+
+        Args:
+            noise_count_threshold (float): Noise count threshold deciding how much noise is allowed in a column
+                                           to be valid.
+            noise_count_offset (int): Offset for the noise count threshold. Affects the noise count criterion.
+                                      Effective specifically for depth columns with very few entries.
+            entries (list, optional): Depth Column Entries for the depth column. Defaults to None.
+        """
         super().__init__()
+
+        self.noise_count_threshold = noise_count_threshold
+        self.noise_count_offset = noise_count_offset
 
         if entries is not None:
             self.entries = entries
@@ -219,10 +231,12 @@ class BoundaryDepthColumn(DepthColumn):
 
     def valid_initial_segment(self, rect: fitz.Rect) -> BoundaryDepthColumn:
         for i in range(len(self.entries) - 1):
-            initial_segment = BoundaryDepthColumn(self.entries[: -i - 1])
+            initial_segment = BoundaryDepthColumn(
+                self.noise_count_threshold, self.noise_count_offset, self.entries[: -i - 1]
+            )
             if initial_segment.can_be_appended(rect):
                 return initial_segment
-        return BoundaryDepthColumn()
+        return BoundaryDepthColumn(self.noise_count_threshold, self.noise_count_offset)
 
     def strictly_contains(self, other: BoundaryDepthColumn):
         return len(other.entries) < len(self.entries) and all(
@@ -254,7 +268,9 @@ class BoundaryDepthColumn(DepthColumn):
             # to allow for OCR errors or gaps in the progression, we only require a segment of length 6 that is an
             # arithmetic progression
             for i in range(len(self.entries) - 6 + 1):
-                if BoundaryDepthColumn(self.entries[i : i + 6]).is_arithmetic_progression():
+                if BoundaryDepthColumn(
+                    self.noise_count_threshold, self.noise_count_offset, self.entries[i : i + 6]
+                ).is_arithmetic_progression():
                     return True
             return False
 
@@ -277,12 +293,12 @@ class BoundaryDepthColumn(DepthColumn):
 
         The depth column is considered valid if:
         - The number of entries is at least 3.
-        - The number of words that intersect with the depth column entries is less than half of the number
-          of entries minus 1.
+        - The number of words that intersect with the depth column entries is less than the noise count threshold
+          time the number of entries minus the noise count offset.
         - The entries are linearly correlated with their vertical position.
 
-        Note: The check for the noise count may require further refinement. Too many valid depth columns are
-        completely dropped because of this check.
+        Note: The noise count criteria may require a rehaul. Some depth columns are not recognized as valid
+        even though they are.
 
         Args:
             all_words (list[TextLine]): A list of all text lines on the page.
@@ -294,8 +310,7 @@ class BoundaryDepthColumn(DepthColumn):
             return False
 
         # When too much other text is in the column, then it is probably not valid
-        # TODO: make this check more robust/intelligent
-        if self.noise_count(all_words) > 0.5 * len(self.entries) - 0:  # TODO: Explain magic numbers
+        if self.noise_count(all_words) > self.noise_count_threshold * len(self.entries) - self.noise_count_offset:
             return False
 
         corr_coef = self.pearson_correlation_coef()
@@ -353,7 +368,11 @@ class BoundaryDepthColumn(DepthColumn):
             return None
 
         new_columns = [
-            BoundaryDepthColumn([entry for index, entry in enumerate(self.entries) if index != remove_index])
+            BoundaryDepthColumn(
+                self.noise_count_threshold,
+                self.noise_count_offset,
+                [entry for index, entry in enumerate(self.entries) if index != remove_index],
+            )
             for remove_index in range(len(self.entries))
         ]
         return max(new_columns, key=lambda column: column.pearson_correlation_coef())
@@ -378,7 +397,9 @@ class BoundaryDepthColumn(DepthColumn):
         if len(final_segment):
             segments.append(final_segment)
 
-        return [BoundaryDepthColumn(segment) for segment in segments]
+        return [
+            BoundaryDepthColumn(self.noise_count_threshold, self.noise_count_offset, segment) for segment in segments
+        ]
 
     def identify_groups(
         self,

--- a/src/stratigraphy/util/depthcolumn.py
+++ b/src/stratigraphy/util/depthcolumn.py
@@ -351,10 +351,10 @@ class BoundaryDepthColumn(DepthColumn):
         linearly correlated with their vertical position.
 
         Args:
-            all_words (list[TextLine]): _description_
+            all_words (list[TextLine]): A list of all text lines on the page.
 
         Returns:
-            BoundaryDepthColumn: _description_
+            BoundaryDepthColumn: The current depth column with entries removed until it is valid.
         """
         current = self
         while current:

--- a/src/stratigraphy/util/draw.py
+++ b/src/stratigraphy/util/draw.py
@@ -86,6 +86,7 @@ def draw_material_descriptions(page: fitz.Page, layers: LayerPrediction) -> None
             layer=layer.material_description,
             index=index,
             is_correct=layer.material_is_correct,  # None if no ground truth
+            depth_is_correct=layer.depth_interval_is_correct,  # None if no ground truth
         )
 
 
@@ -134,6 +135,7 @@ def draw_layer(
     layer: TextBlock,
     index: int,
     is_correct: bool,
+    depth_is_correct: bool,
 ):
     """Draw layers on a pdf page.
 
@@ -143,10 +145,11 @@ def draw_layer(
 
     Args:
         page (fitz.Page): The page to draw on.
-        interval (dict | None): Depth interval for the layer.
+        interval (BoundaryInterval | None): Depth interval for the layer.
         layer (MaterialDescriptionPrediction): Material description block for the layer.
         index (int): Index of the layer.
         is_correct (bool): Whether the text block was correctly identified.
+        depth_is_correct (bool): Whether the depth interval was correctly identified.
     """
     if len(layer.lines):
         layer_rect = fitz.Rect(layer.rect)
@@ -177,6 +180,17 @@ def draw_layer(
                     fill=fitz.utils.getColor(color),
                     fill_opacity=0.2,
                 )
+
+                # draw green line if depth interval is correct else red line
+                if depth_is_correct is not None:
+                    depth_is_correct_color = "green" if depth_is_correct else "red"
+                    page.draw_line(
+                        background_rect.top_left * page.derotation_matrix,
+                        background_rect.bottom_left * page.derotation_matrix,
+                        color=fitz.utils.getColor(depth_is_correct_color),
+                        width=6,
+                        stroke_opacity=0.5,
+                    )
 
             # line from depth interval to material description
             line_anchor = interval.line_anchor

--- a/src/stratigraphy/util/find_depth_columns.py
+++ b/src/stratigraphy/util/find_depth_columns.py
@@ -124,12 +124,15 @@ def find_layer_depth_columns(entries: list[DepthColumnEntry], all_words: list[Te
     ]
 
 
-def find_depth_columns(entries: list[DepthColumnEntry], all_words: list[TextLine]) -> list[BoundaryDepthColumn]:
+def find_depth_columns(
+    entries: list[DepthColumnEntry], all_words: list[TextLine], depth_column_params: dict
+) -> list[BoundaryDepthColumn]:
     """Construct all possible BoundaryDepthColumn objects from the given DepthColumnEntry objects.
 
     Args:
         entries (list[DepthColumnEntry]): All found depth column entries in the page.
         all_words (list[TextLine]): All words in the page.
+        depth_column_params (dict): Parameters for the BoundaryDepthColumn objects.
 
     Returns:
         list[BoundaryDepthColumn]: Found BoundaryDepthColumn objects.
@@ -150,7 +153,7 @@ def find_depth_columns(entries: list[DepthColumnEntry], all_words: list[TextLine
 
         numeric_columns.extend(additional_columns)
         if not has_match:
-            numeric_columns.append(BoundaryDepthColumn([entry]))
+            numeric_columns.append(BoundaryDepthColumn(**depth_column_params, entries=[entry]))
 
         # only keep columns that are not contained in a different column
         numeric_columns = [
@@ -158,7 +161,6 @@ def find_depth_columns(entries: list[DepthColumnEntry], all_words: list[TextLine
             for column in numeric_columns
             if all(not other.strictly_contains(column) for other in numeric_columns)
         ]
-
     numeric_columns = [
         column.reduce_until_valid(all_words)
         for numeric_column in numeric_columns

--- a/src/stratigraphy/util/find_depth_columns.py
+++ b/src/stratigraphy/util/find_depth_columns.py
@@ -24,22 +24,21 @@ def depth_column_entries(all_words: list[TextLine], include_splits: bool) -> lis
 
     def value_as_float(string_value: str) -> float:  # noqa: D103
         # OCR sometimes tends to miss the decimal comma
-        parsed_text = re.sub(r"^([0-9]+)([0-9]{2})", r"\1.\2", string_value)
+        parsed_text = re.sub(r"^-?([0-9]+)([0-9]{2})", r"\1.\2", string_value)
         return abs(float(parsed_text))
 
     entries = []
     for line in sorted(all_words, key=lambda line: line.rect.y0):
         try:
             input_string = line.text.strip().replace(",", ".")
-            regex = re.compile(r"^([0-9]+(\.[0-9]+)?)[müMN\\.]*$")
+            regex = re.compile(r"^-?([0-9]+(\.[0-9]+)?)[müMN\\.]*$")
             match = regex.match(input_string)
-
             if match:
                 value = value_as_float(match.group(1))
                 entries.append(DepthColumnEntry(line.rect, value))
             elif include_splits:
                 # support for e.g. "1.10-1.60m" extracted as a single word
-                regex2 = re.compile(r"^([0-9]+(\.[0-9]+)?)[müMN\\.]*\W+([0-9]+(\.[0-9]+)?)[müMN\\.]*$")
+                regex2 = re.compile(r"^-?([0-9]+(\.[0-9]+)?)[müMN\\.]*\W+([0-9]+(\.[0-9]+)?)[müMN\\.]*$")
                 match2 = regex2.match(input_string)
 
                 if match2:
@@ -126,14 +125,14 @@ def find_layer_depth_columns(entries: list[DepthColumnEntry], all_words: list[Te
 
 
 def find_depth_columns(entries: list[DepthColumnEntry], all_words: list[TextLine]) -> list[BoundaryDepthColumn]:
-    """TODO: Add description here. It is not entirely clear to me (@redur) what this function does.
+    """Construct all possible BoundaryDepthColumn objects from the given DepthColumnEntry objects.
 
     Args:
-        entries (list[DepthColumnEntry]): _description_
-        all_words (list[TextLine]): _description_
+        entries (list[DepthColumnEntry]): All found depth column entries in the page.
+        all_words (list[TextLine]): All words in the page.
 
     Returns:
-        list[BoundaryDepthColumn]: _description_
+        list[BoundaryDepthColumn]: Found BoundaryDepthColumn objects.
     """
     numeric_columns: list[BoundaryDepthColumn] = []
     for entry in entries:

--- a/src/stratigraphy/util/interval.py
+++ b/src/stratigraphy/util/interval.py
@@ -63,7 +63,7 @@ class AnnotatedInterval:
 class BoundaryInterval(Interval):
     """Class for boundary intervals.
 
-    TODO: Write description. It is not entirely clear to me (@redur) what this class does.
+    Boundary intervals are intervals that are defined by a start and an end point.
     """
 
     def __init__(self, start: DepthColumnEntry | None, end: DepthColumnEntry | None):
@@ -149,7 +149,8 @@ class BoundaryInterval(Interval):
 class LayerInterval(Interval):
     """Class for layer intervals.
 
-    TODO: Write description. It is not entirely clear to me (@redur) what this class does.
+    A layer interval is an interval whose start and end-points are defined in a single entry.
+    E.g. 1.00 - 2.30m.
     """
 
     def __init__(self, layer_depth_column_entry: LayerDepthColumnEntry):

--- a/tests/test_find_depth_columns.py
+++ b/tests/test_find_depth_columns.py
@@ -55,7 +55,11 @@ def test_find_depth_columns_arithmetic_progression():  # noqa: D103
         DepthColumnEntry(fitz.Rect(0, 8, 5, 9), 50.0),
     ]
 
-    columns = find_depth_columns(entries, all_words_find_depth_column)
+    columns = find_depth_columns(
+        entries,
+        all_words_find_depth_column,
+        depth_column_params={"noise_count_threshold": 1.25, "noise_count_offset": 0},
+    )
     assert len(columns) == 0, "There should be 0 columns as the above is a perfect arithmetic progression"
 
 
@@ -68,7 +72,11 @@ def test_find_depth_columns():  # noqa: D103
         DepthColumnEntry(fitz.Rect(0, 8, 5, 9), 50.0),
     ]
 
-    columns = find_depth_columns(entries, all_words_find_depth_column)
+    columns = find_depth_columns(
+        entries,
+        all_words_find_depth_column,
+        depth_column_params={"noise_count_threshold": 1.25, "noise_count_offset": 0},
+    )
     assert len(columns) == 1, "There should be 1 column"
     assert len(columns[0].entries) == 5, "The column should have 5 entries"
     assert pytest.approx(columns[0].entries[0].value) == 12.0, "The first entry should have a value of 12.0"
@@ -92,7 +100,11 @@ def test_two_columns_find_depth_columns():  # noqa: D103
         DepthColumnEntry(fitz.Rect(20, 8, 25, 9), 50.0),
         DepthColumnEntry(fitz.Rect(20, 10, 25, 11), 61.0),
     ]
-    columns = find_depth_columns(entries, all_words_find_depth_column)
+    columns = find_depth_columns(
+        entries,
+        all_words_find_depth_column,
+        depth_column_params={"noise_count_threshold": 1.25, "noise_count_offset": 0},
+    )
     assert len(columns) == 2, "There should be 2 columns"
     assert len(columns[0].entries) == 5, "The first column should have 5 entries"
     assert len(columns[1].entries) == 6, "The second column should have 6 entries"


### PR DESCRIPTION
In this PR we:
- Added visualization whether depth interval is correct.
- Improved the depth_column recognition by weakening the noise_count criterion.


**Result**
Depth_interval_accuracy improves from 42% to 62.3% while keeping F1 score at 49.3%.

The F1 score for the Zurich dataset decreased to 87.1% from 87.9%.

For future implementation we might want to reconsider how we split the material description blocks with regards to the criterion that we expect the same number of blocks as depth intervals.

Leaving this PR for review now.