### PR TITLE
Feat: Material Block recognition for Geneva Layout

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -46,21 +46,24 @@ material_description:
   fr:
     including_expressions:
       - sol
-      - végétal
+      - végétal  # remove accents generally; ocr might be wrong
       - dallage
       - terre
       - bitume
       - bitumineux
-      - grave d'infrastructure
+      - grave d'infrastructure  # what happens if we remove this?
       - sable
       - limon
       - gravier
       - asphalte
-      - humus
+      - humus  # hummus maybe?
       - brun
       - gris
+      - grise
       - mou
       - dur
+      - dure
+      - ferme
       - racine
       - revetement
       - pierre
@@ -68,9 +71,19 @@ material_description:
       - beton
       - craie
       - marne
-      - materiau de base
+      - materiau
       - matrice sableuse
-      - enrobé
+      - enrobé  # accent --> check what happens if it's removed
+      - terrain
+      - remblais
+      - remblai
+      - molasse
+      - phase
+      - formations
+      - limoneuse
+      - argileuse
+      - argileux
+      - mousse
     excluding_expressions:
       - monsieur
       - fin

--- a/src/stratigraphy/extract.py
+++ b/src/stratigraphy/extract.py
@@ -50,7 +50,7 @@ def process_page(page: fitz.Page, geometric_lines, language: str, **params: dict
     for x0, y0, x1, y1, word, block_no, line_no, _word_no in fitz.utils.get_text(page, "words"):
         rect = fitz.Rect(x0, y0, x1, y1) * page.rotation_matrix
         text_word = TextWord(rect, word)
-        words.append(TextLine([text_word]))
+        words.append(text_word)
         key = f"{block_no}_{line_no}"
         if key not in words_by_line:
             words_by_line[key] = []
@@ -105,7 +105,7 @@ def process_page(page: fitz.Page, geometric_lines, language: str, **params: dict
             if material_description_rect:
                 layer_identifier_pairs.append((layer_identifier_column, material_description_rect))
 
-        # Obtain the best pair. In contrast do depth columns, there only ever is one layer index column per page.
+        # Obtain the best pair. In contrast to depth columns, there only ever is one layer index column per page.
         if layer_identifier_pairs:
             layer_identifier_pairs.sort(key=lambda pair: score_column_match(pair[0], pair[1]))
             layer_identifier_column, material_description_rect = layer_identifier_pairs[-1]

--- a/src/stratigraphy/extract.py
+++ b/src/stratigraphy/extract.py
@@ -5,11 +5,17 @@ import math
 
 import fitz
 
+from stratigraphy import DATAPATH
 from stratigraphy.util import find_depth_columns
 from stratigraphy.util.dataclasses import Line
 from stratigraphy.util.depthcolumn import DepthColumn
-from stratigraphy.util.find_description import get_description_blocks, get_description_lines
+from stratigraphy.util.find_description import (
+    get_description_blocks,
+    get_description_blocks_from_layer_index,
+    get_description_lines,
+)
 from stratigraphy.util.interval import BoundaryInterval, Interval
+from stratigraphy.util.layer_index_column import find_layer_index_column, find_layer_index_column_entries
 from stratigraphy.util.line import TextLine, TextWord
 from stratigraphy.util.textblock import TextBlock, block_distance
 from stratigraphy.util.util import (
@@ -81,6 +87,56 @@ def process_page(page: fitz.Page, geometric_lines, language: str, **params: dict
             depth_column_entries, words, depth_column_params=params["depth_column_params"]
         )
     )
+
+    # Detect Layer Index Columns
+    layer_index_entries = find_layer_index_column_entries(words)
+    layer_index_columns = find_layer_index_column(layer_index_entries) if layer_index_entries else []
+    if layer_index_columns:
+        layer_index_pairs = []
+        for layer_index_column in layer_index_columns:
+            material_description_rect = find_material_description_column(
+                lines, layer_index_column, language, **params["material_description"]
+            )
+            if material_description_rect:
+                layer_index_pairs.append((layer_index_column, material_description_rect))
+
+        # Obtain the best pair. In contrast do depth columns, there only ever is one layer index column per page.
+        if layer_index_pairs:
+            layer_index_pairs.sort(key=lambda pair: score_column_match(pair[0], pair[1]))
+            layer_index_column, material_description_rect = layer_index_pairs[-1]
+            # split the material description rect into blocks.
+            description_lines = get_description_lines(lines, material_description_rect)
+            blocks = get_description_blocks_from_layer_index(layer_index_column.entries, description_lines)
+
+            predictions = [{"material_description": block.to_json()} for block in blocks]
+            predictions = parse_and_remove_empty_predictions(predictions)
+
+            json_filtered_pairs = [
+                {
+                    "depth_column": None,
+                    "material_description_rect": [
+                        material_description_rect.x0,
+                        material_description_rect.y0,
+                        material_description_rect.x1,
+                        material_description_rect.y1,
+                    ],
+                }
+            ]
+
+            # Visualization: To be dropped before merging to main.
+            for layer_index_column in layer_index_columns:
+                fitz.utils.draw_rect(
+                    page, layer_index_column.rect() * page.derotation_matrix, color=fitz.utils.getColor("blue")
+                )
+            for block in blocks:
+                fitz.utils.draw_rect(page, block.rect * page.derotation_matrix, color=fitz.utils.getColor("red"))
+            fitz.utils.draw_rect(
+                page, material_description_rect * page.derotation_matrix, color=fitz.utils.getColor("blue")
+            )
+            page.parent.save(DATAPATH / "_temp" / "output.pdf", garbage=4, deflate=True, clean=True)
+
+            return predictions, json_filtered_pairs
+
     pairs = []
     for depth_column in depth_columns:
         material_description_rect = find_material_description_column(
@@ -88,7 +144,6 @@ def process_page(page: fitz.Page, geometric_lines, language: str, **params: dict
         )
         if material_description_rect:
             pairs.append((depth_column, material_description_rect))
-
     # lowest score first
     pairs.sort(key=lambda pair: score_column_match(pair[0], pair[1], words))
 
@@ -101,7 +156,7 @@ def process_page(page: fitz.Page, geometric_lines, language: str, **params: dict
     filtered_pairs = [item for index, item in enumerate(pairs) if index not in to_delete]
 
     groups = []  # list of matched depth intervals and text blocks
-    # groups is of the form: ["depth_interval": BoundaryInterval, "block": TextBlock]
+    # groups is of the form: [{"depth_interval": BoundaryInterval, "block": TextBlock}]
     if len(filtered_pairs):  # match depth column items with material description
         for depth_column, material_description_rect in filtered_pairs:
             description_lines = get_description_lines(lines, material_description_rect)

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -35,13 +35,13 @@ def get_description_lines(lines: list[TextLine], material_description_rect: fitz
     return sorted([line for line in filtered_lines if line], key=lambda line: line.rect.y0)
 
 
-def get_description_blocks_from_layer_index(
-    layer_index_entries: list[TextLine], description_lines: list[TextLine]
+def get_description_blocks_from_layer_identifier(
+    layer_identifier_entries: list[TextLine], description_lines: list[TextLine]
 ) -> list[TextBlock]:
-    """Divide the description lines into blocks based on the layer index entries.
+    """Divide the description lines into blocks based on the layer identifier entries.
 
     Args:
-        layer_index_entries (list[TextLine]): The layer index entries.
+        layer_identifier_entries (list[TextLine]): The layer identifier entries.
         description_lines (list[TextLine]): All lines constituting the material description.
 
     Returns:
@@ -49,32 +49,36 @@ def get_description_blocks_from_layer_index(
     """
     blocks = []
     line_index = 0
-    for layer_index_idx, _layer_index in enumerate(layer_index_entries):
-        next_layer_index = (
-            layer_index_entries[layer_index_idx + 1] if layer_index_idx + 1 < len(layer_index_entries) else None
+    for layer_identifier_idx, _layer_index in enumerate(layer_identifier_entries):
+        next_layer_identifier = (
+            layer_identifier_entries[layer_identifier_idx + 1]
+            if layer_identifier_idx + 1 < len(layer_identifier_entries)
+            else None
         )
 
-        matched_block = matching_blocks(description_lines, line_index, next_layer_index)
+        matched_block = matching_blocks(description_lines, line_index, next_layer_identifier)
         line_index += sum([len(block.lines) for block in matched_block])
         blocks.extend(matched_block)
 
     return blocks
 
 
-def matching_blocks(all_lines: list[TextLine], line_index: int, next_layer_index: TextLine | None) -> list[TextBlock]:
-    """Adds lines to a block until the next layer index is reached.
+def matching_blocks(
+    all_lines: list[TextLine], line_index: int, next_layer_identifier: TextLine | None
+) -> list[TextBlock]:
+    """Adds lines to a block until the next layer identifier is reached.
 
     Args:
         all_lines (list[TextLine]): All TextLine objects constituting the material description.
         line_index (int): The index of the last line that is already assigned to a block.
-        next_layer_index (TextLine | None): The next layer index.
+        next_layer_identifier (TextLine | None): The next layer identifier.
 
     Returns:
         list[TextBlock]: The next block or an empty list if no lines are added.
     """
     y1_threshold = None
-    if next_layer_index:
-        next_interval_start_rect = next_layer_index.rect
+    if next_layer_identifier:
+        next_interval_start_rect = next_layer_identifier.rect
         y1_threshold = next_interval_start_rect.y0 + next_interval_start_rect.height / 2
 
     matched_lines = []

--- a/src/stratigraphy/util/find_description.py
+++ b/src/stratigraphy/util/find_description.py
@@ -50,8 +50,6 @@ def get_description_blocks_from_layer_index(
     blocks = []
     line_index = 0
     for layer_index_idx, _layer_index in enumerate(layer_index_entries):
-        # don't allow a layer above depth 0
-
         next_layer_index = (
             layer_index_entries[layer_index_idx + 1] if layer_index_idx + 1 < len(layer_index_entries) else None
         )

--- a/src/stratigraphy/util/layer_identifier_column.py
+++ b/src/stratigraphy/util/layer_identifier_column.py
@@ -4,17 +4,17 @@ import re
 
 import fitz
 
-from stratigraphy.util.line import TextLine
+from stratigraphy.util.line import TextWord
 
 
 class LayerIdentifierColumn:
     """Class for a layer identifier column."""
 
-    def __init__(self, entries: list[TextLine]):
+    def __init__(self, entries: list[TextWord]):
         """Initialize the LayerIdentifierColumn object.
 
         Args:
-            entries (list[TextLine]): The entries corresponding to the layer indices.
+            entries (list[TextWord]): The entries corresponding to the layer indices.
         """
         self.entries = entries
 
@@ -41,11 +41,11 @@ class LayerIdentifierColumn:
     def rects(self) -> list[fitz.Rect]:
         return [entry.rect for entry in self.entries]
 
-    def add_entry(self, entry: TextLine):
+    def add_entry(self, entry: TextWord):
         """Add a new layer identifier column entry to the layer identifier column.
 
         Args:
-            entry (TextLine): The layer identifier column entry to be added.
+            entry (TextWord): The layer identifier column entry to be added.
         """
         self.entries.append(entry)
 
@@ -93,7 +93,7 @@ class LayerIdentifierColumn:
         )
 
 
-def find_layer_identifier_column_entries(all_words: list[TextLine]) -> list:
+def find_layer_identifier_column_entries(all_words: list[TextWord]) -> list:
     r"""Find the layer identifier column entries.
 
     Regex explanation:
@@ -104,13 +104,16 @@ def find_layer_identifier_column_entries(all_words: list[TextLine]) -> list:
     This regular expression will match strings like "1)", "2)", "a)", "b)", "1a4)", "6de)", etc.
 
     Args:
-        all_words (ist[TextLine]): The words to search for layer identifier columns.
+        all_words (list[TextWord]): The words to search for layer identifier columns.
 
     Returns:
         list: The layer identifier column entries.
     """
     entries = []
     for word in sorted(all_words, key=lambda word: word.rect.y0):
+        # TODO There are quite a few false positives such as "(ca. 10 cm)" where "cm)" would be matched currently.
+        # Could we avoid some of those examples by requiring that the word is at the start of a line and/or there are
+        # no other words immediately to the left of it?
         regex = re.compile(r"\b[\da-z-]+\)")
         match = regex.match(word.text)
         if match and len(word.text) < 7:
@@ -118,13 +121,13 @@ def find_layer_identifier_column_entries(all_words: list[TextLine]) -> list:
     return entries
 
 
-def find_layer_identifier_column(entries: list[TextLine]) -> list[LayerIdentifierColumn]:
+def find_layer_identifier_column(entries: list[TextWord]) -> list[LayerIdentifierColumn]:
     """Find the layer identifier column given the index column entries.
 
     Note: Similar to find_depth_columns.find_depth_columns. Refactoring may be desired.
 
     Args:
-        entries (list[TextLine]): The layer identifier column entries.
+        entries (list[TextWord]): The layer identifier column entries.
 
     Returns:
         list[LayerIdentifierColumn]: The found layer identifier columns.

--- a/src/stratigraphy/util/layer_identifier_column.py
+++ b/src/stratigraphy/util/layer_identifier_column.py
@@ -1,4 +1,4 @@
-"""Module for the LayerIndexColumn class."""
+"""Module for the LayerIdentifierColumn class."""
 
 import re
 
@@ -7,11 +7,11 @@ import fitz
 from stratigraphy.util.line import TextLine
 
 
-class LayerIndexColumn:
-    """Class for a layer index column."""
+class LayerIdentifierColumn:
+    """Class for a layer identifier column."""
 
     def __init__(self, entries: list[TextLine]):
-        """Initialize the LayerIndexColumn object.
+        """Initialize the LayerIdentifierColumn object.
 
         Args:
             entries (list[TextLine]): The entries corresponding to the layer indices.
@@ -27,10 +27,10 @@ class LayerIndexColumn:
         return min([rect.x1 for rect in self.rects()])
 
     def rect(self) -> fitz.Rect:
-        """Get the rectangle of the layer index column.
+        """Get the rectangle of the layer identifier column.
 
         Returns:
-            fitz.Rect: The rectangle of the layer index column.
+            fitz.Rect: The rectangle of the layer identifier column.
         """
         x0 = min([rect.x0 for rect in self.rects()])
         x1 = max([rect.x1 for rect in self.rects()])
@@ -42,27 +42,27 @@ class LayerIndexColumn:
         return [entry.rect for entry in self.entries]
 
     def add_entry(self, entry: TextLine):
-        """Add a new layer index column entry to the layer index column.
+        """Add a new layer identifier column entry to the layer identifier column.
 
         Args:
-            entry (TextLine): The layer index column entry to be added.
+            entry (TextLine): The layer identifier column entry to be added.
         """
         self.entries.append(entry)
 
     def can_be_appended(self, rect: fitz.Rect) -> bool:
-        """Checks if a new layer index column entry can be appended to the current layer index column.
+        """Checks if a new layer identifier column entry can be appended to the current layer identifier column.
 
         The checks are:
-        - The width of the new rectangle is greater than the width of the current layer index column. Or;
-        - The middle of the new rectangle is within the horizontal boundaries of the current layer index column.
-        - The new rectangle intersects with the minimal horizontal boundaries of the current layer index column.
+        - The width of the new rectangle is greater than the width of the current layer identifier column. Or;
+        - The middle of the new rectangle is within the horizontal boundaries of the current layer identifier column.
+        - The new rectangle intersects with the minimal horizontal boundaries of the current layer identifier column.
 
 
         Args:
-            rect (fitz.Rect): Rect of the layer index column entry to be appended.
+            rect (fitz.Rect): Rect of the layer identifier column entry to be appended.
 
         Returns:
-            bool: True if the new layer index column entry can be appended, False otherwise.
+            bool: True if the new layer identifier column entry can be appended, False otherwise.
         """
         new_middle = (rect.x0 + rect.x1) / 2
         if (self.rect().width < rect.width or self.rect().x0 < new_middle < self.rect().x1) and (
@@ -77,13 +77,13 @@ class LayerIndexColumn:
         )
 
     def is_contained(self, rect: fitz.Rect) -> bool:
-        """Check if the layer index column is contained in another rectangle.
+        """Check if the layer identifier column is contained in another rectangle.
 
         Args:
-            rect (fitz.Rect): The rectangle to check if it contains the layer index column.
+            rect (fitz.Rect): The rectangle to check if it contains the layer identifier column.
 
         Returns:
-            bool: True if the layer index column is contained in the rectangle, False otherwise.
+            bool: True if the layer identifier column is contained in the rectangle, False otherwise.
         """
         return (
             rect.x0 <= self.rect().x0
@@ -93,8 +93,8 @@ class LayerIndexColumn:
         )
 
 
-def find_layer_index_column_entries(all_words: list[TextLine]) -> list:
-    r"""Find the layer index column entries.
+def find_layer_identifier_column_entries(all_words: list[TextLine]) -> list:
+    r"""Find the layer identifier column entries.
 
     Regex explanation:
     - \b is a word boundary. This ensures that the match must start at the beginning of a word.
@@ -104,10 +104,10 @@ def find_layer_index_column_entries(all_words: list[TextLine]) -> list:
     This regular expression will match strings like "1)", "2)", "a)", "b)", "1a4)", "6de)", etc.
 
     Args:
-        all_words (ist[TextLine]): The words to search for layer index columns.
+        all_words (ist[TextLine]): The words to search for layer identifier columns.
 
     Returns:
-        list: The layer index column entries.
+        list: The layer identifier column entries.
     """
     entries = []
     for word in sorted(all_words, key=lambda word: word.rect.y0):
@@ -118,42 +118,42 @@ def find_layer_index_column_entries(all_words: list[TextLine]) -> list:
     return entries
 
 
-def find_layer_index_column(entries: list[TextLine]) -> list[LayerIndexColumn]:
-    """Find the layer index column given the index column entries.
+def find_layer_identifier_column(entries: list[TextLine]) -> list[LayerIdentifierColumn]:
+    """Find the layer identifier column given the index column entries.
 
     Note: Similar to find_depth_columns.find_depth_columns. Refactoring may be desired.
 
     Args:
-        entries (list[TextLine]): The layer index column entries.
+        entries (list[TextLine]): The layer identifier column entries.
 
     Returns:
-        list[LayerIndexColumn]: The found layer index columns.
+        list[LayerIdentifierColumn]: The found layer identifier columns.
     """
-    layer_index_columns = [LayerIndexColumn([entries[0]])]
+    layer_identifier_columns = [LayerIdentifierColumn([entries[0]])]
     for entry in entries[1:]:
         has_match = False
-        for column in layer_index_columns:
+        for column in layer_identifier_columns:
             if column.can_be_appended(entry.rect):
                 column.add_entry(entry)
                 has_match = True
         if not has_match:
-            layer_index_columns.append(LayerIndexColumn([entry]))
+            layer_identifier_columns.append(LayerIdentifierColumn([entry]))
 
         # only keep columns whose entries are not fully contained in a different column
-        layer_index_columns = [
+        layer_identifier_columns = [
             column
-            for column in layer_index_columns
-            if all(not other.strictly_contains(column) for other in layer_index_columns)
+            for column in layer_identifier_columns
+            if all(not other.strictly_contains(column) for other in layer_identifier_columns)
         ]
         # check if the column rect is a subset of another column rect. If so, merge the entries and sort them by y0.
-        for column in layer_index_columns:
-            for other in layer_index_columns:
+        for column in layer_identifier_columns:
+            for other in layer_identifier_columns:
                 if column != other and column.is_contained(other.rect()):
                     for entry in other.entries:
                         if entry not in column.entries:
                             column.entries.append(entry)
                     column.entries.sort(key=lambda entry: entry.rect.y0)
-                    layer_index_columns.remove(other)
+                    layer_identifier_columns.remove(other)
                     break
-    layer_index_columns = [column for column in layer_index_columns if len(column.entries) > 2]
-    return layer_index_columns
+    layer_identifier_columns = [column for column in layer_identifier_columns if len(column.entries) > 2]
+    return layer_identifier_columns

--- a/src/stratigraphy/util/layer_index_column.py
+++ b/src/stratigraphy/util/layer_index_column.py
@@ -1,0 +1,162 @@
+"""Module for the LayerIndexColumn class."""
+
+import re
+
+import fitz
+
+from stratigraphy.util.line import TextLine
+
+
+class LayerIndexColumn:
+    """Class for a layer index column."""
+
+    def __init__(self, entries: list[TextLine]):
+        """Initialize the LayerIndexColumn object.
+
+        Args:
+            entries (list[TextLine]): The entries corresponding to the layer indices.
+        """
+        self.entries = entries
+
+    @property
+    def max_x0(self) -> float:
+        return max([rect.x0 for rect in self.rects()])
+
+    @property
+    def min_x1(self) -> float:
+        return min([rect.x1 for rect in self.rects()])
+
+    def rect(self) -> fitz.Rect:
+        """Get the rectangle of the layer index column.
+
+        Returns:
+            fitz.Rect: The rectangle of the layer index column.
+        """
+        x0 = min([rect.x0 for rect in self.rects()])
+        x1 = max([rect.x1 for rect in self.rects()])
+        y0 = min([rect.y0 for rect in self.rects()])
+        y1 = max([rect.y1 for rect in self.rects()])
+        return fitz.Rect(x0, y0, x1, y1)
+
+    def rects(self) -> list[fitz.Rect]:
+        return [entry.rect for entry in self.entries]
+
+    def add_entry(self, entry: TextLine):
+        """Add a new layer index column entry to the layer index column.
+
+        Args:
+            entry (TextLine): The layer index column entry to be added.
+        """
+        self.entries.append(entry)
+
+    def can_be_appended(self, rect: fitz.Rect) -> bool:
+        """Checks if a new layer index column entry can be appended to the current layer index column.
+
+        The checks are:
+        - The width of the new rectangle is greater than the width of the current layer index column. Or;
+        - The middle of the new rectangle is within the horizontal boundaries of the current layer index column.
+        - The new rectangle intersects with the minimal horizontal boundaries of the current layer index column.
+
+
+        Args:
+            rect (fitz.Rect): Rect of the layer index column entry to be appended.
+
+        Returns:
+            bool: True if the new layer index column entry can be appended, False otherwise.
+        """
+        new_middle = (rect.x0 + rect.x1) / 2
+        if (self.rect().width < rect.width or self.rect().x0 < new_middle < self.rect().x1) and (
+            rect.x0 <= self.min_x1 and self.max_x0 <= rect.x1
+        ):
+            return True
+        return False
+
+    def strictly_contains(self, other):
+        return len(other.entries) < len(self.entries) and all(
+            other_entry in self.entries for other_entry in other.entries
+        )
+
+    def is_contained(self, rect: fitz.Rect) -> bool:
+        """Check if the layer index column is contained in another rectangle.
+
+        Args:
+            rect (fitz.Rect): The rectangle to check if it contains the layer index column.
+
+        Returns:
+            bool: True if the layer index column is contained in the rectangle, False otherwise.
+        """
+        return (
+            rect.x0 <= self.rect().x0
+            and self.rect().x1 <= rect.x1
+            and rect.y0 <= self.rect().y0
+            and self.rect().y1 <= rect.y1
+        )
+
+    def noise_count(self, words):
+        return 0
+
+
+def find_layer_index_column_entries(all_words: list[TextLine]) -> list:
+    r"""Find the layer index column entries.
+
+    Regex explanation:
+    - \b is a word boundary. This ensures that the match must start at the beginning of a word.
+    - [\da-z]+ matches one or more (+) alphanumeric characters (\d for digits and a-z for lowercase letters).
+    - \) matches a closing parenthesis. The backslash is necessary because parentheses are special characters
+      in regular expressions, so we need to escape it to match a literal parenthesis.
+    This regular expression will match strings like "1)", "2)", "a)", "b)", "1a4)", "6de)", etc.
+
+    Args:
+        all_words (ist[TextLine]): The words to search for layer index columns.
+
+    Returns:
+        list: The layer index column entries.
+    """
+    entries = []
+    for line in sorted(all_words, key=lambda line: line.rect.y0):
+        regex = re.compile(r"\b[\da-z-]+\)")
+        match = regex.match(line.text)
+        if match and len(line.text) < 7:
+            entries.append(line)
+    return entries
+
+
+def find_layer_index_column(entries: list[TextLine]) -> list[LayerIndexColumn]:
+    """Find the layer index column given the index column entries.
+
+    Note: Similar to find_depth_columns.find_depth_columns. Refactoring may be desired.
+
+    Args:
+        entries (list[TextLine]): The layer index column entries.
+
+    Returns:
+        list[LayerIndexColumn]: The found layer index columns.
+    """
+    layer_index_columns = [LayerIndexColumn([entries[0]])]
+    for entry in entries[1:]:
+        has_match = False
+        for column in layer_index_columns:
+            if column.can_be_appended(entry.rect):
+                column.add_entry(entry)
+                has_match = True
+        if not has_match:
+            layer_index_columns.append(LayerIndexColumn([entry]))
+
+        # only keep columns whose entries are not fully contained in a different column
+        layer_index_columns = [
+            column
+            for column in layer_index_columns
+            if all(not other.strictly_contains(column) for other in layer_index_columns)
+        ]
+        # check if the column rect is a subset of another column rect. If so, merge the entries and sort them by y0.
+        for column in layer_index_columns:
+            for other in layer_index_columns:
+                if column != other and column.is_contained(other.rect()):
+                    for entry in other.entries:
+                        if entry not in column.entries:
+                            column.entries.append(entry)
+                    column.entries.sort(key=lambda entry: entry.rect.y0)
+                    layer_index_columns.remove(other)
+                    break
+    layer_index_columns = [column for column in layer_index_columns if len(column.entries) > 2]
+    return layer_index_columns

--- a/src/stratigraphy/util/layer_index_column.py
+++ b/src/stratigraphy/util/layer_index_column.py
@@ -92,9 +92,6 @@ class LayerIndexColumn:
             and self.rect().y1 <= rect.y1
         )
 
-    def noise_count(self, words):
-        return 0
-
 
 def find_layer_index_column_entries(all_words: list[TextLine]) -> list:
     r"""Find the layer index column entries.
@@ -113,11 +110,11 @@ def find_layer_index_column_entries(all_words: list[TextLine]) -> list:
         list: The layer index column entries.
     """
     entries = []
-    for line in sorted(all_words, key=lambda line: line.rect.y0):
+    for word in sorted(all_words, key=lambda word: word.rect.y0):
         regex = re.compile(r"\b[\da-z-]+\)")
-        match = regex.match(line.text)
-        if match and len(line.text) < 7:
-            entries.append(line)
+        match = regex.match(word.text)
+        if match and len(word.text) < 7:
+            entries.append(word)
     return entries
 
 

--- a/tests/test_find_depth_columns.py
+++ b/tests/test_find_depth_columns.py
@@ -9,10 +9,10 @@ from stratigraphy.util.line import TextLine, TextWord
 
 def test_depth_column_entries():  # noqa: D103
     all_words = [
-        TextLine([TextWord(fitz.Rect(0, 0, 5, 1), "10.00m")]),
-        TextLine([TextWord(fitz.Rect(0, 2, 5, 3), "20.0m")]),
-        TextLine([TextWord(fitz.Rect(0, 4, 5, 5), "30.0m")]),
-        TextLine([TextWord(fitz.Rect(0, 6, 5, 7), "40.0m")]),
+        TextWord(fitz.Rect(0, 0, 5, 1), "10.00m"),
+        TextWord(fitz.Rect(0, 2, 5, 3), "20.0m"),
+        TextWord(fitz.Rect(0, 4, 5, 5), "30.0m"),
+        TextWord(fitz.Rect(0, 6, 5, 7), "40.0m"),
     ]
     entries = depth_column_entries(all_words, include_splits=False)
     assert len(entries) == 4, "There should be 4 entries"
@@ -36,13 +36,13 @@ def test_depth_column_entries_with_splits():  # noqa: D103
 
 
 all_words_find_depth_column = [
-    TextLine([TextWord(fitz.Rect(0, 0, 5, 1), "10.00m")]),
-    TextLine([TextWord(fitz.Rect(20, 0, 30, 1), "Kies, Torf und Sand")]),
-    TextLine([TextWord(fitz.Rect(20, 2, 30, 3), "Kies, verwittert.")]),
-    TextLine([TextWord(fitz.Rect(0, 2, 5, 3), "20.0m")]),
-    TextLine([TextWord(fitz.Rect(0, 4, 5, 5), "30.0m")]),
-    TextLine([TextWord(fitz.Rect(0, 6, 5, 7), "40.0m")]),
-    TextLine([TextWord(fitz.Rect(0, 8, 5, 9), "50.0m")]),
+    TextWord(fitz.Rect(0, 0, 5, 1), "10.00m"),
+    TextWord(fitz.Rect(20, 0, 30, 1), "Kies, Torf und Sand"),
+    TextWord(fitz.Rect(20, 2, 30, 3), "Kies, verwittert."),
+    TextWord(fitz.Rect(0, 2, 5, 3), "20.0m"),
+    TextWord(fitz.Rect(0, 4, 5, 5), "30.0m"),
+    TextWord(fitz.Rect(0, 6, 5, 7), "40.0m"),
+    TextWord(fitz.Rect(0, 8, 5, 9), "50.0m"),
 ]
 
 
@@ -111,13 +111,13 @@ def test_two_columns_find_depth_columns():  # noqa: D103
 
 
 all_words_find_layer_depth_column = [
-    TextLine([TextWord(fitz.Rect(0, 0, 5, 1), "12.00-20.0m")]),
-    TextLine([TextWord(fitz.Rect(20, 0, 30, 1), "Kies, Torf und Sand")]),
-    TextLine([TextWord(fitz.Rect(20, 2, 30, 3), "Kies, verwittert.")]),
-    TextLine([TextWord(fitz.Rect(0, 2, 5, 3), "20.0-34.0m")]),
-    TextLine([TextWord(fitz.Rect(0, 4, 5, 5), "34.0 - 40.0m")]),
-    TextLine([TextWord(fitz.Rect(0, 6, 5, 7), "40.0-50m")]),
-    TextLine([TextWord(fitz.Rect(0, 8, 5, 9), "50.0-60m")]),
+    TextWord(fitz.Rect(0, 0, 5, 1), "12.00-20.0m"),
+    TextWord(fitz.Rect(20, 0, 30, 1), "Kies, Torf und Sand"),
+    TextWord(fitz.Rect(20, 2, 30, 3), "Kies, verwittert."),
+    TextWord(fitz.Rect(0, 2, 5, 3), "20.0-34.0m"),
+    TextWord(fitz.Rect(0, 4, 5, 5), "34.0 - 40.0m"),
+    TextWord(fitz.Rect(0, 6, 5, 7), "40.0-50m"),
+    TextWord(fitz.Rect(0, 8, 5, 9), "50.0-60m"),
 ]
 
 


### PR DESCRIPTION
Includes functionalities to recognize material description blocks for the Geneva borehole profile layout. The code detects so called layer index columns which indicate the presence of a material description rect as well as their position marks how to split the material description rect into material blocks. Note: Some visualization code is part of this commit which should be dropped in a follow up commit.