### PR TITLE
quad tree with points that have a set of line indices as data

### DIFF
--- a/src/stratigraphy/line_detection.py
+++ b/src/stratigraphy/line_detection.py
@@ -11,7 +11,6 @@ from numpy.typing import ArrayLike
 
 from stratigraphy.util.dataclasses import Line
 from stratigraphy.util.geometric_line_utilities import (
-    deduplicate_lines,
     drop_vertical_lines,
     merge_parallel_lines_quadtree,
 )
@@ -72,7 +71,6 @@ def extract_lines(page: fitz.Page, line_detection_params: dict) -> list[Line]:
         scale_factor=line_detection_params["pdf_scale_factor"],
     )
     lines = drop_vertical_lines(lines, threshold=line_detection_params["vertical_lines_threshold"])
-    lines = deduplicate_lines(lines)
     merging_params = line_detection_params["line_merging_params"]
 
     return merge_parallel_lines_quadtree(

--- a/src/stratigraphy/util/dataclasses.py
+++ b/src/stratigraphy/util/dataclasses.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from dataclasses import dataclass
 
 import numpy as np
@@ -56,21 +55,3 @@ class Line:
 
     def intercept(self) -> float:
         return self.start.y - self.slope * self.start.x
-
-
-class IndexedLines:
-    """Class to store lines with an index for efficient lookup."""
-
-    def __init__(self, lines: list[Line]):
-        self.hashmap = {}
-        for line in lines:
-            self.hashmap[uuid.uuid4().hex] = line
-
-    def remove(self, line_index: str):
-        if line_index in self.hashmap:
-            del self.hashmap[line_index]
-
-    def add(self, line: Line) -> str:
-        key = uuid.uuid4().hex
-        self.hashmap[key] = line
-        return key

--- a/src/stratigraphy/util/geometric_line_utilities.py
+++ b/src/stratigraphy/util/geometric_line_utilities.py
@@ -227,7 +227,6 @@ def merge_parallel_lines_quadtree(lines: list[Line], tol: int, angle_threshold: 
     lines_quad_tree = LinesQuadTree(width, height)
 
     keys_queue = queue.Queue()
-    print("lines", len(lines))
     for line in lines:
         line_key = lines_quad_tree.add(line)
         keys_queue.put(line_key)

--- a/src/stratigraphy/util/linesquadtree.py
+++ b/src/stratigraphy/util/linesquadtree.py
@@ -14,12 +14,28 @@ class LinesQuadTree:
     """
 
     def __init__(self, width: float, height: float):
+        """Create a LinesQuadTree instance.
+
+        The LinesQuadTree will contain an actual quad tree with the end points of all lines, as well as a hashmap to
+        keep track of the lines themselves.
+
+        Args:
+            width (float): width of the area that should contain all (endpoints of) all lines.
+            height (float): height of the area that should contain all (endpoints of) all lines.
+        """
         self.qtree = quads.QuadTree(
             (width / 2, height / 2), width + 1000, height + 1000
         )  # Add some margin to the width and height to allow for slightly negative values
         self.hashmap = {}
 
     def remove(self, line_key: str):
+        """Remove a line from the quad tree.
+
+        If no matching line exists in the quad tree, then the method returns immediately without error.
+
+        Args:
+            line_key (str): The key of the line to be removed from the quad tree.
+        """
         if line_key in self.hashmap:
             line = self.hashmap[line_key]
             self._qtree_delete(line.start, line_key)
@@ -27,6 +43,15 @@ class LinesQuadTree:
             del self.hashmap[line_key]
 
     def add(self, line: Line) -> str:
+        """Add a line to the quad tree.
+
+        Args:
+            line (Line): the line to be added to the quad tree.
+
+        Returns:
+            str: the UUID key that is automatically generated for the new line.
+
+        """
         line_key = uuid.uuid4().hex
         self.hashmap[line_key] = line
 

--- a/src/stratigraphy/util/linesquadtree.py
+++ b/src/stratigraphy/util/linesquadtree.py
@@ -1,0 +1,76 @@
+"""Quad tree implementation for efficiently finding lines in a specific area of a page/image."""
+
+import uuid
+
+import quads
+
+from stratigraphy.util.dataclasses import Line, Point
+
+
+class LinesQuadTree:
+    """Wrapper around the quad tree implementation of the quads library.
+
+    Enables efficiently finding lines that start or end within a given bounding box.
+    """
+
+    def __init__(self, width: float, height: float):
+        self.qtree = quads.QuadTree(
+            (width / 2, height / 2), width + 1000, height + 1000
+        )  # Add some margin to the width and height to allow for slightly negative values
+        self.hashmap = {}
+
+    def remove(self, line_key: str):
+        if line_key in self.hashmap:
+            line = self.hashmap[line_key]
+            self._qtree_delete((line.start.x, line.start.y), line_key)
+            self._qtree_delete((line.end.x, line.end.y), line_key)
+            del self.hashmap[line_key]
+
+    def add(self, line: Line) -> str:
+        line_key = uuid.uuid4().hex
+        self.hashmap[line_key] = line
+
+        self._qtree_insert((line.start.x, line.start.y), line_key)
+        self._qtree_insert((line.end.x, line.end.y), line_key)
+        return line_key
+
+    def neighbouring_lines(self, line_key: str, tol: float) -> list[(str, Line)]:
+        """Efficiently search for all the lines that have a start or end point close to the given line.
+
+        Args:
+            line_key (keys): The key of the line to search neighbours of.
+            tol (float): Tolerance value. Search only for lines with a start or end point that is within this distance
+                         from the bounding box formed by the start and end points of the given line.
+
+        Returns:
+            list[(str, Line)]: The lines that are close to the given line, returned as a tuples (line_key, line).
+        """
+        if line_key not in self.hashmap:
+            return []
+
+        line = self.hashmap[line_key]
+        min_x = min(line.start.x, line.end.x)
+        max_x = max(line.start.x, line.end.x)
+        min_y = min(line.start.y, line.end.y)
+        max_y = max(line.start.y, line.end.y)
+        bb = quads.BoundingBox(min_x - tol, min_y - tol, max_x + tol, max_y + tol)
+        points = self.qtree.within_bb(bb)
+
+        neighbouring_lines = []
+        for point in points:
+            for neighbour_key in point.data:
+                if neighbour_key != line_key and neighbour_key in self.hashmap:
+                    neighbouring_lines.append((neighbour_key, self.hashmap[neighbour_key]))
+        return neighbouring_lines
+
+    def _qtree_insert(self, point: Point | tuple, line_key: str):
+        qtree_point = self.qtree.find(point)
+        if qtree_point:
+            qtree_point.data.add(line_key)
+        else:
+            self.qtree.insert(point, data={line_key})
+
+    def _qtree_delete(self, point: Point | tuple, line_key: str):
+        qtree_point = self.qtree.find(point)
+        if qtree_point:
+            qtree_point.data.remove(line_key)

--- a/src/stratigraphy/util/linesquadtree.py
+++ b/src/stratigraphy/util/linesquadtree.py
@@ -103,3 +103,6 @@ class LinesQuadTree:
         qtree_point = self.qtree.find(coordinates)
         if qtree_point:
             qtree_point.data.remove(line_key)
+            # If the data is now empty, then we could theoretically completely remove the point from the quad tree.
+            # However, the current implementation from the quads library does not support removing points. Therefore,
+            # a point with empty data might be left in the quad tree.


### PR DESCRIPTION
Code review proposal for https://github.com/swisstopo/swissgeol-boreholes-dataextraction/pull/38
- Link multiple lines with a single point in the quad tree
- Remove the need for recursive calls of the "merge lines by quad tree" method
- Remove the need for the inefficient check for duplicate lines

I think that some unit tests for the LinesQuadTree class could be really useful, but I did not have time to implement any new tests yet. I'll leave that up to you @redur to either add some unit tests, or to accept this PR as-is already and to leave writing unit tests for later.