### PR TITLE
Close #LGVISIUM-84: Added possibility to pass the AWS Credentials in an .env file or as environment variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,6 @@
+MLFLOW_TRACKING="True"
+MLFLOW_TRACKING_URI="http://127.0.0.1:5000"
+
+AWS_ACCESS_KEY_ID=your_access_key_id
+AWS_SECRET_ACCESS_KEY=your_secret_access_key
+AWS_DEFAULT_REGION=your_region

--- a/.env.template
+++ b/.env.template
@@ -3,4 +3,4 @@ MLFLOW_TRACKING_URI="http://127.0.0.1:5000"
 
 AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
-AWS_DEFAULT_REGION=your_region
+AWS_ENDPOINT=your_endpoint_url

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
         "depthcolumn",
         "depthcolumnentry",
         "dotenv",
+        "fastapi",
         "fitz",
         "mlflow",
         "pixmap",

--- a/README.md
+++ b/README.md
@@ -89,27 +89,27 @@ To execute the data extraction pipeline, follow these steps:
 
 1. **Activate the virtual environment**
 
-    Activate your virtual environment. On unix systems this is
+Activate your virtual environment. On unix systems this is
 
-    ``` bash
-    source env/bin/activate
-    ```
+``` bash
+source env/bin/activate
+```
 
 2. **Download the borehole profiles, optional**
 
-    Use `boreholes-download-profiles` to download the files to be processed from an AWS S3 storage. In order to do so, you need to authenticate with aws first. We recommend to use the aws CLI for that purpose. This step is optional, you can continue with step 3 on your own set of borehole profiles.
+Use `boreholes-download-profiles` to download the files to be processed from an AWS S3 storage. In order to do so, you need to authenticate with aws first. We recommend to use the aws CLI for that purpose. This step is optional, you can continue with step 3 on your own set of borehole profiles.
 
 3. **Run the extraction script**
 
-    The main script for the extraction pipeline is located at `src/stratigraphy/main.py`. A cli command is created to run this script.
+The main script for the extraction pipeline is located at `src/stratigraphy/main.py`. A cli command is created to run this script.
 
-    Run `boreholes-extract-all` to run the main extraction script. With the default options, the command will source all PDFs from the `data/Benchmark` directory and create PNG files in the `data/Benchmark/extract` directory.
+Run `boreholes-extract-all` to run the main extraction script. With the default options, the command will source all PDFs from the `data/Benchmark` directory and create PNG files in the `data/Benchmark/extract` directory.
 
-    Use `boreholes-extract-all --help` to see all options for the extraction script.
+Use `boreholes-extract-all --help` to see all options for the extraction script.
 
 4. **Check the results**
 
-    Once the script has finished running, you can check the results in the `data/Benchmark/extract` directory. The result is a `predictions.json` file as well as a png file for each page of each PDF in the `data/Benchmark` directory.
+Once the script has finished running, you can check the results in the `data/Benchmark/extract` directory. The result is a `predictions.json` file as well as a png file for each page of each PDF in the `data/Benchmark` directory.
 
 ### Output Structure
 The `predictions.json` file contains the results of a data extraction process from PDF files. Each key in the JSON object is the name of a PDF file, and the value is a list of extracted items in a dictionary like object. The extracted items for now are the material descriptions in their correct order (given by their depths).
@@ -246,45 +246,45 @@ To launch the API and access its endpoints, follow these steps:
 
 1. **Activate the virtual environment**
 
-    Activate your virtual environment. On Unix systems, this can be done with the following command:
+Activate your virtual environment. On Unix systems, this can be done with the following command:
 
-    ```bash
-    source env/bin/activate
-    ```
+```bash
+source env/bin/activate
+```
 
 2. **Environment variables**
 
-    Please make sure to define the environment variables needed for the API to access the S3 Bucket of interest.
+Please make sure to define the environment variables needed for the API to access the S3 Bucket of interest.
 
