### PR TITLE
Feat/issue 151/multiple borehole smart merge

### DIFF
--- a/src/stratigraphy/depths_materials_column_pairs/bounding_boxes.py
+++ b/src/stratigraphy/depths_materials_column_pairs/bounding_boxes.py
@@ -83,3 +83,26 @@ class PageBoundingBoxes:
             material_description_bbox=BoundingBox(pair.material_description_rect),
             page=page_number,
         )
+
+    def get_outer_rect(self) -> fitz.Rect:
+        """Returns the extreme bounding rectangle.
+
+        Computes the smallest rectangle that encloses all bounding boxes in this PageBoundingBoxes object.
+
+        Returns:
+            fitz.Rect: The bounding rectangle.
+        """
+        all_bboxes = [self.material_description_bbox] + self.depth_column_entry_bboxes
+        if self.sidebar_bbox:
+            all_bboxes.append(self.sidebar_bbox)
+
+        if not all_bboxes:
+            raise ValueError("No bounding boxes available to determine extreme coordinates.")
+
+        # Compute extreme coordinates
+        min_x = min(bbox.rect.x0 for bbox in all_bboxes)
+        min_y = min(bbox.rect.y0 for bbox in all_bboxes)
+        max_x = max(bbox.rect.x1 for bbox in all_bboxes)
+        max_y = max(bbox.rect.y1 for bbox in all_bboxes)
+
+        return fitz.Rect(min_x, min_y, max_x, max_y)

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -105,7 +105,7 @@ class Groundwater(ExtractedFeature):
             "elevation": self.elevation,
         }
 
-    def set_elevation_info(self, terrain_elevation):
+    def set_elevation_infos(self, terrain_elevation):
         if self.depth is None:  # if was not already set
             self.depth = round(terrain_elevation - self.elevation, 2)
         if self.elevation is None:  # if was not already set
@@ -140,7 +140,7 @@ class GroundwatersInBorehole:
 
     def set_elevation_infos(self, terrain_elevation):
         for entry in self.groundwater_feature_list:
-            entry.feature.set_elevation_info(terrain_elevation)
+            entry.feature.set_elevation_infos(terrain_elevation)
 
 
 @dataclass

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -119,7 +119,7 @@ class Groundwater(ExtractedFeature):
         if round(terrain_elevation - self.elevation, 2) - self.depth > prec:  # account for approx, up to 0.5m
             logger.warning(
                 f"Extracted groundwater height informations (depth = {self.depth}, elevation = {self.elevation}) "
-                f"do not match the calcul 'terrain_elevation - gw_elevation = gw_depth': {terrain_elevation} "
+                f"do not match the constraint 'terrain_elevation - gw_elevation = gw_depth': {terrain_elevation} "
                 f"- {self.elevation} = {round(terrain_elevation - self.elevation, 2)} != {self.depth} ± {prec}"
             )
 

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -345,8 +345,6 @@ class GroundwaterLevelExtractor(DataExtractor):
             page_number (int): The page number (1-based) of the PDF document.
             lines (list[TextLine]): The lines of text to extract the groundwater information from.
             document (fitz.Document): The document used to extract groundwater from illustration.
-            terrain_elevation (FeatureOnPage[Elevation] | None): The elevation of the terrain for the borehole (if any
-                is known)
 
         Returns:
             list[FeatureOnPage[Groundwater]]: the extracted coordinates (if any)

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -105,6 +105,12 @@ class Groundwater(ExtractedFeature):
             "elevation": self.elevation,
         }
 
+    def set_elevation_info(self, terrain_elevation):
+        if self.depth is None:  # if was not already set
+            self.depth = round(terrain_elevation - self.elevation, 2)
+        if self.elevation is None:  # if was not already set
+            self.elevation = round(terrain_elevation - self.depth, 2)
+
 
 @dataclass
 class GroundwatersInBorehole:
@@ -131,6 +137,10 @@ class GroundwatersInBorehole:
             GroundwatersInBorehole: the GroundwatersInBorehole object
         """
         return cls([FeatureOnPage.from_json(gw_data, Groundwater) for gw_data in json_object])
+
+    def set_elevation_infos(self, terrain_elevation):
+        for entry in self.groundwater_feature_list:
+            entry.feature.set_elevation_info(terrain_elevation)
 
 
 @dataclass

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -105,7 +105,12 @@ class Groundwater(ExtractedFeature):
             "elevation": self.elevation,
         }
 
-    def set_elevation_infos(self, terrain_elevation):
+    def set_elevation_infos(self, terrain_elevation: float):
+        """Sets the depth and elevation of the groundwater.
+
+        Args:
+            terrain_elevation (float): The elevation of the terrain at the top of the borehole.
+        """
         if self.depth is None:  # if was not already set
             self.depth = round(terrain_elevation - self.elevation, 2)
         if self.elevation is None:  # if was not already set
@@ -138,7 +143,12 @@ class GroundwatersInBorehole:
         """
         return cls([FeatureOnPage.from_json(gw_data, Groundwater) for gw_data in json_object])
 
