### PR TITLE
Fix/issue 146/false positive exact matches

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -1,5 +1,6 @@
 
 block_line_ratio: 0.20
+min_block_clearance: 5
 left_line_length_threshold: 7
 img_template_probability_threshold: 0.62
 

--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -1,6 +1,6 @@
 
 block_line_ratio: 0.20
-min_block_clearance: 5
+min_block_clearance: 10
 left_line_length_threshold: 7
 img_template_probability_threshold: 0.62
 

--- a/src/stratigraphy/depth/interval.py
+++ b/src/stratigraphy/depth/interval.py
@@ -7,9 +7,6 @@ import fitz
 from stratigraphy.lines.line import TextLine
 from stratigraphy.sidebar.sidebarentry import DepthColumnEntry
 from stratigraphy.text.textblock import TextBlock
-from stratigraphy.util.util import read_params
-
-matching_params = read_params("matching_params.yml")
 
 
 class Interval:

--- a/src/stratigraphy/depth/interval.py
+++ b/src/stratigraphy/depth/interval.py
@@ -7,6 +7,9 @@ import fitz
 from stratigraphy.lines.line import TextLine
 from stratigraphy.sidebar.sidebarentry import DepthColumnEntry
 from stratigraphy.text.textblock import TextBlock
+from stratigraphy.util.util import read_params
+
+matching_params = read_params("matching_params.yml")
 
 
 class Interval:
@@ -25,7 +28,7 @@ class AAboveBInterval(Interval):
     """Class for depth intervals where the upper depth is located above the lower depth on the page."""
 
     def matching_blocks(
-        self, all_blocks: list[TextBlock], block_index: int
+        self, all_blocks: list[TextBlock], block_index: int, min_block_clearance: int
     ) -> tuple[list[TextBlock], list[TextBlock], list[TextBlock]]:
         """Calculates pre, exact and post blocks for the boundary interval.
 
@@ -36,6 +39,7 @@ class AAboveBInterval(Interval):
         Args:
             all_blocks (list[TextBlock]): All blocks available blocks.
             block_index (int): Index of the current block.
+            min_block_clearance (int): The required space above and below a block to a have an exact match.
 
         Returns:
             tuple[list[TextBlock], list[TextBlock], list[TextBlock]]: Pre, exact and post blocks.
@@ -52,7 +56,7 @@ class AAboveBInterval(Interval):
             distances_above = [
                 current_block.rect.y0 - other.rect.y1 for other in all_blocks if other.rect.y0 < current_block.rect.y0
             ]
-            distance_above_ok_for_exact = len(distances_above) == 0 or min(distances_above) > 5
+            distance_above_ok_for_exact = len(distances_above) == 0 or min(distances_above) > min_block_clearance
 
             exact_match_blocks = []
             exact_match_index = block_index
@@ -69,7 +73,7 @@ class AAboveBInterval(Interval):
                         exact_match_index += 1
                         distances_below = [other.rect.y0 - exact_match_block.rect.y1 for other in all_blocks]
                         distances_below = [distance for distance in distances_below if distance > 0]
-                        can_end_exact_match = len(distances_below) == 0 or min(distances_below) > 5
+                        can_end_exact_match = len(distances_below) == 0 or min(distances_below) > min_block_clearance
                     else:
                         continue_exact_match = False
 

--- a/src/stratigraphy/sidebar/a_above_b_sidebar.py
+++ b/src/stratigraphy/sidebar/a_above_b_sidebar.py
@@ -233,7 +233,7 @@ class AAboveBSidebar(Sidebar[DepthColumnEntry]):
             if interval.start is None and interval.end.value == 0:
                 continue
 
-            pre, exact, post = interval.matching_blocks(all_blocks, block_index)
+            pre, exact, post = interval.matching_blocks(all_blocks, block_index, params["min_block_clearance"])
             block_index += len(pre) + len(exact) + len(post)
 
             current_blocks.extend(pre)


### PR DESCRIPTION
Resolves #146

The initial issue was not reproducible, and the problems on Nagra were mostly related to those parasite depths that does not belong to any material descriptions (see: https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/146#issuecomment-2786898212).

I remove the magic number and performed a quick parameter search, best value seems to be 10. (see https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/146#issuecomment-2789501775)