-    ```python
-    aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
-    aws_secret_key_access = os.environ.get("AWS_SECRET_ACCESS_KEY")
-    aws_endpoint = os.environ.get("AWS_ENDPOINT")
-    ```
+```python
+aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
+aws_secret_key_access = os.environ.get("AWS_SECRET_ACCESS_KEY")
+aws_endpoint = os.environ.get("AWS_ENDPOINT")
+```
 
 3. **Start the FastAPI server**
 
-    Run the following command to start the FastAPI server:
+Run the following command to start the FastAPI server:
 
-    ```bash
-    uvicorn src.app.main:app --reload --host 0.0.0.0 --port 8002
-    ```
+```bash
+uvicorn src.app.main:app --reload --host 0.0.0.0 --port 8002
+```
 
-    This will start the server on port 8002 of the localhost and enable automatic reloading whenever changes are made to the code. You can see the OpenAPI Specification (formerly Swagger Specification) by opening: `http://127.0.0.1:8002/docs#/` in your favorite browser. 
+This will start the server on port 8002 of the localhost and enable automatic reloading whenever changes are made to the code. You can see the OpenAPI Specification (formerly Swagger Specification) by opening: `http://127.0.0.1:8002/docs#/` in your favorite browser. 
 
 4. **Access the API endpoints**
 
-    Once the server is running, you can access the API endpoints using a web browser or an API testing tool like Postman.
+Once the server is running, you can access the API endpoints using a web browser or an API testing tool like Postman.
 
-    The main endpoint for the data extraction pipeline is `http://localhost:8000/extract-data`. You can send a POST request to this endpoint with the PDF file you want to extract data from.
+The main endpoint for the data extraction pipeline is `http://localhost:8000/extract-data`. You can send a POST request to this endpoint with the PDF file you want to extract data from.
 
-    Additional endpoints and their functionalities can be found in the project's source code.
+Additional endpoints and their functionalities can be found in the project's source code.
 
-    **Note:** Make sure to replace `localhost` with the appropriate hostname or IP address if you are running the server on a remote machine.
+**Note:** Make sure to replace `localhost` with the appropriate hostname or IP address if you are running the server on a remote machine.
 
 5. **Stop the server**
 
