### PR TITLE
Use TextLine objects instead of the full plain text in coordinate extraction

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -112,5 +112,5 @@ coordinate_keys:
   - Koord.
   - coordinates
   - coordinate
-  - coordonnés
+  - coordonnées
   - coordonn

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -16,6 +16,7 @@ from stratigraphy.line_detection import extract_lines, line_detection_params
 from stratigraphy.util.coordinate_extraction import CoordinateExtractor
 from stratigraphy.util.draw import draw_predictions
 from stratigraphy.util.duplicate_detection import remove_duplicate_layers
+from stratigraphy.util.extract_text import extract_text_lines
 from stratigraphy.util.language_detection import detect_language_of_document
 from stratigraphy.util.plot_utils import plot_lines
 from stratigraphy.util.util import flatten, read_params
@@ -176,9 +177,10 @@ def start_pipeline(
                         page_number = page_index + 1
                         logger.info("Processing page %s", page_number)
 
+                        text_lines = extract_text_lines(page)
                         geometric_lines = extract_lines(page, line_detection_params)
                         layer_predictions, depths_materials_column_pairs = process_page(
-                            page, geometric_lines, language, **matching_params
+                            text_lines, geometric_lines, language, **matching_params
                         )
                         # Add remove duplicates here!
                         if page_index > 0:

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -208,6 +208,7 @@ def start_pipeline(
                                 )
                                 mlflow.log_image(img, f"pages/{filename}_page_{page.number + 1}_lines.png")
 
+    logger.info("Writing predictions to JSON file %s", predictions_path)
     with open(predictions_path, "w") as file:
         file.write(json.dumps(predictions))
 

--- a/src/stratigraphy/util/coordinate_extraction.py
+++ b/src/stratigraphy/util/coordinate_extraction.py
@@ -277,25 +277,25 @@ class CoordinateExtractor:
                 coord_substring = self.get_coordinate_substring(lines, page.rect.width)
                 coordinate_values = self.get_coordinate_pairs(coord_substring)
 
-                if len(coordinate_values) == 0:
-                    # if that doesn't work, try to directly detect coordinates in the text
-                    coordinate_values = self.get_coordinate_pairs(text)
+            if len(coordinate_values) == 0:
+                # if that doesn't work, try to directly detect coordinates in the text
+                coordinate_values = self.get_coordinate_pairs(text)
 
-                for east, north in coordinate_values:
-                    if east > 1e6 and north > 1e6:
-                        coordinate = LV95Coordinate(
-                            CoordinateEntry(east),
-                            CoordinateEntry(north),
-                        )
-                    else:
-                        coordinate = LV03Coordinate(
-                            CoordinateEntry(east),
-                            CoordinateEntry(north),
-                        )
-                    if coordinate.is_valid():
-                        return coordinate
+            for east, north in coordinate_values:
+                if east > 1e6 and north > 1e6:
+                    coordinate = LV95Coordinate(
+                        CoordinateEntry(east),
+                        CoordinateEntry(north),
+                    )
+                else:
+                    coordinate = LV03Coordinate(
+                        CoordinateEntry(east),
+                        CoordinateEntry(north),
+                    )
+                if coordinate.is_valid():
+                    return coordinate
 
-                if len(coordinate_values):
-                    logger.warning(f"Could not extract valid coordinates from {coordinate_values}")
+            if len(coordinate_values):
+                logger.warning(f"Could not extract valid coordinates from {coordinate_values}")
 
         logger.info("No coordinates found in this borehole profile.")

--- a/src/stratigraphy/util/coordinate_extraction.py
+++ b/src/stratigraphy/util/coordinate_extraction.py
@@ -157,11 +157,14 @@ class CoordinateExtractor:
         """
         matches = []
         for key in self.coordinate_keys:
-            pattern = regex.compile(r"\b(" + key + "){e<" + str(allowed_errors) + r"}\s", flags=regex.IGNORECASE)
+            print(key)
+            pattern = regex.compile(r"\b(" + key + "){e<" + str(allowed_errors) + r"}\b", flags=regex.IGNORECASE)
             for line in lines:
                 match = pattern.search(line.text)
                 if match:
                     matches.append((line, sum(match.fuzzy_counts)))
+
+        print(matches)
 
         # if no match was found, return None
         if len(matches) == 0:
@@ -189,7 +192,6 @@ class CoordinateExtractor:
         # look for coordinate values to the right and/or immediately below the key
         coordinate_search_rect = fitz.Rect(key_rect.x0, key_rect.y0, page_width, key_rect.y1 + 3 * key_rect.height)
         coordinate_search_lines = [line for line in lines if line.rect.intersects(coordinate_search_rect)]
-
         substring = " ".join([line.text for line in coordinate_search_lines])
         substring = substring.replace(",", ".")
         substring = substring.replace("'", ".")

--- a/src/stratigraphy/util/coordinate_extraction.py
+++ b/src/stratigraphy/util/coordinate_extraction.py
@@ -295,6 +295,7 @@ class CoordinateExtractor:
                     if coordinate.is_valid():
                         return coordinate
 
+                if len(coordinate_values):
                     logger.warning(f"Could not extract valid coordinates from {coordinate_values}")
 
         logger.info("No coordinates found in this borehole profile.")

--- a/src/stratigraphy/util/coordinate_extraction.py
+++ b/src/stratigraphy/util/coordinate_extraction.py
@@ -157,14 +157,11 @@ class CoordinateExtractor:
         """
         matches = []
         for key in self.coordinate_keys:
-            print(key)
             pattern = regex.compile(r"\b(" + key + "){e<" + str(allowed_errors) + r"}\b", flags=regex.IGNORECASE)
             for line in lines:
                 match = pattern.search(line.text)
                 if match:
                     matches.append((line, sum(match.fuzzy_counts)))
-
-        print(matches)
 
         # if no match was found, return None
         if len(matches) == 0:

--- a/src/stratigraphy/util/coordinate_extraction.py
+++ b/src/stratigraphy/util/coordinate_extraction.py
@@ -240,7 +240,10 @@ class CoordinateExtractor:
         ]
 
     def extract_coordinates(self) -> Coordinate | None:
