### PR TITLE
Lgvisium 100/extract depth value error handling

### DIFF
--- a/src/app/api/v1/endpoints/extract_data.py
+++ b/src/app/api/v1/endpoints/extract_data.py
@@ -147,7 +147,7 @@ def extract_coordinates(
             ),
         )
 
-    coord_extractor = CoordinateExtractor(pdf_page)
+    coord_extractor = CoordinateExtractor()
     extracted_coord = coord_extractor.extract_coordinates_from_bbox(
         pdf_page, extract_data_request.page_number, user_defined_bbox
     )

--- a/src/stratigraphy/data_extractor/data_extractor.py
+++ b/src/stratigraphy/data_extractor/data_extractor.py
@@ -95,7 +95,6 @@ class DataExtractor(ABC):
     This class defines the interface for extracting data from stratigraphy data files.
     """
 
-    doc: fitz.Document = None
     feature_keys: list[str] = None
     feature_fp_keys: list[str] = None
     feature_name: str = None
@@ -111,17 +110,15 @@ class DataExtractor(ABC):
 
     preprocess_replacements: dict[str, str] = {}
 
-    def __init__(self, document: fitz.Document):
+    def __init__(self):
         """Initializes the DataExtractor object.
 
         Args:
-            document (fitz.Document): A PDF document.
             feature_name (str): The name of the feature to extract.
         """
         if not self.feature_name:
             raise ValueError("Feature name must be specified.")
 
-        self.doc = document
         self.feature_keys = read_params("matching_params.yml")[f"{self.feature_name}_keys"]
         self.feature_fp_keys = read_params("matching_params.yml")[f"{self.feature_name}_fp_keys"] or []
 

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -189,18 +189,14 @@ class GroundwaterLevelExtractor(DataExtractor):
             key_center = (key_rect.x0 + key_rect.x1) / 2
             groundwater_info_lines.sort(key=lambda line: abs((line.rect.x0 + line.rect.x1) / 2 - key_center))
 
-            try:
-                extracted_gw = self.get_groundwater_info_from_lines(groundwater_info_lines, page)
-                if extracted_gw.feature.depth or extracted_gw.feature.elevation:
-                    # if the depth or elevation is extracted, add the extracted groundwater information to the list
-                    extracted_groundwater_list.append(extracted_gw)
-            except ValueError as error:
-                logger.warning("ValueError: %s", error)
-                logger.warning("Could not extract groundwater information from the lines near the key.")
+            extracted_groundwater = self.get_groundwater_info_from_lines(groundwater_info_lines, page)
+            if extracted_groundwater:
+                # if the depth or elevation is extracted, add the extracted groundwater information to the list
+                extracted_groundwater_list.append(extracted_groundwater)
 
         return extracted_groundwater_list
 
-    def get_groundwater_info_from_lines(self, lines: list[TextLine], page: int) -> FeatureOnPage[Groundwater]:
+    def get_groundwater_info_from_lines(self, lines: list[TextLine], page: int) -> FeatureOnPage[Groundwater] | None:
         """Extracts the groundwater information from a list of text lines.
 
         Args:
@@ -297,7 +293,7 @@ class GroundwaterLevelExtractor(DataExtractor):
                 page=page,
             )
         else:
