### PR TITLE
Lgd 564/improve ocr mistake handling

### DIFF
--- a/src/stratigraphy/sidebar/a_above_b_sidebar.py
+++ b/src/stratigraphy/sidebar/a_above_b_sidebar.py
@@ -124,9 +124,9 @@ class AAboveBSidebar(Sidebar[DepthColumnEntry]):
                         self.entries[i] = DepthColumnEntry(rect=entry.rect, value=new_value)
                         break
 
-            if "4" in str(entry.value) and not self._valid_value(
-                i, entry.value
-            ):  # OCR mistake example also 3 instead of 9
+            if "4" in str(entry.value) and not self._valid_value(i, entry.value):
+                # Correct common OCR mistakes where "4" is recognized instead of "1"
+                # Edge case: OCR also can also replace "3" with "9"
                 alternative_values = generate_alternatives(entry.value)
                 for alternative_value in alternative_values:
                     if self._valid_value(i, alternative_value):
@@ -243,13 +243,12 @@ class AAboveBSidebar(Sidebar[DepthColumnEntry]):
         return groups
 
 
-def generate_alternatives(value):
+def generate_alternatives(value: float) -> list[float]:
     """Generate a list of all possible alternatives by replacing each '4' with '1'."""
     value_str = str(value)
     alternatives = []
     options = [(char if char != "4" else ["4", "1"]) for char in value_str]
 
-    # Create all combinations
     for combo in product(*options):
         alternatives.append(float("".join(combo)))
 

--- a/src/stratigraphy/sidebar/a_above_b_sidebar_extractor.py
+++ b/src/stratigraphy/sidebar/a_above_b_sidebar_extractor.py
@@ -42,7 +42,6 @@ class AAboveBSidebarExtractor:
         clusters = Cluster[DepthColumnEntry].create_clusters(entries)
 
         numeric_columns = [AAboveBSidebar(cluster.entries) for cluster in clusters if len(cluster.entries) >= 3]
-        sidebar_validator = AAboveBSidebarValidator(**sidebar_params)
 
         filtered_columns = [
             column

--- a/src/stratigraphy/sidebar/a_above_b_sidebar_validator.py
+++ b/src/stratigraphy/sidebar/a_above_b_sidebar_validator.py
@@ -82,10 +82,6 @@ class AAboveBSidebarValidator:
             if self.is_valid(sidebar_noise):
                 return sidebar_noise
 
-            corrected_sidebar_noise = self.correct_OCR_mistakes(sidebar_noise, word_rtree)
-            if corrected_sidebar_noise:
-                return corrected_sidebar_noise
-
             new_sidebar = sidebar_noise.sidebar.remove_entry_by_correlation_gradient()
             if not new_sidebar:
                 return None

--- a/src/stratigraphy/sidebar/a_above_b_sidebar_validator.py
+++ b/src/stratigraphy/sidebar/a_above_b_sidebar_validator.py
@@ -6,7 +6,6 @@ import rtree
 
 from .a_above_b_sidebar import AAboveBSidebar
 from .sidebar import SidebarNoise, noise_count
-from .sidebarentry import DepthColumnEntry
 
 
 @dataclasses.dataclass
@@ -90,68 +89,3 @@ class AAboveBSidebarValidator:
             sidebar_noise = SidebarNoise(sidebar=new_sidebar, noise_count=new_noise_count)
 
         return None
-
-    def correct_OCR_mistakes(self, sidebar_noise: SidebarNoise, word_rtree: rtree.index.Index) -> SidebarNoise | None:
-        """Corrects OCR mistakes in the Sidebar entries.
-
-        Loops through all values and corrects common OCR mistakes for the given entry. Then, the column with the
-        highest pearson correlation coefficient is selected and checked for validity.
-
-        This is useful if one or more entries have an OCR mistake, and the column is not valid because of it.
-
-        Currently, there is no limit on the number of corrections per depth column. Indeed, there are examples of depth
-        columns with multiple OCR errors on different depth values. On the other hand, allowing an unlimited number of
-        corrections increases the risk, that a random column of different values is incorrectly accepted as a depth
-        column after making the corrections, especially if the column has a low number of entries. A more robust
-        solution might be to allow corrections on less than 50% of all entries, or something similar. However, we
-        currently don't have enough examples to properly tune this parameter.
-
-        Note: Common mistakes should be extended as needed.
-
-        Args:
-            sidebar_noise (SidebarNoise): The SidebarNoise wrapping the sidebar to validate.
-            word_rtree (index.Index): R-tree of all words on page for efficient spatial queries.
-
-        Returns:
-            SidebarNoise | None: The corrected SidebarNoise, or None if no correction was possible.
-        """
-        sidebar = sidebar_noise.sidebar
-        new_columns = [AAboveBSidebar(entries=[])]
-
-        for entry in sidebar.entries:
-            new_columns = [
-                AAboveBSidebar([*column.entries, DepthColumnEntry(entry.rect, new_value)])
-                for column in new_columns
-                for new_value in _value_alternatives(entry.value)
-            ]
-            # Immediately require strictly increasing values, to avoid exponential complexity when many implausible
-            # alternative values are suggested
-            new_columns = [column for column in new_columns if column.is_strictly_increasing()]
-
-        if new_columns:
-            best_column = max(new_columns, key=lambda column: column.pearson_correlation_coef())
-            new_noise_count = noise_count(best_column, word_rtree)
-
-            # We require a higher correlation coefficient when corrections are made
-            if self.is_valid(
-                SidebarNoise(sidebar=best_column, noise_count=new_noise_count), corr_coef_threshold=0.999
-            ):
-                return SidebarNoise(sidebar=best_column, noise_count=new_noise_count)
-
-        return None
-
-
-def _value_alternatives(value: float) -> set[float]:
-    """Corrects frequent OCR errors in depth column entries.
-
-    Args:
-        value (float): The depth values to find plausible alternatives for
-
-    Returns:
-        set(float): all plausible values (including the original one)
-    """
-    alternatives = {value}
-    # In older documents, OCR sometimes mistakes 1 for 4
-    alternatives.add(float(str(value).replace("4", "1")))
-
-    return alternatives


### PR DESCRIPTION
Follow-up to [Pull#111](https://github.com/swisstopo/swissgeol-boreholes-dataextraction/pull/111):
   - Moved OCR corrections to the make_ascending() function, eliminating the need for OCR corrections in reduce_until_valid().
   - Added correction for entries by a factor of 10 where possible within make_ascending().
   - Optimized is_strictly_increasing() and pearson_correlation_coef() to improve computation time.

These changes reduced processing time for Bearsol.pdf from 12 minutes to 5.4 minutes.

The F1 score for Zurich is now 0.8902 (previously 0.8911), with the slight drop due to a single bore profile. In one entry, the digit 1 was misrecognized as 4, and the decimal point was not detected by the OCR. The current correction method only adjusts for either the decimal point or the misrecognized digit.

The F1 score for Geoquat remains at 0.5979.