### PR TITLE
include input directory in MLFlow experiment name

### DIFF
--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -133,7 +133,8 @@ def start_pipeline(
     if mlflow_tracking:
         import mlflow
 
-        mlflow.set_experiment("Boreholes Stratigraphy")
+        mlflow.set_experiment(f"Boreholes Stratigraphy {input_directory}")
+
         mlflow.start_run()
         mlflow.set_tag("input_directory", str(input_directory))
         mlflow.set_tag("ground_truth_path", str(ground_truth_path))


### PR DESCRIPTION
I would propose to include the input directory in the MLFlow experiment name.

Currently, all runs end up in the same experiment, regardless of whether they use the Zurich or the GeoQuat dataset, or are executed on just a single selected file. This makes it more difficult to make comparisons between different runs.

For example, you might want to set a baseline on the GeoQuat dataset, then do a number of debugging runs on a single problematic file, and (once the problem seems to be fixed) do a benchmark on the full GeoQuat dataset again. Currently, the results from the two benchmarks on the full dataset are far away from each other in the run list. They can be filtered using a query such as `tags.input_directory = '/data/geoquat/validation/'`, but this needs to be entered manually, which is not very user friendly.

I also tried to make use of the "Datasets" from MLFlow (https://mlflow.org/docs/latest/tracking/data-api.html) but there seems to be no easy way to use this, without actually loading the full dataset from one of the supported formats (e.g. Pandas) into MLFlow. Cf. also https://github.com/mlflow/mlflow/issues/10511.

Creating separate experiments for separate inputs seems to be in line with the general recommendations from https://mlflow.org/docs/latest/getting-started/logging-first-model/step3-create-experiment.html .

@redur what do you think?

![image](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/assets/144008419/03b65f6b-be5b-42ed-b54b-a1c7decd79a3)