-        """Extracts the coordinates from a string of text.
+        """Extracts the coordinates from a borehole profile.
+
+        Processes the borehole profile page by page and tries to find the coordinates in the respective text of the
+        page.
 
         Algorithm description:
             - Try to find the coordinate key in the text.

--- a/src/stratigraphy/util/draw.py
+++ b/src/stratigraphy/util/draw.py
@@ -43,6 +43,7 @@ def draw_predictions(predictions: list[FilePredictions], directory: Path, out_di
     if directory.is_file():  # deal with the case when we pass a file instead of a directory
         directory = directory.parent
     for file_name, file_prediction in predictions.items():
+        logger.info("Drawing predictions for file %s", file_name)
         with fitz.Document(directory / file_name) as doc:
             for page_index, page in enumerate(doc):
                 page_number = page_index + 1

--- a/src/stratigraphy/util/extract_text.py
+++ b/src/stratigraphy/util/extract_text.py
@@ -1,0 +1,45 @@
+"""Methods for extracting plain text from a PDF document."""
+
+import fitz
+
+from stratigraphy.util.line import TextLine, TextWord
+
+
+def extract_text_lines(page: fitz.Page) -> list[TextLine]:
+    """Extract all text lines from the page.
+
+    Sometimes, a single lines as identified by PyMuPDF, is still split into separate lines.
+
+    Args:
+        page (fitz.page): the page to extract text from
+
+    Returns:
+        list[TextLine]: A list of text lines.
+    """
+    words = []
+    words_by_line = {}
+    for x0, y0, x1, y1, word, block_no, line_no, _word_no in fitz.utils.get_text(page, "words"):
+        rect = fitz.Rect(x0, y0, x1, y1) * page.rotation_matrix
+        text_word = TextWord(rect, word)
+        words.append(text_word)
+        key = f"{block_no}_{line_no}"
+        if key not in words_by_line:
+            words_by_line[key] = []
+        words_by_line[key].append(text_word)
+
+    raw_lines = [TextLine(words_by_line[key]) for key in words_by_line]
+
+    lines = []
+    current_line_words = []
+    for line_index, raw_line in enumerate(raw_lines):
+        for word_index, word in enumerate(raw_line.words):
+            remaining_line = TextLine(raw_line.words[word_index:])
+            if len(current_line_words) > 0 and remaining_line.is_line_start(lines, raw_lines[line_index + 1 :]):
+                lines.append(TextLine(current_line_words))
+                current_line_words = []
+            current_line_words.append(word)
+        if len(current_line_words):
+            lines.append(TextLine(current_line_words))
+            current_line_words = []
+
+    return lines

--- a/tests/test_coordinate_extraction.py
+++ b/tests/test_coordinate_extraction.py
@@ -79,6 +79,10 @@ def test_CoordinateExtractor_find_coordinate_key():  # noqa: D103
     key_line = extractor.find_coordinate_key(lines)
     assert key_line.text == "Ko0rdinate 615.790 / 157.500"
 
+    lines = _create_simple_lines(["An all-uppercase key should be matched", "COORDONNEES"])
+    key_line = extractor.find_coordinate_key(lines)
+    assert key_line.text == "COORDONNEES"
+
     lines = _create_simple_lines(["This is a sample text", "without any relevant key"])
     key_line = extractor.find_coordinate_key(lines)
     assert key_line is None


### PR DESCRIPTION
- Separate the creation of TextLine object for a given PDF page into a separate method, that is used by both layer extraction and coordinate extraction.
- Instead of finding the coordinate key in the plain document text, find it in the TextLine objects, so that we also have the information of where it is located on the PDF page
- Instead of looking for coordinates within 100 characters of the coordinate key (in the defaut "reading order"), look for coordinates to the right and/or immediately below the coordinate key. This should be a little more robust / less dependent on they way (in which order) text is defined in the document.
- Instead of concatenating the text of all pages at the beginning of the coordinate extraction, we iterate over the pages and return on the first page where a valid coordinate was found. (This also will allow us to know on which page the coordinate was found, which is necessary for a future visualisation.)
- Improve logging a little bit.

The extraction of the coordinates values themselves still happens from plain text, not from the TextLine objects. We could improve on this in a future implementation, to use the TextLine objects everywhere. The main advantage of this would be, that we would also know where on the PDF page the coordinates were found, and we could use this information for the visualisation.

There are no changes in the KPIs for both the Zurich dataset and the Geoquat validation dataset.