### PR TITLE
Added english language expressions to material desciptions in the mat…

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -105,6 +105,50 @@ material_description:
       - profondeur
       - désignation
 
+  en:
+    including_expressions:
+      - sand
+      - sandy
+      - sandstone
+      - silt
+      - silty
+      - siltstone
+      - clay
+      - claystone
+      - gravel
+      - asphalt
+      - humus
+      - brown
+      - gray
+      - soft
+      - hard
+      - root
+      - surface layer
+      - stone
+      - beige
+      - concrete
+      - chalk
+      - marl
+      - core material
+      - limestone
+      - ditto
+      - alternation
+      - leucosome
+    excluding_expressions:
+      - Mr.
+      - end
+      - profile
+      - description
+      - signatures
+      - mixed sample
+      - project
+      - location
+      - address
+      - weather
+      - pump test
+      - core drilling
+      - drilling radius
+
 
 coordinate_keys:
   - Koordinaten


### PR DESCRIPTION
Added English language support to material descriptions in the matching_params.yml. 

Created a list of including and excluding expressions for the English language in material description sections. Current List is a composed of translated German and French expressions combined with expressions found specifically in Nagra dataset. 

For additional language support (Coordinates, Elevation & Groundwater) a new issue has been created: https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/147 