### PR TITLE
Fix/issue 127/pydantic depr warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,10 @@ line-length = 119
 convention = "google"
 
 [tool.pytest.ini_options]
+# Some deprecation warnings come from external libraries (botocore and SWIG). Since we can’t fix these in our code,
+# they are now ignored during test runs to keep the output clean. Link to the existing issues:
+# SWIG: https://github.com/pymupdf/PyMuPDF/issues/3931
+# boto3: https://github.com/boto/boto3/issues/3889
 filterwarnings = [
     "ignore:.*Swig.*has no __module__ attribute:DeprecationWarning",
     "ignore:datetime.datetime.utcnow:DeprecationWarning:botocore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,9 @@ line-length = 119
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:.*Swig.*has no __module__ attribute:DeprecationWarning",
+    "ignore:datetime.datetime.utcnow:DeprecationWarning:botocore"
+]

--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -222,7 +222,7 @@ class BoundingBoxesRequest(ABC, BaseModel):
         index (e.g., 1 for the first page), applicable for multi-page files like PDFs.""",
     )
 
-    model_config = ConfigDict(json_schema_extra={"example": {"filename": str(Path("1007.pdf")), "page_number": 1}})
+    model_config = ConfigDict(json_schema_extra={"example": {"filename": "1007.pdf", "page_number": 1}})
 
     @field_validator("filename", mode="before")
     @classmethod


### PR DESCRIPTION
This PR addresses issue #127. It removes deprecation warnings, that are especially appearing when running pytest.

**Pydantic 2.x Compatibility**
The code has been updated to follow the new Pydantic 2.x format:
  - Replaced the old Config class with model_config = ConfigDict(...) for setting model options.
  - Moved example values from Field(...) into json_schema_extra inside the ConfigDict.

**Ignoring Warnings from Third-Party Libraries**
Some deprecation warnings come from external libraries (botocore and SWIG). Since we can’t fix these in our code, they are now ignored during test runs to keep the output clean.