### PR TITLE
Workaround for issue with cache contamination in pymupdf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "langdetect>=1.0.9",
     "regex",
     "backoff",
-    "PyMuPDF>=1.23.26",
+    "PyMuPDF>=1.25.4",
     "opencv-python-headless",
     "quads>=1.1.0",
     "numpy<2",

--- a/src/app/api/v1/endpoints/create_pngs.py
+++ b/src/app/api/v1/endpoints/create_pngs.py
@@ -25,6 +25,10 @@ def create_pngs(aws_filename: Path) -> PNGResponse:
     # Get the filename from the path
     filename = aws_filename.stem
 
+    # Clear cache to avoid cache contamination across different files, which can cause incorrect visualizations;
+    # see also https://github.com/swisstopo/swissgeol-boreholes-suite/issues/1935
+    fitz.TOOLS.store_shrink(100)
+
     # Initialize the S3 client
     pdf_document = load_pdf_from_aws(aws_filename)
 

--- a/src/stratigraphy/annotations/draw.py
+++ b/src/stratigraphy/annotations/draw.py
@@ -73,6 +73,10 @@ def draw_predictions(
             is_elevation_correct = None
 
         try:
+            # Clear cache to avoid cache contamination across different files, which can cause incorrect
+            # visualizations; see also https://github.com/swisstopo/swissgeol-boreholes-suite/issues/1935
+            fitz.TOOLS.store_shrink(100)
+
             with fitz.Document(directory / file_prediction.file_name) as doc:
                 for page_index, page in enumerate(doc):
                     page_number = page_index + 1


### PR DESCRIPTION
Ensure the cache is clear before creating a visualization of some PDF. Otherwise, it can occur that certain cached objects from one PDF will break the visualization of another PDF. (See also https://github.com/swisstopo/swissgeol-boreholes-suite/issues/1935.)

E.g. this error occurs with Nagra PDFs when first processing `Dossier III_Appendix A_BOZ1-1_Lithostratigraphy_1_2500_0000-1037.39.pdf` and then `Dossier III_Appendix A_BUL1-1_Lithostratigraphy_1_2500_0000-1370.pdf`. The representation of the first (quaternary) layer will then look blue instead of black-on-white.

I will report this as an issue to the PyMuPDF library. -> https://github.com/pymupdf/PyMuPDF/issues/4388