### PR TITLE
Feat/improve depth entry recognition

### DIFF
--- a/src/stratigraphy/benchmark/score.py
+++ b/src/stratigraphy/benchmark/score.py
@@ -147,7 +147,7 @@ def evaluate_borehole_extraction(predictions: dict, number_of_truth_values: dict
     coordinate_metrics, coordinate_document_level_metrics = evaluate_metadata(predictions)
     metrics = {**layer_metrics, **coordinate_metrics}
     document_level_metrics = pd.merge(
-        layer_document_level_metrics, coordinate_document_level_metrics, on="document_name"
+        layer_document_level_metrics, coordinate_document_level_metrics, on="document_name", how="outer"
     )
     return metrics, document_level_metrics
 

--- a/src/stratigraphy/util/boundarydepthcolumnvalidator.py
+++ b/src/stratigraphy/util/boundarydepthcolumnvalidator.py
@@ -1,0 +1,135 @@
+"""This module contains logic to validate BoundaryDepthColumn instances."""
+
+import dataclasses
+
+import numpy as np
+
+from stratigraphy.util.depthcolumn import BoundaryDepthColumn
+from stratigraphy.util.depthcolumnentry import DepthColumnEntry
+from stratigraphy.util.line import TextWord
+
+
+@dataclasses.dataclass
+class BoundaryDepthColumnValidator:
+    """Validation logic for instances of the BoundaryDepthColumn class.
+
+    Args:
+        all_words (list[TextLine]): A list of all text lines on the page.
+        noise_count_threshold (float): Noise count threshold deciding how much noise is allowed in a column
+                                       to be valid.
+        noise_count_offset (int): Offset for the noise count threshold. Affects the noise count criterion.
+                                  Effective specifically for depth columns with very few entries.
+    """
+
+    all_words: list[TextWord]
+    noise_count_threshold: float
+    noise_count_offset: int
+
+    def is_valid(self, column: BoundaryDepthColumn) -> bool:
+        """Checks whether the depth column is valid.
+
+        The depth column is considered valid if:
+        - The number of entries is at least 3.
+        - The number of words that intersect with the depth column entries is less than the noise count threshold
+          time the number of entries minus the noise count offset.
+        - The entries are strictly increasing.
+        - The entries are linearly correlated with their vertical position.
+
+        Note: The noise count criteria may require a rehaul. Some depth columns are not recognized as valid
+        even though they are.
+
+        Args:
+            column (BoundaryDepthColumn): The depth column to validate.
+
+        Returns:
+            bool: True if the depth column is valid, False otherwise.
+        """
+        if len(column.entries) < 3:
+            return False
+
+        # When too much other text is in the column, then it is probably not valid.
+        # The quadratic behavior of the noise count check makes the check stricter for columns with few entries
+        # than columns with more entries. The more entries we have, the less likely it is that we found them by chance.
+        # TODO: Once evaluation data is of good enough qualities, we should optimize for the parameter below.
+        if (
+            column.noise_count(self.all_words)
+            > self.noise_count_threshold * (len(column.entries) - self.noise_count_offset) ** 2
+        ):
+            return False
+        # Check if the entries are strictly increasing.
+        if not all(i.value < j.value for i, j in zip(column.entries, column.entries[1:], strict=False)):
+            return False
+
+        corr_coef = column.pearson_correlation_coef()
+
+        return (
+            corr_coef and corr_coef > np.min([1.0382 - len(column.entries) * 0.01, 0.9985]) and corr_coef > 0.95
+        )  # Magic numbers obtained using an error analysis on critical borehole profiles. Admittedly, this may
+        # be overfitted to the borehole profiles present.
+
+    def reduce_until_valid(self, column: BoundaryDepthColumn) -> BoundaryDepthColumn:
+        """Removes entries from the depth column until it fullfills the is_valid condition.
+
+        is_valid checks whether there is too much noise (i.e. other text) in the column and whether the entries are
+        linearly correlated with their vertical position.
+
+        Args:
+            column (BoundaryDepthColumn): The depth column to validate
+
+        Returns:
+            BoundaryDepthColumn: The current depth column with entries removed until it is valid.
+        """
+        while column:
+            if self.is_valid(column):
+                return column
+            elif self.correct_OCR_mistakes(column) is not None:
+                return self.correct_OCR_mistakes(column)
+            else:
+                column = column.remove_entry_by_correlation_gradient()
+
+    def correct_OCR_mistakes(self, column: BoundaryDepthColumn) -> BoundaryDepthColumn | None:
+        """Corrects OCR mistakes in the depth column entries.
+
+        Loops through all values and corrects common OCR mistakes for the given entry. Then, the column with the
+        highest pearson correlation coefficient is selected and checked for validity.
+
+        This is useful if one entry has an OCR mistake, and the column is not valid because of it.
+
+        Note: Common mistakes should be extended as needed.
+
+        Args:
+            column (BoundaryDepthColumn): The depth column to validate
+
+        Returns:
+            BoundaryDepthColumn | None: The corrected depth column, or None if no correction was possible.
+        """
+        new_columns = []
+        for remove_index in range(len(column.entries)):
+            new_columns.append(
+                BoundaryDepthColumn(
+                    [
+                        entry if index != remove_index else _correct_entry(entry)
+                        for index, entry in enumerate(column.entries)
+                    ],
+                ),
+            )
+        best_column = max(new_columns, key=lambda column: column.pearson_correlation_coef())
+
+        if self.is_valid(best_column):
+            return best_column
+        else:
+            return None
+
+
+def _correct_entry(entry: DepthColumnEntry) -> DepthColumnEntry:
+    """Corrects frequent OCR errors in depth column entries.
+
+    Args:
+        entry (DepthColumnEntry): The depth column entry to correct.
+
+    Returns:
+        DepthColumnEntry: The corrected depth column entry.
+    """
+    text_value = str(entry.value)
+    text_value = text_value.replace("4", "1")  # In older documents, OCR sometimes mistakes 1 for 4
+    return DepthColumnEntry(entry.rect, float(text_value))

--- a/src/stratigraphy/util/depthcolumn.py
+++ b/src/stratigraphy/util/depthcolumn.py
@@ -297,7 +297,9 @@ class BoundaryDepthColumn(DepthColumn):
         return len([line for line in all_words if significant_intersection(line.rect)]) - len(self.entries)
 
     def pearson_correlation_coef(self) -> float:
-        positions = np.array([entry.rect.y0 for entry in self.entries])
+        # We look at the lower y coordinate, because most often the baseline of the depth value text is aligned with
+        # the line of the corresponding layer boundary.
+        positions = np.array([entry.rect.y1 for entry in self.entries])
         entries = np.array([entry.value for entry in self.entries])
 
         # Avoid warnings in the np.corrcoef call, as the correlation coef is undefined if the standard deviation is 0.

--- a/src/stratigraphy/util/find_depth_columns.py
+++ b/src/stratigraphy/util/find_depth_columns.py
@@ -4,6 +4,7 @@ import re
 
 import fitz
 
+from stratigraphy.util.boundarydepthcolumnvalidator import BoundaryDepthColumnValidator
 from stratigraphy.util.depthcolumn import BoundaryDepthColumn, LayerDepthColumn
 from stratigraphy.util.depthcolumnentry import DepthColumnEntry, LayerDepthColumnEntry
 from stratigraphy.util.line import TextWord
@@ -177,7 +178,7 @@ def find_depth_columns(
 
         numeric_columns.extend(additional_columns)
         if not has_match:
-            numeric_columns.append(BoundaryDepthColumn(**depth_column_params, entries=[entry]))
+            numeric_columns.append(BoundaryDepthColumn(entries=[entry]))
 
         # only keep columns that are not contained in a different column
         numeric_columns = [
@@ -186,8 +187,10 @@ def find_depth_columns(
             if all(not other.strictly_contains(column) for other in numeric_columns)
         ]
 
+    boundary_depth_column_validator = BoundaryDepthColumnValidator(all_words, **depth_column_params)
+
     numeric_columns = [
-        column.reduce_until_valid(all_words)
+        boundary_depth_column_validator.reduce_until_valid(column)
         for numeric_column in numeric_columns
         for column in numeric_column.break_on_double_descending()
         # when we have a perfect arithmetic progression, this is usually just a scale
@@ -196,6 +199,6 @@ def find_depth_columns(
     ]
 
     return sorted(
-        [column for column in numeric_columns if column and column.is_valid(all_words)],
+        [column for column in numeric_columns if column and boundary_depth_column_validator.is_valid(column)],
         key=lambda column: len(column.entries),
     )

--- a/src/stratigraphy/util/find_depth_columns.py
+++ b/src/stratigraphy/util/find_depth_columns.py
@@ -185,6 +185,7 @@ def find_depth_columns(
             for column in numeric_columns
             if all(not other.strictly_contains(column) for other in numeric_columns)
         ]
+
     numeric_columns = [
         column.reduce_until_valid(all_words)
         for numeric_column in numeric_columns
@@ -193,6 +194,7 @@ def find_depth_columns(
         # that does not match the descriptions
         if not column.significant_arithmetic_progression()
     ]
+
     return sorted(
         [column for column in numeric_columns if column and column.is_valid(all_words)],
         key=lambda column: len(column.entries),

--- a/tests/test_depthcolumn.py
+++ b/tests/test_depthcolumn.py
@@ -1,0 +1,30 @@
+"""Test suite for the find_depth_columns module."""
+
+import fitz
+from stratigraphy.util.depthcolumn import BoundaryDepthColumn
+from stratigraphy.util.depthcolumnentry import DepthColumnEntry
+
+
+def test_boundarydepthcolumn_isarithmeticprogression():  # noqa: D103
+    column = BoundaryDepthColumn(
+        [
+            DepthColumnEntry(fitz.Rect(), value=1),
+            DepthColumnEntry(fitz.Rect(), value=2),
+            DepthColumnEntry(fitz.Rect(), value=3),
+            DepthColumnEntry(fitz.Rect(), value=4),
+            DepthColumnEntry(fitz.Rect(), value=5),
+        ]
+    )
+    assert column.is_arithmetic_progression(), "The column should be recognized as arithmetic progression"
+
+    column = BoundaryDepthColumn(
+        [
+            DepthColumnEntry(fitz.Rect(), value=17.6),
+            DepthColumnEntry(fitz.Rect(), value=18.15),
+            DepthColumnEntry(fitz.Rect(), value=18.65),
+            DepthColumnEntry(fitz.Rect(), value=19.3),
+            DepthColumnEntry(fitz.Rect(), value=19.9),
+            DepthColumnEntry(fitz.Rect(), value=20.5),
+        ]
+    )
+    assert not column.is_arithmetic_progression(), "The column should not be recognized as arithmetic progression"


### PR DESCRIPTION
Tune some parameters to improve depth entry recognition.
Introduce new checks:
- check if depths are strictly increasing.
- check if correcting a common OCR mistake makes a depth column valid.

Overall, more depth entries are now recognized. For the zurich dataset, even the layer detection is improved. For the geoquad dataset, the layer detection rate is approximately the same.