### PR TITLE
refactor predictions - ground truth associations

### DIFF
--- a/example/example_gw_groundtruth.json
+++ b/example/example_gw_groundtruth.json
@@ -34,14 +34,32 @@
             "borehole_index": 0,
             "groundwater": [
                 {
-                    "date": "2016-04-18",
-                    "depth": 2.22,
-                    "elevation": 448.07
-                },
-                {
                     "date": "2016-04-20",
                     "depth": 3.22,
                     "elevation": 447.07
+                }
+            ],
+            "layers": [],
+            "metadata": {
+                "coordinates": {
+                    "E": 615790,
+                    "N": 157500
+                },
+                "drilling_date": "1995-09-03",
+                "drilling_methods": null,
+                "original_name": "",
+                "project_name": "",
+                "reference_elevation": 788.6,
+                "total_depth": null
+            }
+        },
+        {
+            "borehole_index": 1,
+            "groundwater": [
+                {
+                    "date": "2016-04-18",
+                    "depth": 2.22,
+                    "elevation": 448.07
                 }
             ],
             "layers": [],

--- a/example/example_layers_groundtruth.json
+++ b/example/example_layers_groundtruth.json
@@ -1,0 +1,75 @@
+{
+    "example_borehole_profile.pdf": [
+        {
+            "borehole_index": 0,
+            "groundwater": [],
+            "layers": [
+                {
+                    "depth_interval": {
+                        "end": 0.5,
+                        "start": 0.0
+                    },
+                    "material_description": "KIES, Sand"
+                },
+                {
+                    "depth_interval": {
+                        "end": 2.0,
+                        "start": 0.5
+                    },
+                    "material_description": "stein, sand"
+                }
+            ],
+            "metadata": {
+                "coordinates": {
+                    "E": 615790,
+                    "N": 157500
+                },
+                "drilling_date": "1995-09-03",
+                "drilling_methods": null,
+                "original_name": "",
+                "project_name": "",
+                "reference_elevation": 788.6,
+                "total_depth": null
+            }
+        },
+        {
+            "borehole_index": 1,
+            "groundwater": [],
+            "layers": [
+                {
+                    "depth_interval": {
+                        "end": 1,
+                        "start": null
+                    },
+                    "material_description": "HUMUS"
+                },
+                {
+                    "depth_interval": {
+                        "end": 2,
+                        "start": 1
+                    },
+                    "material_description": "KIES, grau"
+                },
+                {
+                    "depth_interval": {
+                        "end": 3,
+                        "start": 2
+                    },
+                    "material_description": "sand"
+                }
+            ],
+            "metadata": {
+                "coordinates": {
+                    "E": 615790,
+                    "N": 157500
+                },
+                "drilling_date": "1995-09-03",
+                "drilling_methods": null,
+                "original_name": "",
+                "project_name": "",
+                "reference_elevation": 788.6,
+                "total_depth": null
+            }
+        }
+    ]
+}

--- a/src/stratigraphy/annotations/draw.py
+++ b/src/stratigraphy/annotations/draw.py
@@ -9,7 +9,7 @@ import pandas as pd
 from dotenv import load_dotenv
 from stratigraphy.depths_materials_column_pairs.bounding_boxes import BoundingBoxes
 from stratigraphy.layer.layer import Layer
-from stratigraphy.util.file_predictions import OverallFilePredictions
+from stratigraphy.util.overall_file_predictions import OverallFilePredictions
 
 load_dotenv()
 

--- a/src/stratigraphy/annotations/draw.py
+++ b/src/stratigraphy/annotations/draw.py
@@ -9,7 +9,7 @@ import pandas as pd
 from dotenv import load_dotenv
 from stratigraphy.depths_materials_column_pairs.bounding_boxes import BoundingBoxes
 from stratigraphy.layer.layer import Layer
-from stratigraphy.util.predictions import OverallFilePredictions
+from stratigraphy.util.file_predictions import OverallFilePredictions
 
 load_dotenv()
 

--- a/src/stratigraphy/benchmark/score.py
+++ b/src/stratigraphy/benchmark/score.py
@@ -10,7 +10,7 @@ import pandas as pd
 from dotenv import load_dotenv
 from stratigraphy import DATAPATH
 from stratigraphy.benchmark.ground_truth import GroundTruth
-from stratigraphy.util.predictions import OverallFilePredictions
+from stratigraphy.util.file_predictions import OverallFilePredictions
 
 load_dotenv()
 
@@ -41,7 +41,8 @@ def evaluate(
     #############################
     # Evaluate the borehole extraction
     #############################
-    metrics = predictions.evaluate_geology(ground_truth)
+    matched_with_ground_truth = predictions.match_with_ground_truth(ground_truth)
+    metrics = matched_with_ground_truth.evaluate_geology()
 
     metrics.document_level_metrics_df().to_csv(
         temp_directory / "document_level_metrics.csv", index_label="document_name"
@@ -61,7 +62,7 @@ def evaluate(
     #############################
     # Evaluate the borehole extraction metadata
     #############################
-    metadata_metrics_list = predictions.evaluate_metadata_extraction(ground_truth)
+    metadata_metrics_list = matched_with_ground_truth.evaluate_metadata_extraction()
     metadata_metrics = metadata_metrics_list.get_cumulated_metrics()
     document_level_metadata_metrics: pd.DataFrame = metadata_metrics_list.get_document_level_metrics()
     document_level_metadata_metrics.to_csv(

--- a/src/stratigraphy/benchmark/score.py
+++ b/src/stratigraphy/benchmark/score.py
@@ -10,7 +10,7 @@ import pandas as pd
 from dotenv import load_dotenv
 from stratigraphy import DATAPATH
 from stratigraphy.benchmark.ground_truth import GroundTruth
-from stratigraphy.util.file_predictions import OverallFilePredictions
+from stratigraphy.util.overall_file_predictions import OverallFilePredictions
 
 load_dotenv()
 

--- a/src/stratigraphy/evaluation/evaluation_dataclasses.py
+++ b/src/stratigraphy/evaluation/evaluation_dataclasses.py
@@ -114,7 +114,7 @@ class FileBoreholeMetadataMetrics(BoreholeMetadataMetrics):
 class OverallBoreholeMetadataMetrics(metaclass=abc.ABCMeta):
     """Metrics for borehole metadata."""
 
-    borehole_metadata_metrics: list[FileBoreholeMetadataMetrics]
+    borehole_metadata_metrics: list[BoreholeMetadataMetrics]
 
     def __init__(self):
         """Initializes the OverallBoreholeMetadataMetrics object."""

--- a/src/stratigraphy/evaluation/groundwater_evaluator.py
+++ b/src/stratigraphy/evaluation/groundwater_evaluator.py
@@ -128,7 +128,7 @@ class GroundwaterEvaluator:
                 groundwater_depth_metrics=Metrics.micro_average(groundwater_depth_metrics_list),
                 groundwater_elevation_metrics=Metrics.micro_average(groundwater_elevation_metrics_list),
                 groundwater_date_metrics=Metrics.micro_average(groundwater_date_metrics_list),
-                filename=borehole_data.filename,
+                filename=file.filename,
             )
 
             overall_groundwater_metrics.add_groundwater_metrics(file_groundwater_metrics)

--- a/src/stratigraphy/evaluation/groundwater_evaluator.py
+++ b/src/stratigraphy/evaluation/groundwater_evaluator.py
@@ -94,6 +94,7 @@ class GroundwaterEvaluator:
 
                 # TODO store the correctness directly on the Groundwater objects, so we can use that in the
                 # visualizations (cf. https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/124)
+                entries = borehole_data.groundwater.groundwater_feature_list if borehole_data.groundwater else []
                 groundwater_metrics = count_against_ground_truth(
                     [
                         (
@@ -101,20 +102,20 @@ class GroundwaterEvaluator:
                             entry.feature.format_date(),
                             entry.feature.elevation,
                         )
-                        for entry in borehole_data.groundwater.groundwater_feature_list
+                        for entry in entries
                     ],
                     [(entry.depth, entry.format_date(), entry.elevation) for entry in gt_groundwater],
                 )
                 groundwater_depth_metrics = count_against_ground_truth(
-                    [entry.feature.depth for entry in borehole_data.groundwater.groundwater_feature_list],
+                    [entry.feature.depth for entry in entries],
                     [entry.depth for entry in gt_groundwater],
                 )
                 groundwater_elevation_metrics = count_against_ground_truth(
-                    [entry.feature.elevation for entry in borehole_data.groundwater.groundwater_feature_list],
+                    [entry.feature.elevation for entry in entries],
                     [entry.elevation for entry in gt_groundwater],
                 )
                 groundwater_date_metrics = count_against_ground_truth(
-                    [entry.feature.format_date() for entry in borehole_data.groundwater.groundwater_feature_list],
+                    [entry.feature.format_date() for entry in entries],
                     [entry.format_date() for entry in gt_groundwater],
                 )
                 groundwater_metrics_list.append(groundwater_metrics)

--- a/src/stratigraphy/evaluation/layer_evaluator.py
+++ b/src/stratigraphy/evaluation/layer_evaluator.py
@@ -24,15 +24,15 @@ class LayerEvaluator:
 
     def __init__(
         self,
-        layers_list: list[FileLayersWithGroundTruth],
+        file_layers_list: list[FileLayersWithGroundTruth],
     ):
         """Initializes the LayerEvaluator object.
 
         Args:
-            layers_list (list[FileLayersWithGroundTruth]): The layers to evaluate, grouped by borehole in a list,
+            file_layers_list (list[FileLayersWithGroundTruth]): The layers to evaluate, grouped by borehole in a list,
                 with associated ground truth data for each borehole.
         """
-        self.layers_list = layers_list
+        self.file_layers_list = file_layers_list
 
     def get_layer_metrics(self) -> OverallMetrics:
         """Calculate metrics for layer predictions."""
@@ -74,7 +74,7 @@ class LayerEvaluator:
         overall_metrics = OverallMetrics()
 
         # iteration over all the files
-        for file in self.layers_list:
+        for file in self.file_layers_list:
             hits_for_all_borehole = 0
             total_predictions_for_all_boreholes = 0
             fn_for_all_boreholes = 0

--- a/src/stratigraphy/evaluation/layer_evaluator.py
+++ b/src/stratigraphy/evaluation/layer_evaluator.py
@@ -99,7 +99,7 @@ class LayerEvaluator:
 
             # at this point we have the global statistics for all the boreholes in the document
             if total_predictions > 0:
-                overall_metrics.metrics[borehole_data.filename] = Metrics(
+                overall_metrics.metrics[file.filename] = Metrics(
                     tp=hits_for_all_borehole,
                     fp=total_predictions_for_all_boreholes - hits_for_all_borehole,
                     fn=fn_for_all_boreholes,

--- a/src/stratigraphy/evaluation/layer_evaluator.py
+++ b/src/stratigraphy/evaluation/layer_evaluator.py
@@ -100,12 +100,11 @@ class LayerEvaluator:
                 fn_for_all_boreholes += fn
 
             # at this point we have the global statistics for all the boreholes in the document
-            if total_predictions > 0:
-                overall_metrics.metrics[file.filename] = Metrics(
-                    tp=hits_for_all_borehole,
-                    fp=total_predictions_for_all_boreholes - hits_for_all_borehole,
-                    fn=fn_for_all_boreholes,
-                )
+            overall_metrics.metrics[file.filename] = Metrics(
+                tp=hits_for_all_borehole,
+                fp=total_predictions_for_all_boreholes - hits_for_all_borehole,
+                fn=fn_for_all_boreholes,
+            )
 
         return overall_metrics
 

--- a/src/stratigraphy/evaluation/metadata_evaluator.py
+++ b/src/stratigraphy/evaluation/metadata_evaluator.py
@@ -43,12 +43,14 @@ class MetadataEvaluator:
                 ### Compute the metadata correctness for the coordinates.
                 ###########################################################################################################
                 extracted_coordinates = (
-                    borehole_data.metadata.coordinates.feature if borehole_data.metadata.coordinates else None
+                    borehole_data.metadata.coordinates.feature
+                    if borehole_data.metadata and borehole_data.metadata.coordinates
+                    else None
                 )
                 ground_truth_coordinates = borehole_data.ground_truth.get("coordinates")
 
                 coordinate_metrics = self._evaluate_coordinate(extracted_coordinates, ground_truth_coordinates)
-                if borehole_data.metadata.coordinates:
+                if borehole_data.metadata and borehole_data.metadata.coordinates:
                     borehole_data.metadata.coordinates.is_correct = coordinate_metrics.tp > 0
                 coordinate_metrics_list.append(coordinate_metrics)
 
@@ -56,11 +58,13 @@ class MetadataEvaluator:
                 ### Compute the metadata correctness for the elevation.
                 ############################################################################################################
                 extracted_elevation = (
-                    borehole_data.metadata.elevation.feature.elevation if borehole_data.metadata.elevation else None
+                    borehole_data.metadata.elevation.feature.elevation
+                    if borehole_data.metadata and borehole_data.metadata.elevation
+                    else None
                 )
                 ground_truth_elevation = borehole_data.ground_truth.get("reference_elevation")
                 elevation_metrics = self._evaluate_elevation(extracted_elevation, ground_truth_elevation)
-                if borehole_data.metadata.elevation:
+                if borehole_data.metadata and borehole_data.metadata.elevation:
                     borehole_data.metadata.elevation.is_correct = elevation_metrics.tp > 0
                 elevation_metrics_list.append(elevation_metrics)
 

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -178,7 +178,7 @@ class GroundwaterLevelExtractor(DataExtractor):
         page_number: int,
         lines: list[TextLine],
         material_description_bbox: BoundingBox,
-        terrain_elevations: list[FeatureOnPage[Elevation]],
+        terrain_elevation: FeatureOnPage[Elevation] | None,
     ) -> list[FeatureOnPage[Groundwater]]:
         """Extracts groundwater information from a near material description bounding box on a page.
 
@@ -187,7 +187,8 @@ class GroundwaterLevelExtractor(DataExtractor):
             page_number (int): The page number (1-based) to process.
             lines (list[TextLine]): The list of text lines to retrieve the groundwater from.
             material_description_bbox (BoundingBox): The material description box from which
-            terrain_elevations (llist[FeatureOnPage[Elevation]]): The elevations of the terrain.
+            terrain_elevation (FeatureOnPage[Elevation] | None): The elevation of the terrain for the borehole (if
+                any is known).
 
         Returns:
             list[FeatureOnPage[Groundwater]]: The groundwater information near a material description bounding box.
@@ -207,7 +208,7 @@ class GroundwaterLevelExtractor(DataExtractor):
             page_number=page_number,
             lines=lines_for_groundwater_key,
             document=document,
-            terrain_elevations=terrain_elevations,
+            terrain_elevation=terrain_elevation,
         )
 
     def get_groundwater_near_key(self, lines: list[TextLine], page: int) -> list[FeatureOnPage[Groundwater]]:
@@ -345,7 +346,7 @@ class GroundwaterLevelExtractor(DataExtractor):
         page_number: int,
         lines: list[TextLine],
         document: fitz.Document,
-        terrain_elevations: list[FeatureOnPage[Elevation]],
+        terrain_elevation: FeatureOnPage[Elevation] | None,
     ) -> list[FeatureOnPage[Groundwater]]:
         """Extracts the groundwater information from a borehole profile.
 
@@ -358,7 +359,8 @@ class GroundwaterLevelExtractor(DataExtractor):
             page_number (int): The page number (1-based) of the PDF document.
             lines (list[TextLine]): The lines of text to extract the groundwater information from.
             document (fitz.Document): The document used to extract groundwater from illustration.
-            terrain_elevations (list[FeatureOnPage[Elevation]]): The elevations of the borehole.
+            terrain_elevation (FeatureOnPage[Elevation] | None): The elevation of the terrain for the borehole (if any
+                is known)
 
         Returns:
             list[FeatureOnPage[Groundwater]]: the extracted coordinates (if any)
@@ -370,33 +372,27 @@ class GroundwaterLevelExtractor(DataExtractor):
             )
 
             # Extract groundwater from illustration
-            terrain_elevations = terrain_elevations or [None]  # Ensure we always have at least one iteration
-
-            for terrain_elev_feature in terrain_elevations:
-                found_groundwater, confidence_list = get_groundwater_from_illustration(
-                    self, lines, page_number, document, terrain_elev_feature
-                )
-                if found_groundwater:
-                    break  # Not sure if early exit is correct
+            found_groundwater, confidence_list = get_groundwater_from_illustration(
+                self, lines, page_number, document, terrain_elevation
+            )
 
             if found_groundwater:
                 logger.info("Confidence list: %s", confidence_list)
                 logger.info("Found groundwater from illustration on page %s: %s", page_number, found_groundwater)
 
-        if terrain_elevations:
+        if terrain_elevation:
             # If the elevation is provided, calculate the depth of the groundwater
             for entry in found_groundwater:
                 # middle position of the groundwater found
                 avg_entry_pos = (entry.rect.top_left + entry.rect.bottom_right) / 2
                 best_dist = float("inf")
                 # as multiple terrain elevations can be found, we keep the closest to the current groundwater entry
-                for terrain_elev_feature in terrain_elevations:
-                    dist = avg_entry_pos.distance_to(terrain_elev_feature.rect)
-                    if dist < best_dist:
-                        if not entry.feature.depth and entry.feature.elevation:
-                            best_depth = round(terrain_elev_feature.feature.elevation - entry.feature.elevation, 2)
-                        if not entry.feature.elevation and entry.feature.depth:
-                            best_elev = round(terrain_elev_feature.feature.elevation - entry.feature.depth, 2)
+                dist = avg_entry_pos.distance_to(terrain_elevation.rect)
+                if dist < best_dist:
+                    if not entry.feature.depth and entry.feature.elevation:
+                        best_depth = round(terrain_elevation.feature.elevation - entry.feature.elevation, 2)
+                    if not entry.feature.elevation and entry.feature.depth:
+                        best_elev = round(terrain_elevation.feature.elevation - entry.feature.depth, 2)
                 if not entry.feature.depth and entry.feature.elevation:
                     entry.feature.depth = best_depth
                 if not entry.feature.elevation and entry.feature.depth:

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -381,22 +381,11 @@ class GroundwaterLevelExtractor(DataExtractor):
                 logger.info("Found groundwater from illustration on page %s: %s", page_number, found_groundwater)
 
         if terrain_elevation:
-            # If the elevation is provided, calculate the depth of the groundwater
             for entry in found_groundwater:
-                # middle position of the groundwater found
-                avg_entry_pos = (entry.rect.top_left + entry.rect.bottom_right) / 2
-                best_dist = float("inf")
-                # as multiple terrain elevations can be found, we keep the closest to the current groundwater entry
-                dist = avg_entry_pos.distance_to(terrain_elevation.rect)
-                if dist < best_dist:
-                    if not entry.feature.depth and entry.feature.elevation:
-                        best_depth = round(terrain_elevation.feature.elevation - entry.feature.elevation, 2)
-                    if not entry.feature.elevation and entry.feature.depth:
-                        best_elev = round(terrain_elevation.feature.elevation - entry.feature.depth, 2)
                 if not entry.feature.depth and entry.feature.elevation:
-                    entry.feature.depth = best_depth
+                    entry.feature.depth = round(terrain_elevation.feature.elevation - entry.feature.elevation, 2)
                 if not entry.feature.elevation and entry.feature.depth:
-                    entry.feature.elevation = best_elev
+                    entry.feature.elevation = round(terrain_elevation.feature.elevation - entry.feature.depth, 2)
 
         if found_groundwater:
             groundwater_output = ", ".join([str(entry.feature) for entry in found_groundwater])

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -267,12 +267,21 @@ def start_pipeline(
                 for borehole_index, page_bounding_box in enumerate(process_page_results.bounding_boxes):
                     material_description_bbox = page_bounding_box.material_description_bbox
 
+                    # TODO: first match elevation with boreholes more intelligently, then pass the correct value to
+                    # the groundwater extraction logic
+                    terrain_elevation = None
+                    if metadata.elevations:
+                        if len(metadata.elevations) > borehole_index:
+                            terrain_elevation = metadata.elevations[borehole_index]
+                        else:
+                            terrain_elevation = metadata.elevations[0]
+
                     groundwater_entries_near_bbox = GroundwaterLevelExtractor.near_material_description(
                         document=doc,
                         page_number=page_number,
                         lines=text_lines,
                         material_description_bbox=material_description_bbox,
-                        terrain_elevations=metadata.elevations if metadata.elevations else None,
+                        terrain_elevation=terrain_elevation,
                     )
                     # avoid duplicate entries
                     seen_entry = [

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -26,12 +26,8 @@ from stratigraphy.layer.layer import LayersInDocument
 from stratigraphy.lines.line_detection import extract_lines, line_detection_params
 from stratigraphy.metadata.metadata import FileMetadata, MetadataInDocument
 from stratigraphy.text.extract_text import extract_text_lines
-from stratigraphy.util.predictions import (
-    BoreholeListBuilder,
-    BoreholePredictions,
-    FilePredictions,
-    OverallFilePredictions,
-)
+from stratigraphy.util.file_predictions import FilePredictions, OverallFilePredictions
+from stratigraphy.util.predictions import BoreholeListBuilder, BoreholePredictions
 from stratigraphy.util.util import flatten, read_params
 
 load_dotenv()

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -26,7 +26,8 @@ from stratigraphy.layer.layer import LayersInDocument
 from stratigraphy.lines.line_detection import extract_lines, line_detection_params
 from stratigraphy.metadata.metadata import FileMetadata, MetadataInDocument
 from stratigraphy.text.extract_text import extract_text_lines
-from stratigraphy.util.file_predictions import FilePredictions, OverallFilePredictions
+from stratigraphy.util.file_predictions import FilePredictions
+from stratigraphy.util.overall_file_predictions import OverallFilePredictions
 from stratigraphy.util.predictions import BoreholeListBuilder, BoreholePredictions
 from stratigraphy.util.util import flatten, read_params
 

--- a/src/stratigraphy/util/borehole_predictions.py
+++ b/src/stratigraphy/util/borehole_predictions.py
@@ -1,0 +1,120 @@
+"""Classes for the predictions per borehole, and for associating them with ground truth data."""
+
+import dataclasses
+
+from stratigraphy.depths_materials_column_pairs.bounding_boxes import BoundingBoxes
+from stratigraphy.groundwater.groundwater_extraction import GroundwatersInBorehole
+from stratigraphy.layer.layer import LayersInBorehole
+from stratigraphy.metadata.metadata import BoreholeMetadata
+
+
+@dataclasses.dataclass
+class BoreholePredictions:
+    """Class that hold predicted information about a single borehole."""
+
+    borehole_index: int
+    layers_in_borehole: LayersInBorehole
+    file_name: str
+    metadata: BoreholeMetadata
+    groundwater_in_borehole: GroundwatersInBorehole
+    bounding_boxes: list[BoundingBoxes]
+
+    def to_json(self) -> dict:
+        """Converts the object to a dictionary.
+
+        Returns:
+            dict: The object as a dictionary.
+        """
+        return {
+            "borehole_index": self.borehole_index,
+            "metadata": self.metadata.to_json(),
+            "layers": [layer.to_json() for layer in self.layers_in_borehole.layers],
+            "bounding_boxes": [bboxes.to_json() for bboxes in self.bounding_boxes],
+            "groundwater": self.groundwater_in_borehole.to_json() if self.groundwater_in_borehole is not None else [],
+        }
+
+    @classmethod
+    def from_json(cls, json_object, file_name) -> "BoreholePredictions":
+        """Extract a BoreholePrediction object from a json dictionary.
+
+        Args:
+            json_object (dict): the json object containing the informations of the borehole
+            file_name: the file name
+
+        Returns:
+            (BoreholePredictions): the extracted object
+        """
+        return cls(
+            json_object["borehole_index"],
+            LayersInBorehole.from_json(json_object["layers"]),
+            file_name,
+            BoreholeMetadata.from_json(json_object["metadata"]),
+            GroundwatersInBorehole.from_json(json_object["groundwater"]),
+            [BoundingBoxes.from_json(bbox_json) for bbox_json in json_object["bounding_boxes"]],
+        )
+
+
+@dataclasses.dataclass
+class BoreholePredictionsWithGroundTruth:
+    """Predictions for a specific borehole with associated ground truth."""
+
+    predictions: BoreholePredictions
+    ground_truth: dict
+
+
+@dataclasses.dataclass
+class BoreholeLayersWithGroundTruth:
+    """Stratigraphy predictions for a specific borehole with associated ground truth."""
+
+    layers: LayersInBorehole
+    ground_truth: list
+
+
+@dataclasses.dataclass
+class BoreholeGroundwaterWithGroundTruth:
+    """Groundwater predictions for a specific borehole with associated ground truth."""
+
+    groundwater: GroundwatersInBorehole
+    ground_truth: list
+
+
+@dataclasses.dataclass
+class BoreholeMetadataWithGroundTruth:
+    """Borehole metadata predictions for a specific borehole with associated ground truth."""
+
+    metadata: BoreholeMetadata
+    ground_truth: dict
+
+
+@dataclasses.dataclass
+class FilePredictionsWithGroundTruth:
+    """All predictions for a specific file with associated ground truth."""
+
+    filename: str
+    language: str
+    boreholes: list[BoreholePredictionsWithGroundTruth]
+
+
+@dataclasses.dataclass
+class FileMetadataWithGroundTruth:
+    """All borehole metadata predictions for a specific file with associated ground truth."""
+
+    filename: str
+    boreholes: list[BoreholeMetadataWithGroundTruth]
+
+
+@dataclasses.dataclass
+class FileLayersWithGroundTruth:
+    """All stratigraphy predictions for a specific file with associated ground truth."""
+
+    filename: str
+    language: str
+    boreholes: list[BoreholeLayersWithGroundTruth]
+
+
+@dataclasses.dataclass
+class FileGroundwaterWithGroundTruth:
+    """All groundwater predictions for a specific file with associated ground truth."""
+
+    filename: str
+    boreholes: list[BoreholeGroundwaterWithGroundTruth]

--- a/src/stratigraphy/util/borehole_predictions.py
+++ b/src/stratigraphy/util/borehole_predictions.py
@@ -58,7 +58,7 @@ class BoreholePredictions:
 class BoreholePredictionsWithGroundTruth:
     """Predictions for a specific borehole with associated ground truth."""
 
-    predictions: BoreholePredictions
+    predictions: BoreholePredictions | None
     ground_truth: dict
 
 
@@ -66,7 +66,7 @@ class BoreholePredictionsWithGroundTruth:
 class BoreholeLayersWithGroundTruth:
     """Stratigraphy predictions for a specific borehole with associated ground truth."""
 
-    layers: LayersInBorehole
+    layers: LayersInBorehole | None
     ground_truth: list
 
 
@@ -74,7 +74,7 @@ class BoreholeLayersWithGroundTruth:
 class BoreholeGroundwaterWithGroundTruth:
     """Groundwater predictions for a specific borehole with associated ground truth."""
 
-    groundwater: GroundwatersInBorehole
+    groundwater: GroundwatersInBorehole | None
     ground_truth: list
 
 
@@ -82,7 +82,7 @@ class BoreholeGroundwaterWithGroundTruth:
 class BoreholeMetadataWithGroundTruth:
     """Borehole metadata predictions for a specific borehole with associated ground truth."""
 
-    metadata: BoreholeMetadata
+    metadata: BoreholeMetadata | None
     ground_truth: dict
 
 

--- a/src/stratigraphy/util/file_predictions.py
+++ b/src/stratigraphy/util/file_predictions.py
@@ -1,0 +1,131 @@
+"""Classes for predictions per PDF file."""
+
+import dataclasses
+
+from stratigraphy.benchmark.ground_truth import GroundTruth
+from stratigraphy.evaluation.layer_evaluator import LayerEvaluator
+from stratigraphy.metadata.metadata import FileMetadata
+from stratigraphy.util.borehole_predictions import (
+    BoreholePredictions,
+    BoreholePredictionsWithGroundTruth,
+    FilePredictionsWithGroundTruth,
+)
+from stratigraphy.util.predictions import AllBoreholePredictionsWithGroundTruth
+
+
+@dataclasses.dataclass
+class FilePredictions:
+    """A class to represent predictions for a single file.
+
+    It is responsible for grouping all the lists of elements into a single list of BoreholePrediction objects.
+    """
+
+    borehole_predictions_list: list[BoreholePredictions]
+    file_metadata: FileMetadata
+    file_name: str
+
+    def to_json(self) -> dict:
+        """Converts the object to a dictionary.
+
+        Returns:
+            dict: The object as a dictionary.
+        """
+        return {
+            **self.file_metadata.to_json(),
+            "boreholes": [borehole.to_json() for borehole in self.borehole_predictions_list],
+        }
+
+
+class OverallFilePredictions:
+    """A class to represent predictions for all files."""
+
+    def __init__(self) -> None:
+        """Initializes the OverallFilePredictions object."""
+        self.file_predictions_list: list[FilePredictions] = []
+        self.matching_pred_to_gt_boreholes = dict()  # set when evaluating layers
+
+    def add_file_predictions(self, file_predictions: FilePredictions) -> None:
+        """Add file predictions to the list of file predictions.
+
+        Args:
+            file_predictions (FilePredictions): The file predictions to add.
+        """
+        self.file_predictions_list.append(file_predictions)
+
+    def get_metadata_as_dict(self) -> dict:
+        """Returns the metadata of the predictions as a dictionary.
+
+        Returns:
+            dict: The metadata of the predictions as a dictionary.
+        """
+        return {
+            "_".join([file_prediction.file_name, str(borehole_prediction.borehole_index)]): {
+                "file_metadata": file_prediction.file_metadata.to_json(),
+                "borehole_metadata": borehole_prediction.metadata.to_json(),
+            }
+            for file_prediction in self.file_predictions_list
+            for borehole_prediction in file_prediction.borehole_predictions_list
+        }
+
+    def to_json(self) -> dict:
+        """Converts the object to a dictionary by merging individual file predictions.
+
+        Returns:
+            dict: A dictionary representation of the object.
+        """
+        return {fp.file_name: fp.to_json() for fp in self.file_predictions_list}
+
+    @classmethod
+    def from_json(cls, prediction_from_file: dict) -> "OverallFilePredictions":
+        """Converts a dictionary to an object.
+
+        Args:
+            prediction_from_file (dict): A dictionary representing the predictions.
+
+        Returns:
+            OverallFilePredictions: The object.
+        """
+        overall_file_predictions = OverallFilePredictions()
+        for file_name, file_data in prediction_from_file.items():
+            file_metadata = FileMetadata.from_json(file_data, file_name)
+
+            borehole_list = [BoreholePredictions.from_json(bh_data, file_name) for bh_data in file_data["boreholes"]]
+
+            overall_file_predictions.add_file_predictions(FilePredictions(borehole_list, file_metadata, file_name))
+        return overall_file_predictions
+
+    ############################################################################################################
+    ### Evaluation methods
+    ############################################################################################################
+
+    def match_with_ground_truth(self, ground_truth: GroundTruth) -> AllBoreholePredictionsWithGroundTruth:
+        """Match the extracted boreholes with corresponding boreholes in the ground truth data.
+
+        Args:
+            ground_truth (GroundTruth): The ground truth.
+
+        Returns:
+            AllBoreholePredictionsWithGroundTruth: all predictions per borehole with associated ground truth data.
+        """
+        files = []
+        for file_predictions in self.file_predictions_list:
+            boreholes = []
+            ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
+            if ground_truth_for_file:
+                borehole_matching_gt_to_pred = LayerEvaluator.evaluate_borehole(
+                    [bh.layers_in_borehole for bh in file_predictions.borehole_predictions_list],
+                    {idx: borehole_data["layers"] for idx, borehole_data in ground_truth_for_file.items()},
+                )
+                for gt_idx, borehole_idx in borehole_matching_gt_to_pred.items():
+                    boreholes.append(
+                        BoreholePredictionsWithGroundTruth(
+                            predictions=file_predictions.borehole_predictions_list[borehole_idx],
+                            ground_truth=ground_truth_for_file[gt_idx],
+                        )
+                    )
+            files.append(
+                FilePredictionsWithGroundTruth(
+                    file_predictions.file_name, file_predictions.file_metadata.language, boreholes
+                )
+            )
+        return AllBoreholePredictionsWithGroundTruth(files)

--- a/src/stratigraphy/util/file_predictions.py
+++ b/src/stratigraphy/util/file_predictions.py
@@ -2,15 +2,8 @@
 
 import dataclasses
 
-from stratigraphy.benchmark.ground_truth import GroundTruth
-from stratigraphy.evaluation.layer_evaluator import LayerEvaluator
 from stratigraphy.metadata.metadata import FileMetadata
-from stratigraphy.util.borehole_predictions import (
-    BoreholePredictions,
-    BoreholePredictionsWithGroundTruth,
-    FilePredictionsWithGroundTruth,
-)
-from stratigraphy.util.predictions import AllBoreholePredictionsWithGroundTruth
+from stratigraphy.util.borehole_predictions import BoreholePredictions
 
 
 @dataclasses.dataclass
@@ -34,98 +27,3 @@ class FilePredictions:
             **self.file_metadata.to_json(),
             "boreholes": [borehole.to_json() for borehole in self.borehole_predictions_list],
         }
-
-
-class OverallFilePredictions:
-    """A class to represent predictions for all files."""
-
-    def __init__(self) -> None:
-        """Initializes the OverallFilePredictions object."""
-        self.file_predictions_list: list[FilePredictions] = []
-        self.matching_pred_to_gt_boreholes = dict()  # set when evaluating layers
-
-    def add_file_predictions(self, file_predictions: FilePredictions) -> None:
-        """Add file predictions to the list of file predictions.
-
-        Args:
-            file_predictions (FilePredictions): The file predictions to add.
-        """
-        self.file_predictions_list.append(file_predictions)
-
-    def get_metadata_as_dict(self) -> dict:
-        """Returns the metadata of the predictions as a dictionary.
-
-        Returns:
-            dict: The metadata of the predictions as a dictionary.
-        """
-        return {
-            "_".join([file_prediction.file_name, str(borehole_prediction.borehole_index)]): {
-                "file_metadata": file_prediction.file_metadata.to_json(),
-                "borehole_metadata": borehole_prediction.metadata.to_json(),
-            }
-            for file_prediction in self.file_predictions_list
-            for borehole_prediction in file_prediction.borehole_predictions_list
-        }
-
-    def to_json(self) -> dict:
-        """Converts the object to a dictionary by merging individual file predictions.
-
-        Returns:
-            dict: A dictionary representation of the object.
-        """
-        return {fp.file_name: fp.to_json() for fp in self.file_predictions_list}
-
-    @classmethod
-    def from_json(cls, prediction_from_file: dict) -> "OverallFilePredictions":
-        """Converts a dictionary to an object.
-
-        Args:
-            prediction_from_file (dict): A dictionary representing the predictions.
-
-        Returns:
-            OverallFilePredictions: The object.
-        """
-        overall_file_predictions = OverallFilePredictions()
-        for file_name, file_data in prediction_from_file.items():
-            file_metadata = FileMetadata.from_json(file_data, file_name)
-
-            borehole_list = [BoreholePredictions.from_json(bh_data, file_name) for bh_data in file_data["boreholes"]]
-
-            overall_file_predictions.add_file_predictions(FilePredictions(borehole_list, file_metadata, file_name))
-        return overall_file_predictions
-
-    def match_with_ground_truth(self, ground_truth: GroundTruth) -> AllBoreholePredictionsWithGroundTruth:
-        """Match the extracted boreholes with corresponding boreholes in the ground truth data.
-
-        Args:
-            ground_truth (GroundTruth): The ground truth.
-
-        Returns:
-            AllBoreholePredictionsWithGroundTruth: all predictions per borehole with associated ground truth data.
-        """
-        files = []
-        for file_predictions in self.file_predictions_list:
-            boreholes = []
-            ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
-            if ground_truth_for_file:
-                borehole_idx_to_ground_truth_idx = {
-                    borehole_idx: gt_idx
-                    for gt_idx, borehole_idx in LayerEvaluator.evaluate_borehole(
-                        [bh.layers_in_borehole for bh in file_predictions.borehole_predictions_list],
-                        {idx: borehole_data["layers"] for idx, borehole_data in ground_truth_for_file.items()},
-                    ).items()
-                }
-                for borehole_idx, predictions in enumerate(file_predictions.borehole_predictions_list):
-                    if borehole_idx in borehole_idx_to_ground_truth_idx:
-                        borehole_ground_truth = ground_truth_for_file[borehole_idx_to_ground_truth_idx[borehole_idx]]
-                    else:
-                        borehole_ground_truth = {}
-                    boreholes.append(
-                        BoreholePredictionsWithGroundTruth(predictions=predictions, ground_truth=borehole_ground_truth)
-                    )
-            files.append(
-                FilePredictionsWithGroundTruth(
-                    file_predictions.file_name, file_predictions.file_metadata.language, boreholes
-                )
-            )
-        return AllBoreholePredictionsWithGroundTruth(files)

--- a/src/stratigraphy/util/file_predictions.py
+++ b/src/stratigraphy/util/file_predictions.py
@@ -8,10 +8,7 @@ from stratigraphy.util.borehole_predictions import BoreholePredictions
 
 @dataclasses.dataclass
 class FilePredictions:
-    """A class to represent predictions for a single file.
-
-    It is responsible for grouping all the lists of elements into a single list of BoreholePrediction objects.
-    """
+    """A class to represent predictions for a single file."""
 
     borehole_predictions_list: list[BoreholePredictions]
     file_metadata: FileMetadata

--- a/src/stratigraphy/util/overall_file_predictions.py
+++ b/src/stratigraphy/util/overall_file_predictions.py
@@ -17,7 +17,6 @@ class OverallFilePredictions:
     def __init__(self) -> None:
         """Initializes the OverallFilePredictions object."""
         self.file_predictions_list: list[FilePredictions] = []
-        self.matching_pred_to_gt_boreholes = dict()  # set when evaluating layers
 
     def add_file_predictions(self, file_predictions: FilePredictions) -> None:
         """Add file predictions to the list of file predictions.
@@ -71,6 +70,8 @@ class OverallFilePredictions:
 
     def match_with_ground_truth(self, ground_truth: GroundTruth) -> AllBoreholePredictionsWithGroundTruth:
         """Match the extracted boreholes with corresponding boreholes in the ground truth data.
+
+        This is done by comparing the layers of the extracted boreholes with those in the groundtruth.
 
         Args:
             ground_truth (GroundTruth): The ground truth.

--- a/src/stratigraphy/util/overall_file_predictions.py
+++ b/src/stratigraphy/util/overall_file_predictions.py
@@ -1,0 +1,92 @@
+"""Classes for predictions per PDF file."""
+
+from stratigraphy.benchmark.ground_truth import GroundTruth
+from stratigraphy.evaluation.layer_evaluator import LayerEvaluator
+from stratigraphy.metadata.metadata import FileMetadata
+from stratigraphy.util.borehole_predictions import (
+    BoreholePredictions,
+    FilePredictionsWithGroundTruth,
+)
+from stratigraphy.util.file_predictions import FilePredictions
+from stratigraphy.util.predictions import AllBoreholePredictionsWithGroundTruth
+
+
+class OverallFilePredictions:
+    """A class to represent predictions for all files."""
+
+    def __init__(self) -> None:
+        """Initializes the OverallFilePredictions object."""
+        self.file_predictions_list: list[FilePredictions] = []
+        self.matching_pred_to_gt_boreholes = dict()  # set when evaluating layers
+
+    def add_file_predictions(self, file_predictions: FilePredictions) -> None:
+        """Add file predictions to the list of file predictions.
+
+        Args:
+            file_predictions (FilePredictions): The file predictions to add.
+        """
+        self.file_predictions_list.append(file_predictions)
+
+    def get_metadata_as_dict(self) -> dict:
+        """Returns the metadata of the predictions as a dictionary.
+
+        Returns:
+            dict: The metadata of the predictions as a dictionary.
+        """
+        return {
+            "_".join([file_prediction.file_name, str(borehole_prediction.borehole_index)]): {
+                "file_metadata": file_prediction.file_metadata.to_json(),
+                "borehole_metadata": borehole_prediction.metadata.to_json(),
+            }
+            for file_prediction in self.file_predictions_list
+            for borehole_prediction in file_prediction.borehole_predictions_list
+        }
+
+    def to_json(self) -> dict:
+        """Converts the object to a dictionary by merging individual file predictions.
+
+        Returns:
+            dict: A dictionary representation of the object.
+        """
+        return {fp.file_name: fp.to_json() for fp in self.file_predictions_list}
+
+    @classmethod
+    def from_json(cls, prediction_from_file: dict) -> "OverallFilePredictions":
+        """Converts a dictionary to an object.
+
+        Args:
+            prediction_from_file (dict): A dictionary representing the predictions.
+
+        Returns:
+            OverallFilePredictions: The object.
+        """
+        overall_file_predictions = OverallFilePredictions()
+        for file_name, file_data in prediction_from_file.items():
+            file_metadata = FileMetadata.from_json(file_data, file_name)
+
+            borehole_list = [BoreholePredictions.from_json(bh_data, file_name) for bh_data in file_data["boreholes"]]
+
+            overall_file_predictions.add_file_predictions(FilePredictions(borehole_list, file_metadata, file_name))
+        return overall_file_predictions
+
+    def match_with_ground_truth(self, ground_truth: GroundTruth) -> AllBoreholePredictionsWithGroundTruth:
+        """Match the extracted boreholes with corresponding boreholes in the ground truth data.
+
+        Args:
+            ground_truth (GroundTruth): The ground truth.
+
+        Returns:
+            AllBoreholePredictionsWithGroundTruth: all predictions per borehole with associated ground truth data.
+        """
+        files = []
+        for file_predictions in self.file_predictions_list:
+            boreholes = []
+            ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
+            if ground_truth_for_file:
+                boreholes = LayerEvaluator.match_predictions_with_ground_truth(file_predictions, ground_truth_for_file)
+            files.append(
+                FilePredictionsWithGroundTruth(
+                    file_predictions.file_name, file_predictions.file_metadata.language, boreholes
+                )
+            )
+        return AllBoreholePredictionsWithGroundTruth(files)

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -134,7 +134,7 @@ class AllBoreholePredictionsWithGroundTruth:
                 file.filename,
                 [
                     BoreholeMetadataWithGroundTruth(
-                        predictions.predictions.metadata,
+                        predictions.predictions.metadata if predictions.predictions else None,
                         predictions.ground_truth.get("metadata", {}),
                     )
                     for predictions in file.boreholes
@@ -161,7 +161,7 @@ class AllBoreholePredictionsWithGroundTruth:
                 file.language,
                 [
                     BoreholeLayersWithGroundTruth(
-                        predictions.predictions.layers_in_borehole,
+                        predictions.predictions.layers_in_borehole if predictions.predictions else None,
                         predictions.ground_truth.get("layers", []),
                     )
                     for predictions in file.boreholes
@@ -202,7 +202,7 @@ class AllBoreholePredictionsWithGroundTruth:
                 file.filename,
                 [
                     BoreholeGroundwaterWithGroundTruth(
-                        predictions.predictions.groundwater_in_borehole,
+                        predictions.predictions.groundwater_in_borehole if predictions.predictions else None,
                         predictions.ground_truth.get("groundwater", []) or [],  # value can be `None`
                     )
                     for predictions in file.boreholes

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -114,12 +114,15 @@ class BoreholeListBuilder:
 
     @staticmethod
     def _extend_list(lst: list[T], default_elem: T, target_length: int) -> list[T]:
-        # deepcopy is necessary, because the is_correct attribute is already stored on this object, but the same
-        # extracted value might be correct on one borehole and incorrect on another one.
+        """Extends a list with deep copies of a base element until it reaches the target length.
+
+        deepcopy is necessary, because the is_correct attribute is already stored on this object, but the same
+        extracted value might be correct on one borehole and incorrect on another one.
+        """
+
         def create_new_elem():
             return deepcopy(lst[0]) if lst else default_elem
 
-        """Extends a list with deep copies of a base element until it reaches the target length."""
         while len(lst) < target_length:
             lst.append(create_new_elem())  # Append copies to match the required length
 

--- a/tests/test_groundwater.py
+++ b/tests/test_groundwater.py
@@ -147,6 +147,7 @@ def test_evaluate_with_ground_truth(groundtruth, example_groundwater_1: dict):
     # Sample groundwater entries
     groundwater_entries = example_groundwater_1
 
+    # dictionary used to "manually" build the FileGroundwaterWithGroundTruth object
     pred_to_gt_matching = {"example_borehole_profile.pdf": {0: 0}}
     evaluator = GroundwaterEvaluator(
         groundwater_list=[
@@ -182,6 +183,7 @@ def test_evaluate_multiple_entries(groundtruth, example_groundwater_1, example_g
     # Sample groundwater entries
     groundwater_entries = {**example_groundwater_1, **example_groundwater_2}
 
+    # dictionary used to "manually" build the FileGroundwaterWithGroundTruth object
     pred_to_gt_matching = {"example_borehole_profile.pdf": {0: 0}, "example_borehole_profile_2.pdf": {0: 1, 1: 0}}
     evaluator = GroundwaterEvaluator(
         groundwater_list=[

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -7,11 +7,13 @@ import fitz
 import pytest
 from stratigraphy.benchmark.ground_truth import GroundTruth
 from stratigraphy.data_extractor.data_extractor import FeatureOnPage
+from stratigraphy.evaluation.layer_evaluator import LayerEvaluator
 from stratigraphy.evaluation.utility import count_against_ground_truth
 from stratigraphy.groundwater.groundwater_extraction import Groundwater, GroundwatersInBorehole
-from stratigraphy.layer.layer import LayersInBorehole
+from stratigraphy.layer.layer import Layer, LayerDepths, LayerDepthsEntry, LayersInBorehole
 from stratigraphy.metadata.coordinate_extraction import CoordinateEntry, LV95Coordinate
 from stratigraphy.metadata.metadata import BoreholeMetadata, FileMetadata
+from stratigraphy.text.textblock import MaterialDescription
 from stratigraphy.util.borehole_predictions import BoreholePredictionsWithGroundTruth, FilePredictionsWithGroundTruth
 from stratigraphy.util.file_predictions import FilePredictions
 from stratigraphy.util.overall_file_predictions import OverallFilePredictions
@@ -66,9 +68,88 @@ def sample_file_prediction() -> FilePredictions:
 
 
 @pytest.fixture
+def file_prediction_with_two_boreholes() -> FilePredictions:
+    """Fixture to create a sample FilePredictions object that has two boreholes."""
+    filename = "example_borehole_profile.pdf"
+    coord = FeatureOnPage(
+        feature=LV95Coordinate(
+            east=CoordinateEntry(coordinate_value=2789456), north=CoordinateEntry(coordinate_value=1123012)
+        ),
+        rect=fitz.Rect(),
+        page=1,
+    )
+
+    layers_in_borehole = LayersInBorehole(
+        [
+            Layer(
+                material_description=FeatureOnPage(MaterialDescription(text=descr, lines=[]), fitz.Rect(), 0),
+                depths=LayerDepths(LayerDepthsEntry(start, fitz.Rect()), LayerDepthsEntry(end, fitz.Rect())),
+            )
+            for descr, start, end in [
+                ("HUMUS", None, 1),
+                ("KIES, grau", 1, 2),
+                ("sand", 2, 3),
+            ]
+        ]
+    )
+    layers_in_borehole_2 = LayersInBorehole(
+        [
+            Layer(
+                material_description=FeatureOnPage(MaterialDescription(text=descr, lines=[]), fitz.Rect(), 0),
+                depths=LayerDepths(LayerDepthsEntry(start, fitz.Rect()), LayerDepthsEntry(end, fitz.Rect())),
+            )
+            for descr, start, end in [
+                ("KIES, Sand,", 0.0, 0.5),
+                ("stein, sand", 0.5, 2.0),
+            ]
+        ]
+    )
+
+    dt_date = datetime(2024, 10, 1)
+    groundwater_on_page = FeatureOnPage(
+        feature=Groundwater(depth=100, date=dt_date, elevation=20),
+        page=1,
+        rect=fitz.Rect(0, 0, 100, 100),
+    )
+    groundwater_in_bh = GroundwatersInBorehole(groundwater_feature_list=[groundwater_on_page])
+
+    file_metadata = FileMetadata(language="en", filename=filename, page_dimensions=[Mock(width=10, height=20)])
+    metadata = BoreholeMetadata(coordinates=coord, elevation=None)
+
+    return FilePredictions(
+        [
+            BoreholePredictions(
+                borehole_index=0,
+                layers_in_borehole=layers_in_borehole,
+                file_name=filename,
+                metadata=metadata,
+                groundwater_in_borehole=groundwater_in_bh,
+                bounding_boxes=[],
+            ),
+            BoreholePredictions(
+                borehole_index=1,
+                layers_in_borehole=layers_in_borehole_2,
+                file_name=filename,
+                metadata=metadata,
+                groundwater_in_borehole=groundwater_in_bh,
+                bounding_boxes=[],
+            ),
+        ],
+        file_name=filename,
+        file_metadata=file_metadata,
+    )
+
+
+@pytest.fixture
 def groundtruth():
     """Path to the ground truth file."""
     return GroundTruth("example/example_groundtruth.json")
+
+
+@pytest.fixture
+def groundtruth_with_two_boreholes():
+    """Path to the ground truth file that has two boreholes."""
+    return GroundTruth("example/example_layers_groundtruth.json")
 
 
 @pytest.fixture
@@ -119,14 +200,27 @@ def test_overall_file_predictions(sample_file_prediction: FilePredictions):
     assert set(result.keys()) == {"example_borehole_profile.pdf"}
 
 
+def test_evaluate_layer_matching(
+    file_prediction_with_two_boreholes: FilePredictions, groundtruth_with_two_boreholes: GroundTruth
+):
+    """Test the matching of predictions to ground truths when multiple boreholes are present in one document."""
+    groundtruth_for_file = groundtruth_with_two_boreholes.for_file("example_borehole_profile.pdf")
+    sample_file_prediction_with_ground_truth: FilePredictionsWithGroundTruth = (
+        LayerEvaluator.match_predictions_with_ground_truth(file_prediction_with_two_boreholes, groundtruth_for_file)
+    )
+    # We test the matching by comparing the number of layers, one borehole has 2, the other has 3.
+    assert all(
+        [
+            len(pred.predictions.layers_in_borehole.layers) == len(pred.ground_truth["layers"])
+            for pred in sample_file_prediction_with_ground_truth
+        ]
+    )
+
+
 def test_evaluate_metadata_extraction(sample_file_prediction_with_ground_truth: FilePredictionsWithGroundTruth):
     """Test evaluate_metadata_extraction method of OverallFilePredictions."""
-    overall_predictions = OverallFilePredictions()
-    overall_predictions.add_file_predictions(sample_file_prediction)
-    all_predsk_with_gt = AllBoreholePredictionsWithGroundTruth([sample_file_prediction_with_ground_truth])
-
-    #
-    metadata_metrics = all_predsk_with_gt.evaluate_metadata_extraction()
+    all_predictions_with_gt = AllBoreholePredictionsWithGroundTruth([sample_file_prediction_with_ground_truth])
+    metadata_metrics = all_predictions_with_gt.evaluate_metadata_extraction()
 
     assert metadata_metrics is not None  # Ensure the evaluation returns a result
 


### PR DESCRIPTION
@TicaGit something like this is what I had in mind when reviewing the other PR.

It still needs some cleaning up, and I'm not entirely happy with the amount of "wrapper dataclasses" that I had to define for this, but overall the logic seems much cleaner / easier to follow like this.

Unit tests don't work yet. The main problem there is that we have unit tests that seem to test two things at once: the matching of extracted data with ground truth data, as well as the evaluation of the individual attributes. We should probably split that into two.

In the evaluation, extracted data without a corresponding ground truth now always counts as false positives. This decreases the scores a little bit, also for Geoquat, as there are a few examples where one borehole in the ground truth is extracted in two parts by the pipeline. I think that in this case, it is correct that we score this lower, than when we would extract the same layers as a single borehole.