-    To stop the FastAPI server, press `Ctrl + C` in the terminal where the server is running. Please refer to the [FastAPI documentation](https://fastapi.tiangolo.com) for more information on how to work with FastAPI and build APIs using this framework.
+To stop the FastAPI server, press `Ctrl + C` in the terminal where the server is running. Please refer to the [FastAPI documentation](https://fastapi.tiangolo.com) for more information on how to work with FastAPI and build APIs using this framework.
 
 
 ## API as Docker Image
@@ -293,47 +293,47 @@ The borehole application offers a given amount of functionalities (extract text,
 
 1. **Navigate to the project directory**
 
-    Change your current directory to the project directory:
+Change your current directory to the project directory:
 
-    ```bash
-    cd swissgeol-boreholes-dataextraction
-    ```
+```bash
+cd swissgeol-boreholes-dataextraction
+```
 
 2. **Build the Docker image**
 
-    Build the Docker image using the following command:
+Build the Docker image using the following command:
 
-    ```bash
-    docker build -t borehole-api . -f Dockerfile
-    ```
+```bash
+docker build -t borehole-api . -f Dockerfile
+```
 
-    ```bash
-    docker build --platform linux/amd64 -t borehole-api:test .
-    ```
+```bash
+docker build --platform linux/amd64 -t borehole-api:test .
+```
 
-    This command will build the Docker image with the tag `borehole-api`.
+This command will build the Docker image with the tag `borehole-api`.
 
 3. **Verify the Docker image**
 
-    Verify that the Docker image has been successfully built by running the following command:
+Verify that the Docker image has been successfully built by running the following command:
 
-    ```bash
-    docker images
-    ```
+```bash
+docker images
+```
 
-    You should see the `borehole-api` image listed in the output.
+You should see the `borehole-api` image listed in the output.
 
 4. **Run the Docker container**
 
 4.1. **Run the Docker Container without concerning about AWS Credentials**
 
-    To run the Docker container, use the following command:
+To run the Docker container, use the following command:
 
-    ```bash
-    docker run -p 8000:8000 borehole-api
-    ```
+```bash
+docker run -p 8000:8000 borehole-api
+```
 
-    This command will start the container and map port 8000 of the container to port 8000 of the host machine.
+This command will start the container and map port 8000 of the container to port 8000 of the host machine.
 
 4.2. **Run the docker image with the AWS credentials**
 
@@ -416,36 +416,36 @@ You can find an example for such a `.env` file in `.env.template`. If you rename
 
 5. **Access the API**
 
-    Once the container is running, you can access the API by opening a web browser and navigating to `http://localhost:8000`.
+Once the container is running, you can access the API by opening a web browser and navigating to `http://localhost:8000`.
 
-    You can also use an API testing tool like Postman to send requests to the API endpoints.
+You can also use an API testing tool like Postman to send requests to the API endpoints.
 
-    **Note:** If you are running Docker on a remote machine, replace `localhost` with the appropriate hostname or IP address.
+**Note:** If you are running Docker on a remote machine, replace `localhost` with the appropriate hostname or IP address.
 
 
 6. **Query the API**
 
 ```bash
-    curl -X 'POST' \
-    'http://localhost:8000/api/V1/create_pngs' \
-    -H 'accept: application/json' \
-    -H 'Content-Type: application/json' \
-    -d '{
-    "filename": "10021.pdf"
-    }'
+curl -X 'POST' \
+'http://localhost:8000/api/V1/create_pngs' \
+-H 'accept: application/json' \
+-H 'Content-Type: application/json' \
+-d '{
+"filename": "10021.pdf"
+}'
 ```
 
 7. **Stop the Docker container**
 
-    To stop the Docker container, press `Ctrl + C` in the terminal where the container is running.
+To stop the Docker container, press `Ctrl + C` in the terminal where the container is running.
 
-    Alternatively, you can use the following command to stop the container:
+Alternatively, you can use the following command to stop the container:
 
-    ```bash
-    docker stop <container_id>
-    ```
+```bash
+docker stop <container_id>
+```
 
-    Replace `<container_id>` with the ID of the running container, which can be obtained by running `docker ps`.
+Replace `<container_id>` with the ID of the running container, which can be obtained by running `docker ps`.
 
 
 ## AWS Lambda Deployment
@@ -462,10 +462,9 @@ We created a script that should make it possible for you to deploy the FastAPI i
 
 To deploy the staging version of the FastPI, run the following command: 
 
-```shell
+```bash
 IMAGE=borehole-fastapi ENV=stage AWS_PROFILE=dcleres-visium AWS_S3_BUCKET=dcleres-boreholes-integration-tmp ./deploy_api_aws_lambda.sh
 ```
-
 
 ## Experiment Tracking
 We perform experiment tracking using MLFlow. Each developer has his own local MLFlow instance. 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ To launch the API and access its endpoints, follow these steps:
     ```python
     aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
     aws_secret_key_access = os.environ.get("AWS_SECRET_ACCESS_KEY")
-    aws_session_token = os.environ.get("AWS_SESSION_TOKEN")
     aws_endpoint = os.environ.get("AWS_ENDPOINT")
     ```
 
@@ -372,8 +371,11 @@ Add the following lines to your `~/.bashrc`, `~/.bash_profile`, or `~/.zshrc` (d
 ```bash
 export AWS_ACCESS_KEY_ID=your_access_key_id
 export AWS_SECRET_ACCESS_KEY=your_secret_access_key
-export AWS_DEFAULT_REGION=your_region 
+export AWS_ENDPOINT=your_endpoint_url
 ```
+
+Please note that the endpoint url is in the following format: `https://{bucket}.s3.<RegionName>.amazonaws.com`. This URL can be found in AWS when you go to your target S3 bucket, select and item in the bucket and look into the Properties under `Object URL`. Please remove the file specific extension and you will end up with your object URL.  
+
 After editing, run the following command to apply the changes:
 
 ```bash
@@ -387,15 +389,15 @@ For Command Prompt:
 ```bash
 setx AWS_ACCESS_KEY_ID your_access_key_id
 setx AWS_SECRET_ACCESS_KEY your_secret_access_key
-setx AWS_DEFAULT_REGION your_region
+setx AWS_ENDPOINT your_endpoint_url
 ```
 
 For PowerShell:
 
 ```bash
-$env:AWS_ACCESS_KEY_ID="your_access_key_id"
-$env:AWS_SECRET_ACCESS_KEY="your_secret_access_key"
-$env:AWS_DEFAULT_REGION="your_region"
+$env:AWS_ACCESS_KEY_ID=your_access_key_id
+$env:AWS_SECRET_ACCESS_KEY=your_secret_access_key
+$env:AWS_ENDPOINT=your_endpoint_url
 ```
 
 4.2.3. **Passing the AWS credentials in an Environment File**
@@ -405,12 +407,12 @@ Another option is to store the credentials in a .env file and load them into you
 ```bash
 AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
-AWS_DEFAULT_REGION=your_region
+AWS_ENDPOINT=your_endpoint_url
 ```
 
 You can find an example for such a `.env` file in `.env.template`. If you rename this file to `.env` and add your AWS credentials you should be good to go. 
 
-5. **Access the API**
+1. **Access the API**
 
     Once the container is running, you can access the API by opening a web browser and navigating to `http://localhost:8000`.
 

--- a/README.md
+++ b/README.md
@@ -341,24 +341,24 @@ The borehole application offers a given amount of functionalities (extract text,
 
 If you have the AWS credentials configured locally in the `~/.aws` file, you can run the following command to forward your AWS credentials to the docker container 
 
-    To run the docker image from `Dockerfile` locally: 
+To run the docker image from `Dockerfile` locally: 
 
-    ```bash
+```bash
 
-    docker run -v ~/.aws:/root/.aws -d -p 8000:8000 borehole-api
-    ```
+docker run -v ~/.aws:/root/.aws -d -p 8000:8000 borehole-api
+```
 
-    To run the Docker image from `Dockerfile` with the environment variables from the `.env` file
+To run the Docker image from `Dockerfile` with the environment variables from the `.env` file
 
-    ```bash
-    docker run --env-file .env -d -p 8000:8000 borehole-api
-    ```
+```bash
+docker run --env-file .env -d -p 8000:8000 borehole-api
+```
 
-    To run the docker image used for AWS Lambda: `Dockerfile.aws.lambda`: 
+To run the docker image used for AWS Lambda: `Dockerfile.aws.lambda`: 
 
-    ```bash 
-    docker run --platform linux/amd64 -v ~/.aws:/root/.aws -d -p 8000:8000 borehole-api:test
-    ```
+```bash 
+docker run --platform linux/amd64 -v ~/.aws:/root/.aws -d -p 8000:8000 borehole-api:test
+```
 
 4.2.2. **Passing the AWS credentials as Environment Variables**
 
@@ -374,7 +374,9 @@ export AWS_SECRET_ACCESS_KEY=your_secret_access_key
 export AWS_ENDPOINT=your_endpoint_url
 ```
 
-Please note that the endpoint url is in the following format: `https://{bucket}.s3.<RegionName>.amazonaws.com`. This URL can be found in AWS when you go to your target S3 bucket, select and item in the bucket and look into the Properties under `Object URL`. Please remove the file specific extension and you will end up with your object URL.  
+Please note that the endpoint url is in the following format: `https://{bucket}.s3.<RegionName>.amazonaws.com`. This 
+URL can be found in AWS when you go to your target S3 bucket, select any item in the bucket and look into the 
+Properties under `Object URL`. Please remove the file specific extension and you will end up with your endpoint URL. 
 
 After editing, run the following command to apply the changes:
 
@@ -412,7 +414,7 @@ AWS_ENDPOINT=your_endpoint_url
 
 You can find an example for such a `.env` file in `.env.template`. If you rename this file to `.env` and add your AWS credentials you should be good to go. 
 
-1. **Access the API**
+5. **Access the API**
 
     Once the container is running, you can access the API by opening a web browser and navigating to `http://localhost:8000`.
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ The borehole application offers a given amount of functionalities (extract text,
 
 4. **Run the Docker container**
 
+4.1. **Run the Docker Container without concerning about AWS Credentials**
+
     To run the Docker container, use the following command:
 
     ```bash
@@ -334,21 +336,81 @@ The borehole application offers a given amount of functionalities (extract text,
 
     This command will start the container and map port 8000 of the container to port 8000 of the host machine.
 
-5. **Run the docker image with the AWS credentials**
+4.2. **Run the docker image with the AWS credentials**
+
+4.2.1. **Using a `~/.aws` file**
 
 If you have the AWS credentials configured locally in the `~/.aws` file, you can run the following command to forward your AWS credentials to the docker container 
+
+    To run the docker image from `Dockerfile` locally: 
 
     ```bash
 
     docker run -v ~/.aws:/root/.aws -d -p 8000:8000 borehole-api
     ```
 
+    To run the Docker image from `Dockerfile` with the environment variables from the `.env` file
+
+    ```bash
+    docker run --env-file .env -d -p 8000:8000 borehole-api
+    ```
+
+    To run the docker image used for AWS Lambda: `Dockerfile.aws.lambda`: 
+
     ```bash 
     docker run --platform linux/amd64 -v ~/.aws:/root/.aws -d -p 8000:8000 borehole-api:test
     ```
 
+4.2.2. **Passing the AWS credentials as Environment Variables**
 
-6. **Access the API**
+It is also possible to set the AWS credentials as you environment variables and the environment variables of the Docker image you are trying to run. 
+
+Unix-based Systems (Linux/macOS)
+
+Add the following lines to your `~/.bashrc`, `~/.bash_profile`, or `~/.zshrc` (depending on your shell):
+
+```bash
+export AWS_ACCESS_KEY_ID=your_access_key_id
+export AWS_SECRET_ACCESS_KEY=your_secret_access_key
+export AWS_DEFAULT_REGION=your_region 
+```
+After editing, run the following command to apply the changes:
+
+```bash
+source ~/.bashrc  # Or ~/.bash_profile, ~/.zshrc based on your configuration
+```
+
+Windows (Command Prompt or PowerShell)
+
+For Command Prompt:
+
+```bash
+setx AWS_ACCESS_KEY_ID your_access_key_id
+setx AWS_SECRET_ACCESS_KEY your_secret_access_key
+setx AWS_DEFAULT_REGION your_region
+```
+
+For PowerShell:
+
+```bash
+$env:AWS_ACCESS_KEY_ID="your_access_key_id"
+$env:AWS_SECRET_ACCESS_KEY="your_secret_access_key"
+$env:AWS_DEFAULT_REGION="your_region"
+```
+
+4.2.3. **Passing the AWS credentials in an Environment File**
+
+Another option is to store the credentials in a .env file and load them into your Python environment using the `python-dotenv` package:
+
+```bash
+AWS_ACCESS_KEY_ID=your_access_key_id
+AWS_SECRET_ACCESS_KEY=your_secret_access_key
+AWS_DEFAULT_REGION=your_region
+```
+
+You can find an example for such a `.env` file in `.env.template`. If you rename this file to `.env` and add your AWS credentials you should be good to go. 
+
+5. **Access the API**
 
     Once the container is running, you can access the API by opening a web browser and navigating to `http://localhost:8000`.
 
@@ -357,7 +419,7 @@ If you have the AWS credentials configured locally in the `~/.aws` file, you can
     **Note:** If you are running Docker on a remote machine, replace `localhost` with the appropriate hostname or IP address.
 
 
-7. **Query the API**
+6. **Query the API**
 
 ```bash
     curl -X 'POST' \
@@ -369,7 +431,7 @@ If you have the AWS credentials configured locally in the `~/.aws` file, you can
     }'
 ```
 
-8. **Stop the Docker container**
+7. **Stop the Docker container**
 
     To stop the Docker container, press `Ctrl + C` in the terminal where the container is running.
 
@@ -386,7 +448,7 @@ If you have the AWS credentials configured locally in the `~/.aws` file, you can
 
 AWS Lambda is a serverless computing service provided by Amazon Web Services that allows you to run code without managing servers. It automatically scales your applications by executing code in response to triggers. You only pay for the compute time used.
 
-In this project we are using Mangum to wrap the FastAPI with a handler that we will package and deploy as a Lambda function in AWS. Then using AWS API Gateway we will route all incoming requests to invoke the lambda and handle the routing internally within our application.
+In this project we are using `Mangum` to wrap the FastAPI with a handler that we will package and deploy as a Lambda function in AWS. Then using AWS API Gateway we will route all incoming requests to invoke the lambda and handle the routing internally within our application.
 
 We created a script that should make it possible for you to deploy the FastAPI in AWS lambda using a single command. The script is creating all the required AWS resources to run the API. The resources that will be created for you are: 
 - AWS Lambda Function

--- a/src/app/api/v1/endpoints/create_pngs.py
+++ b/src/app/api/v1/endpoints/create_pngs.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import fitz
 from app.common.aws import load_pdf_from_aws, upload_file_to_s3
-from app.common.config import config
 from app.common.schemas import PNGResponse
 from fastapi import HTTPException
 
@@ -49,8 +48,7 @@ def create_pngs(aws_filename: Path):
             )
 
             # Generate the S3 URL
-            png_url = f"https://{config.bucket_name}.s3.amazonaws.com/{s3_bucket_png_path}"
-            png_urls.append(png_url)
+            png_urls.append(s3_bucket_png_path)
 
             # Clean up the local file
             os.remove(png_path)

--- a/src/app/common/aws.py
+++ b/src/app/common/aws.py
@@ -34,7 +34,7 @@ def create_s3_client():
                 "s3",
                 aws_access_key_id=config.aws_access_key_id,
                 aws_secret_access_key=config.aws_secret_access_key,
-                region_name=config.aws_region,
+                endpoint_url=config.aws_endpoint,
             )
             # Test the fallback client
             s3_client.list_buckets()

--- a/src/app/common/aws.py
+++ b/src/app/common/aws.py
@@ -108,10 +108,12 @@ def load_data_from_aws(filename: Path, prefix: str = "") -> bytes:
     Returns:
         bytes: The loaded PNG image.
     """
+    s3_client = get_s3_client()
+
     # Check if the PNG exists in S3
     try:
-        png_object = get_s3_client().get_object(Bucket=config.bucket_name, Key=str(prefix / filename))
-    except get_s3_client().exceptions.NoSuchKey:
+        png_object = s3_client.get_object(Bucket=config.bucket_name, Key=str(prefix / filename))
+    except s3_client.exceptions.NoSuchKey:
         raise HTTPException(status_code=404, detail=f"Document {prefix / filename} not found in S3 bucket.") from None
 
     # Load the PNG from the S3 object

--- a/src/app/common/aws.py
+++ b/src/app/common/aws.py
@@ -94,7 +94,7 @@ def load_data_from_aws(filename: Path, prefix: str = "") -> bytes:
     """Load a document from AWS S3.
 
     Args:
-        filename (str): The filename of the PDF image.
+        filename (str): The filename of the document.
         prefix (str): The prefix of the file in the bucket.
 
     Returns:

--- a/src/app/common/aws.py
+++ b/src/app/common/aws.py
@@ -69,15 +69,7 @@ def load_pdf_from_aws(filename: Path) -> fitz.Document:
     """
     # Load the PDF from the S3 object
     data = load_data_from_aws(filename)
-
-    try:
-        pdf_document = fitz.open(stream=data, filetype="pdf")
-    except Exception:  # TODO: Specify the exception
-        raise HTTPException(
-            status_code=404, detail="Failed to load PDF document. The filename is not found in the bucket."
-        ) from None
-
-    return pdf_document
+    return fitz.open(stream=data, filetype="pdf")
 
 
 def load_png_from_aws(filename: Path) -> np.ndarray:
@@ -102,23 +94,23 @@ def load_data_from_aws(filename: Path, prefix: str = "") -> bytes:
     """Load a document from AWS S3.
 
     Args:
-        filename (str): The filename of the PNG image.
+        filename (str): The filename of the PDF image.
         prefix (str): The prefix of the file in the bucket.
 
     Returns:
-        bytes: The loaded PNG image.
+        bytes: The loaded document.
     """
     s3_client = get_s3_client()
 
-    # Check if the PNG exists in S3
+    # Check if the document exists in S3
     try:
-        png_object = s3_client.get_object(Bucket=config.bucket_name, Key=str(prefix / filename))
+        s3_object = s3_client.get_object(Bucket=config.bucket_name, Key=str(prefix / filename))
     except s3_client.exceptions.NoSuchKey:
         raise HTTPException(status_code=404, detail=f"Document {prefix / filename} not found in S3 bucket.") from None
 
-    # Load the PNG from the S3 object
+    # Load the document from the S3 object
     try:
-        data = png_object["Body"].read()
+        data = s3_object["Body"].read()
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to load data.") from None
 

--- a/src/app/common/config.py
+++ b/src/app/common/config.py
@@ -22,16 +22,17 @@ class Config(BaseSettings):
     logging_level: int = logging.DEBUG
 
     ###########################################################
-    # AWS
+    # AWS Settings
     ###########################################################
     bucket_name: str = get_aws_bucket_name()
     test_bucket_name: str = "test-bucket"
 
-    # TODO: check how this is used on the VM
-    # aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID")
-    # aws_secret_key_access = os.environ.get("AWS_SECRET_ACCESS_KEY")
-    # aws_session_token = os.environ.get("AWS_SESSION_TOKEN")
-    # aws_endpoint = os.environ.get("AWS_ENDPOINT")
+    ###########################################################
+    # AWS Credentials
+    ###########################################################
+    aws_access_key_id: str | None = os.environ.get("AWS_ACCESS_KEY_ID")
+    aws_secret_access_key: str | None = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    aws_region: str | None = os.environ.get("AWS_REGION")
 
 
 config = Config()

--- a/src/app/common/config.py
+++ b/src/app/common/config.py
@@ -32,7 +32,7 @@ class Config(BaseSettings):
     ###########################################################
     aws_access_key_id: str | None = os.environ.get("AWS_ACCESS_KEY_ID")
     aws_secret_access_key: str | None = os.environ.get("AWS_SECRET_ACCESS_KEY")
-    aws_region: str | None = os.environ.get("AWS_REGION")
+    aws_endpoint: str | None = os.environ.get("AWS_ENDPOINT")
 
 
 config = Config()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,6 @@ def s3_client(monkeypatch):
         monkeypatch.setattr(conn, "upload_file", mock_upload_file)
 
         # Patch the s3_client in the aws module to use the mock
-        monkeypatch.setattr("app.common.aws.s3_client", conn)
+        monkeypatch.setattr("app.common.aws.create_s3_client", conn)
 
         yield conn

--- a/tests/test_create_pngs.py
+++ b/tests/test_create_pngs.py
@@ -64,7 +64,7 @@ def test_create_pngs_invalid_filename(test_client: TestClient):
     }
 
 
-def test_create_pngs_nonexistent_pdf(test_client: TestClient):
+def test_create_pngs_nonexistent_pdf(test_client: TestClient, s3_client):
     """Test the create_pngs endpoint with a nonexistent PDF file."""
     response = test_client.post("/api/V1/create_pngs", json={"filename": "nonexistent.pdf"})
     assert response.status_code == 404

--- a/tests/test_create_pngs.py
+++ b/tests/test_create_pngs.py
@@ -49,11 +49,10 @@ def test_create_pngs_success(test_client: TestClient, s3_client, upload_test_pdf
 
     # Verify that PNG files are uploaded to S3
     for png_url in json_response["png_urls"]:
-        png_key = png_url.split("/", 3)[-1]
         try:
-            s3_client.head_object(Bucket=config.test_bucket_name, Key=png_key)
+            s3_client.head_object(Bucket=config.test_bucket_name, Key=png_url)
         except ClientError:
-            pytest.fail(f"PNG file {png_key} not found in S3.")
+            pytest.fail(f"PNG file {png_url} not found in S3.")
 
 
 def test_create_pngs_invalid_filename(test_client: TestClient):

--- a/tests/test_create_pngs.py
+++ b/tests/test_create_pngs.py
@@ -68,7 +68,7 @@ def test_create_pngs_nonexistent_pdf(test_client: TestClient):
     """Test the create_pngs endpoint with a nonexistent PDF file."""
     response = test_client.post("/api/V1/create_pngs", json={"filename": "nonexistent.pdf"})
     assert response.status_code == 404
-    assert response.json() == {"detail": "Failed to load PDF document. The filename is not found in the bucket."}
+    assert response.json() == {"detail": "Document nonexistent.pdf not found in S3 bucket."}
 
 
 def test_create_pngs_missing_pdf_extension(test_client: TestClient):

--- a/tests/test_create_pngs.py
+++ b/tests/test_create_pngs.py
@@ -4,6 +4,10 @@ To see the objects that are being created before the tests are run, you can look
 test_client fixture is created by the TestClient(app) call, which creates a test client for the FastAPI app.
 The s3_client fixture is created by the mock_aws decorator, which mocks the AWS S3 client using Moto.
 
+NOTE: Please note that the code in tests/conftest.py is called before the tests are run. This is where the AWS S3
+client is mocked using Moto. The s3_client fixture is then used in the test functions to interact with the mocked
+S3 client. Furthermore, the upload_test_pdf fixture is used to upload a test PDF file to the S3 bucket before
+running the tests.
 """
 
 from pathlib import Path

--- a/tests/test_data_extraction_from_bbox.py
+++ b/tests/test_data_extraction_from_bbox.py
@@ -59,6 +59,8 @@ def get_text_request_on_rotated_pdf():
 @pytest.fixture(scope="function")
 def upload_test_pdf(s3_client):
     """Upload a test PDF file to S3."""
+    s3_client.list_buckets()
+
     s3_client.upload_file(Filename=str(TEST_PDF_PATH), Bucket=config.test_bucket_name, Key=str(TEST_PDF_KEY))
     s3_client.upload_file(
         Filename=str(TEST_ROTATED_PDF_PATH), Bucket=config.test_bucket_name, Key=str(TEST_ROTATED_PDF_KEY)
@@ -210,7 +212,7 @@ def test_invalid_pdf(test_client: TestClient, upload_test_pdf, upload_test_png):
     request_json["filename"] = "invalid.pdf"
     response = test_client.post("/api/V1/extract_data", json=request_json)
     assert response.status_code == 404
-    assert response.json() == {"detail": "Failed to load PDF document. The filename is not found in the bucket."}
+    assert response.json() == {"detail": "Document invalid.pdf not found in S3 bucket."}
 
 
 def test_number_extraction(test_client: TestClient, upload_test_pdf, upload_test_png):

--- a/tests/test_data_extraction_from_bbox.py
+++ b/tests/test_data_extraction_from_bbox.py
@@ -59,8 +59,6 @@ def get_text_request_on_rotated_pdf():
 @pytest.fixture(scope="function")
 def upload_test_pdf(s3_client):
     """Upload a test PDF file to S3."""
-    s3_client.list_buckets()
-
     s3_client.upload_file(Filename=str(TEST_PDF_PATH), Bucket=config.test_bucket_name, Key=str(TEST_PDF_KEY))
     s3_client.upload_file(
         Filename=str(TEST_ROTATED_PDF_PATH), Bucket=config.test_bucket_name, Key=str(TEST_ROTATED_PDF_KEY)


### PR DESCRIPTION
I implemented the changes required by test users to make it possible to use environment variables to specify the AWS credentials to the API. The credentials can also be specified in an `.env` file now. 

The `create_pngs` path also now directly returns the file path within the S3 bucket without specifying the bucket URL. 

