### PR TITLE
Close #LGVISIUM-70: Combine groundwater information with elevation to determine groundwater depth

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -166,7 +166,6 @@ elevation_keys:
   - Höhe
   - Kote
   - OK Terrain
-  - Tiefe ab OKT
   - OKT
   - Ansatzhöhe
   - Terrainkote

--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -135,6 +135,8 @@ groundwater_keys:
   - Wsp.
   - Wsp
   - GW-Spiegel
+  - Grundwasser
+  - Spiegel
 
   # French
   - nappe phréatique

--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -134,6 +134,7 @@ groundwater_keys:
   - GrW Sp
   - Wsp.
   - Wsp
+  - GW-Spiegel
 
   # French
   - nappe phréatique
@@ -163,6 +164,7 @@ elevation_keys:
   - Höhe
   - Kote
   - OK Terrain
+  - Tiefe ab OKT
   - OKT
   - Ansatzhöhe
   - Terrainkote

--- a/src/stratigraphy/elevation/elevation_extraction.py
+++ b/src/stratigraphy/elevation/elevation_extraction.py
@@ -70,7 +70,7 @@ class ElevationExtractor(DataExtractor):
 
     # look for elevation values to the right and/or immediately below the key
     search_right_factor: float = 5
-    search_below_factor: float = 1
+    search_below_factor: float = 4
 
     preprocess_replacements = {",": ".", "'": ".", "o": "0", "\n": " ", "ate": "ote"}
 

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -269,13 +269,18 @@ class GroundwaterLevelExtractor(DataExtractor):
         else:
             raise ValueError("Could not extract all required information from the lines provided.")
 
-    def extract_groundwater(self, elevation: ElevationInformation | None) -> list[GroundwaterInformationOnPage]:
+    def extract_groundwater(
+        self, terrain_elevation: ElevationInformation | None
+    ) -> list[GroundwaterInformationOnPage]:
         """Extracts the groundwater information from a borehole profile.
 
         Processes the borehole profile page by page and tries to find the coordinates in the respective text of the
         page.
         Algorithm description:
             1. if that gives no results, search for coordinates close to an explicit "groundwater" label (e.g. "Gswp")
+
+        Args:
+            terrain_elevation (ElevationInformation | None): The elevation of the borehole.
 
         Returns:
             list[GroundwaterInformationOnPage]: the extracted coordinates (if any)
@@ -289,13 +294,13 @@ class GroundwaterLevelExtractor(DataExtractor):
                 # or XXXX # Add other techniques here
             )
 
-            if elevation:
+            if terrain_elevation:
                 # If the elevation is provided, calculate the depth of the groundwater
                 for entry in found_groundwater:
                     if not entry.groundwater.depth and entry.groundwater.elevation:
-                        entry.groundwater.depth = round(elevation.elevation - entry.groundwater.elevation, 2)
+                        entry.groundwater.depth = round(terrain_elevation.elevation - entry.groundwater.elevation, 2)
                     if not entry.groundwater.elevation and entry.groundwater.depth:
-                        entry.groundwater.elevation = round(elevation.elevation - entry.groundwater.depth, 2)
+                        entry.groundwater.elevation = round(terrain_elevation.elevation - entry.groundwater.depth, 2)
 
             if found_groundwater:
                 groundwater_output = ", ".join([str(entry.groundwater) for entry in found_groundwater])

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -189,7 +189,7 @@ def start_pipeline(
 
                     # Extract the groundwater levels
                     groundwater_extractor = GroundwaterLevelExtractor(document=doc)
-                    groundwater = groundwater_extractor.extract_groundwater()
+                    groundwater = groundwater_extractor.extract_groundwater(elevation)
                     if groundwater:
                         predictions[filename]["groundwater"] = [
                             groundwater_entry.to_dict() for groundwater_entry in groundwater

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -260,6 +260,15 @@ class FilePredictions:
 
     @staticmethod
     def count_against_ground_truth(values: list, ground_truth: list) -> dict:
+        """Count the number of true positives, false positives and false negatives.
+
+        Args:
+            values (list): The values to count.
+            ground_truth (list): The ground truth values.
+
+        Returns:
+            dict: The number of true positives, false positives and false negatives.
+        """
         # Counter deals with duplicates when doing intersection
         values_counter = Counter(values)
         ground_truth_counter = Counter(ground_truth)


### PR DESCRIPTION
Combined the information from the elevation with the groundwater information. This makes it possible to infer the elevation or depth from a groundwater measurement based on the elevation information from the borehole profile. The groundwater metrics benefited quite a bit from these changes, and with this feature, we can fill in missing depth or elevation information which were required. 

During the work on this issue, I also saw that some of the information from the Groundtruth seems to be wrong. 

There are still a few false positives due to the fact that the depth of the groundwater sometimes seems to be determined against the elevation of the drilling and sometimes against the elevation of the borehole. It is not exactly clear to me what the difference is and how we can mitigate this. 