-            raise ValueError("Could not extract all required information from the lines provided.")
+            logger.warning("Could not extract groundwater depth nor elevation from the lines near the key.")
 
     def extract_groundwater(
         self, page_number: int, lines: list[TextLine], terrain_elevation: Elevation | None

--- a/src/stratigraphy/groundwater/gw_illustration_template_matching.py
+++ b/src/stratigraphy/groundwater/gw_illustration_template_matching.py
@@ -39,14 +39,16 @@ def get_groundwater_from_illustration(
     groundwater_extractor: GroundwaterLevelExtractor,
     lines: list[TextLine],
     page_number: int,
+    document: fitz.Document,
     terrain_elevation: Elevation | None,
 ) -> tuple[list[FeatureOnPage[Groundwater]], list[float]]:
     """Extracts the groundwater information from an illustration.
 
     Args:
-        groundwater_extractor (GroundwaterLevelExtractor): the groundwater level extractor
-        lines (list[TextLine]): the lines of text to extract the groundwater information from
-        page_number (int): the page number (1-based) of the PDF document
+        groundwater_extractor (GroundwaterLevelExtractor): the groundwater level extractor.
+        lines (list[TextLine]): The lines of text to extract the groundwater information from.
+        page_number (int): The page number (1-based) of the PDF document.
+        document (fitz.Document): The document to extract groundwater from illustration from.
         terrain_elevation (Elevation | None): The elevation of the terrain.
 
     Returns:
@@ -57,8 +59,8 @@ def get_groundwater_from_illustration(
     confidence_list = []
 
     # convert the doc to an image
-    page = groundwater_extractor.doc.load_page(page_number - 1)
-    filename = Path(groundwater_extractor.doc.name).stem
+    page = document.load_page(page_number - 1)
+    filename = Path(document.name).stem
     png_filename = f"{filename}-{page_number + 1}.png"
     png_path = f"/tmp/{png_filename}"  # Local path to save the PNG
     fitz.utils.get_pixmap(page, matrix=fitz.Matrix(2, 2), clip=page.rect).save(png_path)

--- a/src/stratigraphy/groundwater/utility.py
+++ b/src/stratigraphy/groundwater/utility.py
@@ -1,6 +1,5 @@
 """Series of utility functions for groundwater stratigraphy."""
 
-import logging
 from datetime import date, datetime
 
 import regex
@@ -43,12 +42,10 @@ def extract_depth(text: str, max_depth: int) -> float | None:
                 depth = float(depth_match.group(1).replace(",", "."))
                 if depth > max_depth:
                     # If the extracted depth is greater than the max depth, set it to None and continue searching.
-                    logging.warning(f"Depth {depth} exceeds max_depth {max_depth}")
                     depth = None
                 else:
                     break
-        except ValueError as ve:
-            logging.warning(f"ValueError occurred: {ve}")
+        except ValueError:
             continue
     return depth
 

--- a/src/stratigraphy/groundwater/utility.py
+++ b/src/stratigraphy/groundwater/utility.py
@@ -1,5 +1,6 @@
 """Series of utility functions for groundwater stratigraphy."""
 
+import logging
 from datetime import date, datetime
 
 import regex
@@ -30,20 +31,25 @@ def extract_depth(text: str, max_depth: int) -> float | None:
     depth_patterns = [
         r"([\d.]+)\s*m\s*u\.t\.",
         r"([\d.]+)\s*m\s*u\.t",
-        r"(\d+.\d+)",
+        r"(\d+\.\d+)",
     ]
 
     depth = None
     corrected_text = correct_ocr_text(text).lower()
     for pattern in depth_patterns:
         depth_match = regex.search(pattern, corrected_text)
-        if depth_match:
-            depth = float(depth_match.group(1).replace(",", "."))
-            if depth > max_depth:
-                # If the extracted depth is greater than the max depth, set it to None and continue searching.
-                depth = None
-            else:
-                break
+        try:
+            if depth_match:
+                depth = float(depth_match.group(1).replace(",", "."))
+                if depth > max_depth:
+                    # If the extracted depth is greater than the max depth, set it to None and continue searching.
+                    logging.warning(f"Depth {depth} exceeds max_depth {max_depth}")
+                    depth = None
+                else:
+                    break
+        except ValueError as ve:
+            logging.warning(f"ValueError occurred: {ve}")
+            continue
     return depth
 
 

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -258,7 +258,7 @@ def start_pipeline(
                             ##avoid duplicate entries
                             for groundwater_entry in groundwater_entries_near_bbox:
                                 if groundwater_entry not in aggregated_groundwater_entries:
-                                    aggregated_groundwater_entries.extend(groundwater_entries_near_bbox)
+                                    aggregated_groundwater_entries.append(groundwater_entry)
 
                         # TODO: Add remove duplicates here!
                         if page_index > 0:

--- a/src/stratigraphy/metadata/coordinate_extraction.py
+++ b/src/stratigraphy/metadata/coordinate_extraction.py
@@ -311,7 +311,7 @@ class CoordinateExtractor(DataExtractor):
 
         logger.info("No coordinates found in this borehole profile.")
 
-    def extract_coordinates(self) -> Coordinate | None:
+    def extract_coordinates(self, document: fitz.Document) -> Coordinate | None:
         """Extracts the coordinates from a borehole profile.
 
         Processes the borehole profile page by page and tries to find the coordinates in the respective text of the
@@ -322,10 +322,13 @@ class CoordinateExtractor(DataExtractor):
             2. if that gives no results, search for coordinates close to an explicit "coordinates" label
             3. if that gives no results either, try to detect coordinates in the full text
 
+        Args:
+            document (fitz.Document): document from which coordinates are extracted page by page
+
         Returns:
             Coordinate | None: the extracted coordinates (if any)
         """
-        for page in self.doc:
+        for page in document:
             page_number = page.number + 1  # page.number is 0-based
 
             return self.extract_coordinates_from_bbox(page, page_number)

--- a/src/stratigraphy/metadata/elevation_extraction.py
+++ b/src/stratigraphy/metadata/elevation_extraction.py
@@ -219,13 +219,19 @@ class ElevationExtractor(DataExtractor):
 
         logger.info("No elevation found in the bounding box.")
 
-    def extract_elevation(self) -> Elevation | None:
+    def extract_elevation(self, document: fitz.Document) -> Elevation | None:
         """Extracts the elevation information from a borehole profile.
 
         Processes the borehole profile page by page and tries to find the feature key in the respective text of the
         page.
+
+        Args:
+            document (fitz.Document): document from which elevation is extracted page by page
+
+        Returns:
+            Elevation | None: The extracted elevation information.
         """
-        for page in self.doc:
+        for page in document:
             page_number = page.number + 1  # page.number is 0-based
 
             # TODO: This return the first found elevation, but we might want to check all pages.

--- a/src/stratigraphy/metadata/metadata.py
+++ b/src/stratigraphy/metadata/metadata.py
@@ -106,12 +106,12 @@ class BoreholeMetadata(metaclass=abc.ABCMeta):
         )
 
         # Extract the coordinates of the borehole
-        coordinate_extractor = CoordinateExtractor(document=document)
-        coordinates = coordinate_extractor.extract_coordinates()
+        coordinate_extractor = CoordinateExtractor()
+        coordinates = coordinate_extractor.extract_coordinates(document=document)
 
         # Extract the elevation information
-        elevation_extractor = ElevationExtractor(document=document)
-        elevation = elevation_extractor.extract_elevation()
+        elevation_extractor = ElevationExtractor()
+        elevation = elevation_extractor.extract_elevation(document=document)
 
         # Get the name of the document
         filename = Path(document.name)

--- a/tests/test_coordinate_extraction.py
+++ b/tests/test_coordinate_extraction.py
@@ -68,13 +68,13 @@ def test_to_jsonLV03():  # noqa: D103
 
 doc = fitz.open(DATAPATH.parent / "example" / "example_borehole_profile.pdf")
 doc_with_digits_in_coordinates = fitz.open(DATAPATH.parent / "example" / "A7367.pdf")
-extractor = CoordinateExtractor(doc)
+extractor = CoordinateExtractor()
 
 
 def test_CoordinateExtractor_extract_coordinates():  # noqa: D103
     """Test the extraction of coordinates from a PDF document."""
     # Assuming there is a method called 'extract' in CoordinateExtractor class
-    coordinates = extractor.extract_coordinates()
+    coordinates = extractor.extract_coordinates(doc)
     # Check if the returned value is a list
     assert isinstance(coordinates, Coordinate)
     assert repr(coordinates.east) == "615'790.0"
@@ -84,7 +84,7 @@ def test_CoordinateExtractor_extract_coordinates():  # noqa: D103
 def test_CoordinateExtractor_extract_coordinates_with_digits_in_coordinates():  # noqa: D103
     """Test the extraction of coordinates from a PDF document with digits in the coordinates."""
     # Assuming there is a method called 'extract' in CoordinateExtractor class
-    coordinates = CoordinateExtractor(doc_with_digits_in_coordinates).extract_coordinates()
+    coordinates = CoordinateExtractor().extract_coordinates(doc_with_digits_in_coordinates)
     # Check if the returned value is a list
     assert isinstance(coordinates, Coordinate)
     assert repr(coordinates.east) == "607'562.0"

--- a/tests/test_coordinate_extraction.py
+++ b/tests/test_coordinate_extraction.py
@@ -150,8 +150,8 @@ def test_CoordinateExtractor_get_coordinates_with_x_y_labels():  # noqa: D103
 
 
 def test_get_axis_aligned_lines():
-    """Test the extraction of lines near feature key."""  # searches (x1-x0) *10 to right and (y1-y0) * 3 below
-    rect_key = fitz.Rect(x0=200, y0=200, x1=300, y1=250)  # x1 limit = 1300, y0 limit = 150
+    """Test the extraction of lines near feature key."""
+    rect_key = fitz.Rect(x0=200, y0=200, x1=300, y1=250)
 
     # Key line
     key_line = TextLine([TextWord(fitz.Rect(200, 200, 300, 400), "Linie1", page=1)])
@@ -184,6 +184,8 @@ def test_get_axis_aligned_lines():
         overlap_right_below,
     ]
 
+    # CoordinateExtractor searches (x1-x0) *10 to right and (y1-y0) * 3 below rect_key
+    # Thus, x1 limit = 1300, y0 limit = 150
     feature_lines = extractor.get_axis_aligned_lines(lines=text_lines, rect=rect_key)
     expected_lines = [key_line, overlap_right, inside_below, inside_right, overlap_right_below, overlap_right]
 

--- a/tests/test_coordinate_extraction.py
+++ b/tests/test_coordinate_extraction.py
@@ -187,7 +187,7 @@ def test_get_axis_aligned_lines():
     # CoordinateExtractor searches (x1-x0) *10 to right and (y1-y0) * 3 below rect_key
     # Thus, x1 limit = 1300, y0 limit = 150
     feature_lines = extractor.get_axis_aligned_lines(lines=text_lines, rect=rect_key)
-    expected_lines = [key_line, overlap_right, inside_below, inside_right, overlap_right_below, overlap_right]
+    expected_lines = [key_line, overlap_right, inside_below, inside_right, overlap_right_below]
 
     for feature_line in feature_lines:
         assert feature_line in expected_lines, f"Unexpected feature line: {feature_line}"

--- a/tests/test_coordinate_extraction.py
+++ b/tests/test_coordinate_extraction.py
@@ -149,6 +149,51 @@ def test_CoordinateExtractor_get_coordinates_with_x_y_labels():  # noqa: D103
     assert len(coordinates) == 2
 
 
+def test_get_axis_aligned_lines():
+    """Test the extraction of lines near feature key."""  # searches (x1-x0) *10 to right and (y1-y0) * 3 below
+    rect_key = fitz.Rect(x0=200, y0=200, x1=300, y1=250)  # x1 limit = 1300, y0 limit = 150
+
+    # Key line
+    key_line = TextLine([TextWord(fitz.Rect(200, 200, 300, 400), "Linie1", page=1)])
+    # Inside horizontal range (right)
+    inside_right = TextLine([TextWord(fitz.Rect(310, 200, 410, 250), "Linie2", page=1)])
+    # Inside vertical range (below)
+    inside_below = TextLine([TextWord(fitz.Rect(200, 260, 300, 310), "Linie3", page=1)])
+    # Outside vertical and horizontal range (above)
+    outside_above = TextLine([TextWord(fitz.Rect(200, 140, 300, 190), "Linie4", page=1)])
+    # Completely outside both ranges (diagonal)
+    outside_diagonal = TextLine([TextWord(fitz.Rect(310, 260, 410, 310), "Linie5", page=1)])
+    # Edge case: exactly on horizontal limit
+    boundary_left = TextLine([TextWord(fitz.Rect(100, 200, 200, 250), "Linie6", page=1)])
+    # Edge case: exactly on edge of horizontal limit and vertical limit
+    boundary_edge_above = TextLine([TextWord(fitz.Rect(300, 250, 400, 300), "Linie7", page=1)])
+    # # Inside vertical limit, overlap with horizontal limit
+    overlap_right = TextLine([TextWord(fitz.Rect(250, 200, 350, 250), "Linie8", page=1)])
+    # # Overlap with vertical and horizontal limit
+    overlap_right_below = TextLine([TextWord(fitz.Rect(250, 225, 350, 275), "Linie9", page=1)])
+
+    text_lines = [
+        key_line,
+        inside_right,
+        inside_below,
+        outside_above,
+        outside_diagonal,
+        boundary_left,
+        boundary_edge_above,
+        overlap_right,
+        overlap_right_below,
+    ]
+
+    feature_lines = extractor.get_axis_aligned_lines(lines=text_lines, rect=rect_key)
+    expected_lines = [key_line, overlap_right, inside_below, inside_right, overlap_right_below, overlap_right]
+
+    for feature_line in feature_lines:
+        assert feature_line in expected_lines, f"Unexpected feature line: {feature_line}"
+
+    for expected_line in expected_lines:
+        assert expected_line in feature_lines, f"Expected line is missing: {expected_line}"
+
+
 def test_CoordinateExtractor_get_coordinates_near_key():  # noqa: D103
     """Test the extraction of coordinates near a key."""
     lines = _create_simple_lines(

--- a/tests/test_data_extraction_from_bbox.py
+++ b/tests/test_data_extraction_from_bbox.py
@@ -13,7 +13,7 @@ import fitz
 import pytest
 from app.common.aws import load_pdf_from_aws
 from app.common.config import config
-from app.common.schemas import ExtractDataRequest, FormatTypes
+from app.common.schemas import BoundingBox, ExtractDataRequest, FormatTypes
 from fastapi.testclient import TestClient
 
 TEST_PDF_KEY = Path("sample.pdf")
@@ -37,7 +37,7 @@ def get_default_small_coordinate_request():
     return ExtractDataRequest(
         filename=TEST_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 0, "y0": 0, "x1": 100, "y1": 100},
+        bbox=BoundingBox(x0=0, y0=0, x1=100, y1=100),
         format=FormatTypes.COORDINATES,
     )
 
@@ -47,7 +47,7 @@ def get_default_coordinate_request():
     return ExtractDataRequest(
         filename=TEST_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 0, "y0": 0, "x1": 3000, "y1": 3000},
+        bbox=BoundingBox(x0=0, y0=0, x1=3000, y1=3000),
         format=FormatTypes.COORDINATES,
     )
 
@@ -57,7 +57,7 @@ def get_text_request_on_rotated_pdf():
     return ExtractDataRequest(
         filename=TEST_ROTATED_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 0, "y0": 0, "x1": 600, "y1": 150},
+        bbox=BoundingBox(x0=0, y0=0, x1=600, y1=150),
         format=FormatTypes.TEXT,
     )
 
@@ -125,7 +125,7 @@ def test_extract_text_success(test_client: TestClient, upload_test_pdf, upload_t
     request = ExtractDataRequest(
         filename=TEST_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 0, "y0": 0, "x1": 1000, "y1": 1000},
+        bbox=BoundingBox(x0=0, y0=0, x1=1000, y1=1000),
         format=FormatTypes.TEXT,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -156,7 +156,7 @@ def test_clipping_behavior(test_client: TestClient, upload_test_pdf, upload_test
     request = ExtractDataRequest(
         filename=TEST_CLIPPING_BEHAVIOR_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 311, "y0": 269, "x1": 821, "y1": 704},  # pixels
+        bbox=BoundingBox(x0=311, y0=269, x1=821, y1=704),  # pixels
         format=FormatTypes.TEXT,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -174,7 +174,7 @@ def test_clipping_behavior(test_client: TestClient, upload_test_pdf, upload_test
     request = ExtractDataRequest(
         filename=TEST_CLIPPING_BEHAVIOR_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 311, "y0": 299, "x1": 813, "y1": 704},  # pixels
+        bbox=BoundingBox(x0=311, y0=299, x1=813, y1=704),  # pixels
         format=FormatTypes.TEXT,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -192,7 +192,7 @@ def test_clipping_behavior(test_client: TestClient, upload_test_pdf, upload_test
     request = ExtractDataRequest(
         filename=TEST_CLIPPING_BEHAVIOR_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 311, "y0": 269, "x1": 611, "y1": 336},  # pixels
+        bbox=BoundingBox(x0=311, y0=269, x1=611, y1=336),  # pixels
         format=FormatTypes.TEXT,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -210,7 +210,7 @@ def test_clipping_behavior(test_client: TestClient, upload_test_pdf, upload_test
     request = ExtractDataRequest(
         filename=TEST_CLIPPING_BEHAVIOR_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 1848, "y0": 242, "x1": 2145, "y1": 303},  # pixels
+        bbox=BoundingBox(x0=1848, y0=242, x1=2145, y1=303),  # pixels
         format=FormatTypes.TEXT,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -227,7 +227,7 @@ def test_clipping_behavior(test_client: TestClient, upload_test_pdf, upload_test
     request = ExtractDataRequest(
         filename=TEST_CLIPPING_BEHAVIOR_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 315, "y0": 281, "x1": 371, "y1": 330},  # pixels
+        bbox=BoundingBox(x0=315, y0=281, x1=371, y1=330),  # pixels
         format=FormatTypes.TEXT,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -241,7 +241,7 @@ def test_clipping_behavior(test_client: TestClient, upload_test_pdf, upload_test
     request = ExtractDataRequest(
         filename=TEST_CLIPPING_BEHAVIOR_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 315, "y0": 300, "x1": 465, "y1": 330},  # pixels
+        bbox=BoundingBox(x0=315, y0=300, x1=465, y1=330),  # pixels
         format=FormatTypes.TEXT,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -256,7 +256,7 @@ def test_extract_text_empty(test_client: TestClient, upload_test_pdf, upload_tes
     request = ExtractDataRequest(
         filename=TEST_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 0, "y0": 0, "x1": 100, "y1": 100},
+        bbox=BoundingBox(x0=0, y0=0, x1=100, y1=100),
         format=FormatTypes.TEXT,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -287,7 +287,7 @@ def test_extract_coordinate_success(test_client: TestClient, upload_test_pdf, up
     request = ExtractDataRequest(
         filename=TEST_CLIPPING_BEHAVIOR_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 1625, "y0": 900, "x1": 2819, "y1": 968},  # pixels
+        bbox=BoundingBox(x0=1625, y0=900, x1=2819, y1=968),  # pixels
         format=FormatTypes.COORDINATES,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -305,7 +305,7 @@ def test_extract_coordinate_success(test_client: TestClient, upload_test_pdf, up
     request = ExtractDataRequest(
         filename=TEST_CLIPPING_BEHAVIOR_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 1625, "y0": 1000, "x1": 2819, "y1": 1068},  # pixels
+        bbox=BoundingBox(x0=1625, y0=1000, x1=2819, y1=1068),  # pixels
         format=FormatTypes.COORDINATES,
     )
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
@@ -393,7 +393,7 @@ def test_number_extraction(test_client: TestClient, upload_test_pdf, upload_test
     ####################################################################################################
     request = get_text_request_on_rotated_pdf()
     request.format = FormatTypes.NUMBER
-    request.bbox = {"x0": 0, "y0": 0, "x1": 300, "y1": 300}
+    request.bbox = BoundingBox(x0=0, y0=0, x1=300, y1=300)
 
     response = test_client.post("/api/V1/extract_data", content=request.model_dump_json())
     assert response.status_code == 200
@@ -408,7 +408,8 @@ def test_number_extraction_failure(test_client: TestClient, upload_test_pdf, upl
     request = ExtractDataRequest(
         filename=TEST_PDF_KEY.name,
         page_number=1,
-        bbox={"x0": 0, "y0": 850, "x1": 1000, "y1": 950},  # Line with the coordinates in the document
+        bbox=BoundingBox(x0=0, y0=850, x1=1000, y1=950),
+        # Line with the coordinates in the document
         format=FormatTypes.NUMBER,
     )
 


### PR DESCRIPTION
Changes done:

- In the extract_depth function, the ValueError handling has been incorporated, and the matched pattern are now more specific to groundwater depth. This change reduced the number of ValueErrors encountered during float conversion, which previously caused the process to exit the loop prematurely. However, this refinement has led to an increase in false positives.

- To reduce these false positives, the logic for finding groundwater information has been changed. Groundwater search is now directly tied to the material description bounding box, meaning groundwater data is only search for in areas associated with material descriptions. This adjustment reduces unnecessary searches on pages without material descriptions and ensures groundwater extraction is more contextually related to material description areas. Since groundwater details can sometimes appear at the end of a page or farther from the material description, the search around the bounding box is not overly strict.

- To further reduce false postitives the logic for finding lines near keys was changed (impacting coordinate, elevation, and depth extraction). Instead of searching in a rectangle ( including entries diagonal to the key), the updated code now searches along the x and y axes. This adjustment improves the F1 score for groundwater extraction while slightly worsening performance for elevation extraction (data/geoquat/validation/ A11486.pdf).

More in Ticket LGVISIUM-100
