### PR TITLE
Close #LGVISIUM-94: Renaming of the output from create png api path

### DIFF
--- a/src/app/api/v1/endpoints/create_pngs.py
+++ b/src/app/api/v1/endpoints/create_pngs.py
@@ -16,7 +16,7 @@ def create_pngs(aws_filename: Path) -> PNGResponse:
         aws_filename (str): The key of the PDF document in the S3 bucket. For example, "10012.pdf".
 
     Returns:
-        PNGResponse: The URLs of the PNG images in the S3 bucket.
+        PNGResponse: The S3 keys of the PNG images in the S3 bucket.
     """
     # Check if the PDF name is valid
     if not aws_filename.suffix == ".pdf":
@@ -47,7 +47,7 @@ def create_pngs(aws_filename: Path) -> PNGResponse:
                 s3_bucket_png_path,  # The key (name) of the file in the bucket
             )
 
-            # Generate the S3 URL
+            # Generate the S3 key
             s3_keys.append(s3_bucket_png_path)
 
             # Clean up the local file

--- a/src/app/api/v1/endpoints/create_pngs.py
+++ b/src/app/api/v1/endpoints/create_pngs.py
@@ -55,4 +55,4 @@ def create_pngs(aws_filename: Path) -> PNGResponse:
     except Exception:
         raise HTTPException(status_code=500, detail="An error occurred while processing the PDF.") from None
 
-    return PNGResponse(key=s3_keys)
+    return PNGResponse(keys=s3_keys)

--- a/src/app/api/v1/endpoints/create_pngs.py
+++ b/src/app/api/v1/endpoints/create_pngs.py
@@ -9,7 +9,7 @@ from app.common.schemas import PNGResponse
 from fastapi import HTTPException
 
 
-def create_pngs(aws_filename: Path):
+def create_pngs(aws_filename: Path) -> PNGResponse:
     """Convert a PDF document to PNG images. Please note that this function will overwrite any existing PNG files.
 
     Args:
@@ -28,7 +28,7 @@ def create_pngs(aws_filename: Path):
     # Initialize the S3 client
     pdf_document = load_pdf_from_aws(aws_filename)
 
-    png_urls = []
+    s3_keys = []
 
     # Convert each page of the PDF to PNG
     try:
@@ -48,11 +48,11 @@ def create_pngs(aws_filename: Path):
             )
 
             # Generate the S3 URL
-            png_urls.append(s3_bucket_png_path)
+            s3_keys.append(s3_bucket_png_path)
 
             # Clean up the local file
             os.remove(png_path)
     except Exception:
         raise HTTPException(status_code=500, detail="An error occurred while processing the PDF.") from None
 
-    return PNGResponse(png_urls=png_urls)
+    return PNGResponse(key=s3_keys)

--- a/src/app/api/v1/endpoints/create_pngs.py
+++ b/src/app/api/v1/endpoints/create_pngs.py
@@ -47,7 +47,7 @@ def create_pngs(aws_filename: Path) -> PNGResponse:
                 s3_bucket_png_path,  # The key (name) of the file in the bucket
             )
 
-            # Generate the S3 key
+            # Save the generated the S3 keys as a list to return through the API
             s3_keys.append(s3_bucket_png_path)
 
             # Clean up the local file

--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -42,7 +42,7 @@ class PNGRequest(BaseModel):
 class PNGResponse(BaseModel):
     """Response schema for the create_pngs endpoint."""
 
-    key: list[str]  # key in the S3 bucket
+    keys: list[str]  # keys in the S3 bucket
 
 
 ########################################################################################################################

--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -42,7 +42,7 @@ class PNGRequest(BaseModel):
 class PNGResponse(BaseModel):
     """Response schema for the create_pngs endpoint."""
 
-    png_urls: list[str]
+    key: list[str]  # key in the S3 bucket
 
 
 ########################################################################################################################

--- a/tests/test_create_pngs.py
+++ b/tests/test_create_pngs.py
@@ -48,11 +48,11 @@ def test_create_pngs_success(test_client: TestClient, s3_client, upload_test_pdf
     response = test_client.post("/api/V1/create_pngs", json={"filename": TEST_PDF_KEY.rsplit("/", 1)[-1]})
     assert response.status_code == 200
     json_response = response.json()
-    assert "key" in json_response
-    assert len(json_response["key"]) > 0
+    assert "keys" in json_response
+    assert len(json_response["keys"]) > 0
 
     # Verify that PNG files are uploaded to S3
-    for png_url in json_response["key"]:
+    for png_url in json_response["keys"]:
         try:
             s3_client.head_object(Bucket=config.test_bucket_name, Key=png_url)
         except ClientError:

--- a/tests/test_create_pngs.py
+++ b/tests/test_create_pngs.py
@@ -48,11 +48,11 @@ def test_create_pngs_success(test_client: TestClient, s3_client, upload_test_pdf
     response = test_client.post("/api/V1/create_pngs", json={"filename": TEST_PDF_KEY.rsplit("/", 1)[-1]})
     assert response.status_code == 200
     json_response = response.json()
-    assert "png_urls" in json_response
-    assert len(json_response["png_urls"]) > 0
+    assert "key" in json_response
+    assert len(json_response["key"]) > 0
 
     # Verify that PNG files are uploaded to S3
-    for png_url in json_response["png_urls"]:
+    for png_url in json_response["key"]:
         try:
             s3_client.head_object(Bucket=config.test_bucket_name, Key=png_url)
         except ClientError:


### PR DESCRIPTION
As the API is returning the key within the S3 bucket where the created PNG file is stored, it felt necessary to adapt the naming in the API response as well to avoid any type of confusion regarding what is returned. 