-    def set_elevation_infos(self, terrain_elevation):
+    def set_elevation_infos(self, terrain_elevation: float):
+        """Sets the depth and elevation of all groundwater entries.
+
+        Args:
+            terrain_elevation (float): The elevation of the terrain at the top of the borehole.
+        """
         for entry in self.groundwater_feature_list:
             entry.feature.set_elevation_infos(terrain_elevation)
 

--- a/src/stratigraphy/groundwater/gw_illustration_template_matching.py
+++ b/src/stratigraphy/groundwater/gw_illustration_template_matching.py
@@ -47,7 +47,6 @@ def get_groundwater_from_illustration(
         lines (list[TextLine]): The lines of text to extract the groundwater information from.
         page_number (int): The page number (1-based) of the PDF document.
         document (fitz.Document): The document to extract groundwater from illustration from.
-        terrain_elevation (Elevation | None): The elevation of the terrain.
 
     Returns:
         list[FeatureOnPage[Groundwater]]: the extracted groundwater information

--- a/src/stratigraphy/groundwater/utility.py
+++ b/src/stratigraphy/groundwater/utility.py
@@ -11,13 +11,13 @@ def extract_date(text: str) -> tuple[date | None, str | None]:
 
     if not date_match:
         return None, None
-    original_data_str = date_match.group(0)
+    original_date_str = date_match.group(0)
     cleaned_date_str = f"{date_match.group(1)}.{date_match.group(2)}.{date_match.group(3)}"
     date_format = "%d.%m.%y" if len(date_match.group(3)) == 2 else "%d.%m.%Y"
     # Validate date before parsing
     if not is_valid_date(cleaned_date_str, date_format):
         return None, None
-    return datetime.strptime(cleaned_date_str, date_format).date(), original_data_str
+    return datetime.strptime(cleaned_date_str, date_format).date(), original_date_str
 
 
 def is_valid_date(date_str: str, date_format: str) -> bool:

--- a/src/stratigraphy/groundwater/utility.py
+++ b/src/stratigraphy/groundwater/utility.py
@@ -7,14 +7,26 @@ import regex
 
 def extract_date(text: str) -> tuple[date | None, str | None]:
     """Extract the date from a string in the format dd.mm.yyyy or dd.mm.yy."""
-    date_match = regex.search(r"(\d{1,2}\.\d{1,2}\.\d{2,4})", text)
+    date_match = regex.search(r"(\d{1,2})\s*\.\s*(\d{1,2})\s*\.\s*(\d{2,4})", text)
 
     if not date_match:
         return None, None
+    original_data_str = date_match.group(0)
+    cleaned_date_str = f"{date_match.group(1)}.{date_match.group(2)}.{date_match.group(3)}"
+    date_format = "%d.%m.%y" if len(date_match.group(3)) == 2 else "%d.%m.%Y"
+    # Validate date before parsing
+    if not is_valid_date(cleaned_date_str, date_format):
+        return None, None
+    return datetime.strptime(cleaned_date_str, date_format).date(), original_data_str
 
-    date_str = date_match.group(1)
-    date_format = "%d.%m.%y" if len(date_str.split(".")[2]) == 2 else "%d.%m.%Y"
-    return datetime.strptime(date_str, date_format).date(), date_str
+
+def is_valid_date(date_str: str, date_format: str) -> bool:
+    """Check if a date string is valid for a given format."""
+    try:
+        datetime.strptime(date_str, date_format)  # Try parsing the date
+        return True
+    except ValueError:
+        return False
 
 
 def extract_depth(text: str, max_depth: int) -> float | None:

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -271,15 +271,10 @@ def start_pipeline(
                     # pages, requiring multiple BoundingBoxes, one for each page.
                     material_description_bbox = extracted_borehole.bounding_boxes[0].material_description_bbox
 
-                    # TODO: first match elevation with boreholes more intelligently, then pass the correct value to
-                    # the groundwater extraction logic
-                    # probably do after matching
                     terrain_elevation = None
-                    if metadata.elevations:
-                        if len(metadata.elevations) > borehole_index:
-                            terrain_elevation = metadata.elevations[borehole_index]
-                        else:
-                            terrain_elevation = metadata.elevations[0]
+                    if metadata.elevations and len(metadata.elevations) == 1:
+                        # only one elevation found, can set it during extraction phase
+                        terrain_elevation = metadata.elevations[0]
 
                     groundwater_entries_near_bbox = GroundwaterLevelExtractor.near_material_description(
                         document=doc,
@@ -333,6 +328,9 @@ def start_pipeline(
                 elevations_list=metadata.elevations,
                 coordinates_list=metadata.coordinates,
             ).build()
+            # now that the matching is done, the depths of groundwater can be set if multiple elevations were found
+            for borehole in borehole_predictions_list:
+                borehole.set_groundwater_elevation_infos()
 
             # Add file predictions
             predictions.add_file_predictions(FilePredictions(borehole_predictions_list, file_metadata, filename))

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -291,7 +291,6 @@ def start_pipeline(
                         if groundwater_entry not in seen_entry:
                             aggregated_groundwater_entries[borehole_index].append(groundwater_entry)
 
-                # TODO: Add remove duplicates here!
                 if page_index > 0:
                     layer_with_bb_predictions = remove_duplicate_layers(
                         previous_page=doc[page_index - 1],

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -273,6 +273,7 @@ def start_pipeline(
 
                     # TODO: first match elevation with boreholes more intelligently, then pass the correct value to
                     # the groundwater extraction logic
+                    # probably do after matching
                     terrain_elevation = None
                     if metadata.elevations:
                         if len(metadata.elevations) > borehole_index:

--- a/src/stratigraphy/metadata/elevation_extraction.py
+++ b/src/stratigraphy/metadata/elevation_extraction.py
@@ -108,7 +108,7 @@ class ElevationExtractor(DataExtractor):
 
             try:
                 extracted_elevation = self.get_elevation_from_lines(elevation_lines, page)
-                if extracted_elevation.feature.elevation:
+                if extracted_elevation.feature.elevation and extracted_elevation not in extracted_elevation_list:
                     extracted_elevation_list.append(extracted_elevation)
             except ValueError as error:
                 logger.warning("ValueError: %s", error)
@@ -129,10 +129,6 @@ class ElevationExtractor(DataExtractor):
         Returns:
             list[FeatureOnPage[Elevation]]: The best extracted elevation information.
         """
-        # first remove the duplicate. Even if 2 boreholes have the same elevation, it will be handled later. Keeping
-        # duplicates here could only harm us.
-        extracted_elevation_list = list({obj.feature.elevation: obj for obj in extracted_elevation_list}.values())
-
         # Sort the extracted elevation information by elevation with the highest elevation first
         extracted_elevation_list.sort(key=lambda x: x.feature.elevation, reverse=True)
 

--- a/src/stratigraphy/util/borehole_predictions.py
+++ b/src/stratigraphy/util/borehole_predictions.py
@@ -54,6 +54,7 @@ class BoreholePredictions:
         )
 
     def set_groundwater_elevation_infos(self):
+        """Sets the depth and elevation of the groundwater entries of this borehole."""
         if not self.metadata.elevation:
             return
         borehole_terrain_elevation = self.metadata.elevation.feature.elevation

--- a/src/stratigraphy/util/borehole_predictions.py
+++ b/src/stratigraphy/util/borehole_predictions.py
@@ -53,6 +53,12 @@ class BoreholePredictions:
             [PageBoundingBoxes.from_json(bbox_json) for bbox_json in json_object["bounding_boxes"]],
         )
 
+    def set_groundwater_elevation_infos(self):
+        if not self.metadata.elevation:
+            return
+        borehole_terrain_elevation = self.metadata.elevation.feature.elevation
+        self.groundwater_in_borehole.set_elevation_infos(borehole_terrain_elevation)
+
 
 @dataclasses.dataclass
 class BoreholePredictionsWithGroundTruth:

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -70,6 +70,7 @@ class BoreholeListBuilder:
     def build(self) -> list[BoreholePredictions]:
         """Creates a list of BoreholePredictions after ensuring all lists have the same length."""
         self._extend_length_to_match_boreholes_num_pred()
+        self._match_elements_to_borehole()
 
         return [
             BoreholePredictions(
@@ -121,6 +122,30 @@ class BoreholeListBuilder:
             lst.append(create_new_elem())  # Append copies to match the required length
 
         return lst[:target_length]
+
+    def _match_elements_to_borehole(self):
+        # iterative matching
+        elevation_to_match = self._elevations_list
+
+        matched_borehole_layers = {}
+        while elevation_to_match:
+            for elevation in elevation_to_match:
+                avg_entry_pos = (elevation.rect.top_left + elevation.rect.bottom_right) / 2
+                best_dist = float("inf")
+                # we keep the elevation closest to the current groundwater entry
+                for borehole_layers in self._layers_with_bb_in_document.boreholes_layers_with_bb:
+                    # TODO compute extreme coord of borehole, match smallest
+                    best_match = borehole_layers
+                    dist = avg_entry_pos.distance_to(borehole_layers.rect)
+                    best_dist = dist
+                    if best_dist:
+                        pass
+                    # if dist < best_dist:
+                    #     if not entry.feature.depth and entry.feature.elevation:
+                    #         best_depth = round(terrain_elev.elevation - entry.feature.elevation, 2)
+                    #     if not entry.feature.elevation and entry.feature.depth:
+                    #         best_elev = round(terrain_elev.elevation - entry.feature.depth, 2)
+            matched_borehole_layers.add(best_match)
 
 
 @dataclasses.dataclass

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -132,8 +132,7 @@ class BoreholeListBuilder:
     ) -> dict[int, int]:
         """Matches extracted elements to boreholes.
 
-        This is done by minimizing the total sum of the distances from the elements to the coresponding layers.
-
+        This is done by minimizing the total sum of the distances from the elements to the corresponding layers.
         Args:
             element_list (list[FeatureOnPage  |  None  |  list[FeatureOnPage]]): list of element to match
 

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -57,8 +57,8 @@ class BoreholeListBuilder:
         """Initializes the BoreholeListBuilder with extracted borehole-related data.
 
         Args:
-            layers_with_bb_in_document (LayersInDocument): Object containing borehole layers extracted from the
-                document, along with its corespoding bounding boxes.
+            layers_with_bb_in_document (LayersInDocument): Object containing a list of extracted boreholes, each
+            holding a list of layers and a list of bounding boxes.
             file_name (str): The name of the processed document.
             groundwater_in_doc (GroundwaterInDocument): Contains detected groundwater entries for boreholes.
 
@@ -74,6 +74,8 @@ class BoreholeListBuilder:
 
     def build(self) -> list[BoreholePredictions]:
         """Creates a list of BoreholePredictions after ensuring all lists have the same length."""
+        if not self._layers_with_bb_in_document.boreholes_layers_with_bb:
+            return []  # no borehole identified
         self._extend_length_to_match_boreholes_num_pred()
 
         # for each element, perform the perfect matching with the borehole layers, and retrieve the matching dict
@@ -140,7 +142,8 @@ class BoreholeListBuilder:
         Returns:
             dict[int, int]: the dictionary containing the best mapping borehole_index -> element_index
         """
-        if not element_list[0]:
+        # solve trivial case and case where the elements are None
+        if len(element_list) == 1 or not element_list[0]:
             return {idx: idx for idx in range(len(element_list))}
 
         # Normalize input: Ensure all element in the outer list are a list (even if it's just one feature).

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -156,13 +156,10 @@ class BoreholeListBuilder:
 
         borehole_index_to_matched_elem_index = defaultdict(list)
         for i, feat in enumerate(element_list):
-            smallest_dist = None
-
-            for j, bboxes in enumerate(borehole_bounding_boxes):
-                dist = self._compute_distance(feat, bboxes)  # Compute the distance
-                if not smallest_dist or dist < smallest_dist:
-                    best_bbox_idx = j
-                    smallest_dist = dist
+            best_bbox_idx = min(
+                range(len(borehole_bounding_boxes)),
+                key=lambda j: self._compute_distance(feat, borehole_bounding_boxes[j]),
+            )
             borehole_index_to_matched_elem_index[best_bbox_idx].append(i)
 
         return borehole_index_to_matched_elem_index

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -137,7 +137,7 @@ class BoreholeListBuilder:
             element_list (list[FeatureOnPage  |  None  |  list[FeatureOnPage]]): list of element to match
 
         Returns:
-            dict[int, int]: the dictonary containing the best mapping borehole_index -> element_index
+            dict[int, int]: the dictionary containing the best mapping borehole_index -> element_index
         """
         if not element_list[0]:
             return {idx: idx for idx in range(len(element_list))}

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -133,6 +133,7 @@ class BoreholeListBuilder:
         """Matches extracted elements to boreholes.
 
         This is done by minimizing the total sum of the distances from the elements to the corresponding layers.
+
         Args:
             element_list (list[FeatureOnPage  |  None  |  list[FeatureOnPage]]): list of element to match
 

--- a/src/stratigraphy/util/predictions.py
+++ b/src/stratigraphy/util/predictions.py
@@ -165,6 +165,7 @@ class BoreholeListBuilder:
                 # the current boreholes layers don't appear on the page where the element is
                 return float("inf")
             outer_rect = bbox.get_outer_rect()  # Get the outer rect of the bounding box
+            # the center is the average of the extreme coordinates of each feature in the list.
             element_center = fitz.Point(0, 0)
             for feat in feat_list:
                 element_center += (feat.rect.top_left + feat.rect.bottom_right) / 2
@@ -173,14 +174,17 @@ class BoreholeListBuilder:
             dist = element_center.distance_to(outer_rect)
             return dist
 
-        # Fill the cost matrix with distances between each elevation and each borehole
+        # Fill the cost matrix with distances between each element and each borehole
         for i, feat_list in enumerate(elements_to_match):
             for j, bboxes in enumerate(borehole_bounding_boxes):
                 dist = distance_func(feat_list, bboxes)  # Compute the distance
                 cost_matrix[i, j] = dist
 
-        # Use the Hungarian algorithm (Kuhn-Munkres) to solve the assignment problem, finds the perfect matching
-        # with minimal cost.
+        # Use the Hungarian algorithm (Kuhn-Munkres) to solve the assignment problem.
+        # It finds the optimal one-to-one matching between elements and borehole layers such that the total
+        # distance (cost) between matched pairs is minimized.
+        # In simpler terms: out of all possible ways to pair elements with boreholes, this picks the combination that
+        # results in the shortest total distance between them.
         elem_indexes, layer_indexes = linear_sum_assignment(cost_matrix)
 
         # Store the index of the matched elements in a dictionary

--- a/tests/test_groundwater.py
+++ b/tests/test_groundwater.py
@@ -1,5 +1,7 @@
 """Tests for the groundwater module."""
 
+from datetime import date
+
 import pytest
 from stratigraphy.benchmark.ground_truth import GroundTruth
 from stratigraphy.data_extractor.data_extractor import FeatureOnPage
@@ -10,7 +12,25 @@ from stratigraphy.evaluation.groundwater_evaluator import (
     OverallGroundwaterMetrics,
 )
 from stratigraphy.groundwater.groundwater_extraction import Groundwater, GroundwatersInBorehole
+from stratigraphy.groundwater.utility import extract_date
 from stratigraphy.util.borehole_predictions import BoreholeGroundwaterWithGroundTruth, FileGroundwaterWithGroundTruth
+
+
+@pytest.fixture
+def date_test_cases():
+    """Provides test cases for extract_date function."""
+    return [
+        # Valid full-year dates
+        ("The date is 12.05.1998", date(1998, 5, 12), "12.05.1998"),
+        # Valid short-year dates
+        ("Event on 07.04.99", date(1999, 4, 7), "07.04.99"),
+        # Extra spaces
+        ("  10 . 03 . 1985 ", date(1985, 3, 10), "10 . 03 . 1985"),
+        # Invalid dates
+        ("Invalid format: 30.02.2020", None, None),
+        # No date in text
+        ("No date here!", None, None),
+    ]
 
 
 @pytest.fixture
@@ -53,6 +73,12 @@ def groundwater_at_3m22() -> dict:
         },
         Groundwater,
     )
+
+
+def test_extract_date(date_test_cases):
+    """Test extract_date function with various inputs."""
+    for text, expected_date, expected_str in date_test_cases:
+        assert extract_date(text) == (expected_date, expected_str)
 
 
 def test_add_groundwater_metrics(sample_metrics):


### PR DESCRIPTION
Summary
This PR primarily addresses issue #151: Unreliable Assignment of Extracted Data to Borehole Profiles. Since this issue is related to groundwater data extraction, the PR also resolves issue #142 and its duplicate #118.

**Improvements in Data Assignment ("Smart Merge")**
- Borehole elements (elevation, coordinates, groundwater) are now correctly assigned to their respective borehole layers based on their position on the page, rather than relying on extraction order.
- BoreholeInDocument now stores all extracted groundwater data, but no assignments occur during extraction. Instead, all assignments happen in BoreholeListBuilder.build(), ensuring correctness.
- Elevation is no longer passed during the extraction phase. Missing groundwater attributes (depth, elevation) are assigned after matching for better accuracy and consistency.

**Groundwater Date Parsing Fixes**
- Improved regex to correctly match dates containing spaces (e.g., "24. 11.2017").
- Added error handling to prevent crashes when strings are incorrectly identified as dates.
