### PR TITLE
Fix/issue 119/layer identifier sidbar fix

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -1,6 +1,7 @@
 
 block_line_ratio: 0.20
 left_line_length_threshold: 7
+layer_identifier_acceptance_ratio: 0.5
 img_template_probability_threshold: 0.62
 
 depth_column_params:  # these params should be optimized as soon as there is reliable evaluation data

--- a/src/stratigraphy/extract.py
+++ b/src/stratigraphy/extract.py
@@ -88,7 +88,13 @@ class MaterialDescriptionRectWithSidebarExtractor:
             item for index, item in enumerate(material_descriptions_sidebar_pairs) if index not in to_delete
         ]
 
-        return [self._create_borehole_from_pair(pair) for pair in filtered_pairs]
+        # We order the boreholes with the highest score first. When one borehole is actually present in the ground
+        # truth, but more than one are detected, we want the most correct to be assigned
+        # TODO we actually should try to merge similar extracted boreholes to keep the most information possible.
+        return [
+            self._create_borehole_from_pair(pair)
+            for pair in sorted(filtered_pairs, key=lambda pair: pair.score_match, reverse=True)
+        ]
 
     def _create_borehole_from_pair(self, pair: MaterialDescriptionRectWithSidebar) -> ExtractedBorehole:
         bounding_boxes = PageBoundingBoxes.from_material_description_rect_with_sidebar(pair, self.page_number)

--- a/src/stratigraphy/sidebar/layer_identifier_sidebar.py
+++ b/src/stratigraphy/sidebar/layer_identifier_sidebar.py
@@ -132,15 +132,22 @@ class LayerIdentifierSidebar(Sidebar[LayerIdentifierEntry]):
             and self.rect().y1 <= rect.y1
         )
 
-    def _natural_sort_key(self, value):
+    def _standardize_key(self, value: str) -> list[str | int]:
         """Splits a string into parts: [int, str, int] for natural sorting.
 
         Example: '6d12)' → [6, 'd', 12]
+
+        Args:
+            value (str): the value to convert to standartized key.
+
+        Returns:
+            list[str | int]: the list containing the key in order.
         """
         value = value.strip().replace(")", "").lower()
 
         # Split into alternating numbers and letters
         parts = re.findall(r"\d+|[a-z]+", value)
+        # conversion to int needed because 2 < 12 for example (with strings, '12' < '2', because '1' < '2')
         key = [int(p) if p.isdigit() else p for p in parts]
         return key
 
@@ -156,8 +163,8 @@ class LayerIdentifierSidebar(Sidebar[LayerIdentifierEntry]):
         """
         valid_count = 0
         for entry, next_entry in zip(self.entries, self.entries[1:], strict=False):
-            current = self._natural_sort_key(entry.value)
-            next_ = self._natural_sort_key(next_entry.value)
+            current = self._standardize_key(entry.value)
+            next_ = self._standardize_key(next_entry.value)
 
             try:
                 if current < next_:

--- a/src/stratigraphy/sidebar/layer_identifier_sidebar.py
+++ b/src/stratigraphy/sidebar/layer_identifier_sidebar.py
@@ -1,5 +1,7 @@
 """Module for the layer identifier sidebars."""
 
+import logging
+import re
 from dataclasses import dataclass
 
 import fitz
@@ -8,10 +10,14 @@ from stratigraphy.depth.a_to_b_interval_extractor import AToBIntervalExtractor
 from stratigraphy.lines.line import TextLine
 from stratigraphy.text.textblock import TextBlock
 from stratigraphy.util.dataclasses import Line
+from stratigraphy.util.util import read_params
 
 from .interval_block_group import IntervalBlockGroup
 from .sidebar import Sidebar
 from .sidebarentry import LayerIdentifierEntry
+
+logger = logging.getLogger(__name__)
+matching_params = read_params("matching_params.yml")
 
 
 @dataclass
@@ -125,3 +131,44 @@ class LayerIdentifierSidebar(Sidebar[LayerIdentifierEntry]):
             and rect.y0 <= self.rect().y0
             and self.rect().y1 <= rect.y1
         )
+
+    def _natural_sort_key(self, value):
+        """Splits a string into parts: [int, str, int] for natural sorting.
+
+        Example: '6d12)' → [6, 'd', 12]
+        """
+        value = value.strip().replace(")", "").lower()
+
+        # Split into alternating numbers and letters
+        parts = re.findall(r"\d+|[a-z]+", value)
+        key = [int(p) if p.isdigit() else p for p in parts]
+        return key
+
+    def has_regular_progression(self):
+        """Checks if a LayerIdentifierSidebar object is valid.
+
+        This check is particularly useful to reject cases where columns of heights are detected, due to the letter
+            "m)" which could indicate meters (e.g., 350.0 m in deepwell Arsch). It also rejects some invalid sidebars
+            that appear in other documents.
+
+        Returns:
+            bool: Indicates whether the sidebar follows a logical order.
+        """
+        valid_count = 0
+        for entry, next_entry in zip(self.entries, self.entries[1:], strict=False):
+            current = self._natural_sort_key(entry.value)
+            next_ = self._natural_sort_key(next_entry.value)
+
+            try:
+                if current < next_:
+                    valid_count += 1
+            except TypeError as e:
+                # happens when comparing a string with an int, it is usually due to a extraction error (e.g. "e" < 2)
+                logger.warning(
+                    f"{e} encountered during comparison between {entry.value} and {next_entry.value}. This is "
+                    "typically due to extraction issues, such as mixing strings and numbers (l -> 1, q -> 9)."
+                )
+                continue
+
+        valid_ratio = valid_count / (len(self.entries) - 1)
+        return valid_ratio > matching_params["layer_identifier_acceptance_ratio"]

--- a/src/stratigraphy/sidebar/layer_identifier_sidebar_extractor.py
+++ b/src/stratigraphy/sidebar/layer_identifier_sidebar_extractor.py
@@ -69,7 +69,7 @@ class LayerIdentifierSidebarExtractor:
         result = []
         # Remove columns that are fully contained in a longer column
         # Also check that the columns are mostly ascending, both numerically and alphabetically (e.g. 2 < 3a < 3b
-        # < 5 is valid). Some errors are tolerated, as the indicators (especially in Geneva) sometimes carry a 
+        # < 5 is valid). Some errors are tolerated, as the indicators (especially in Geneva) sometimes carry a
         # semantic meaning instead of being strictly ordered (e.g. geoquat/validation/9394.pdf), and we also need to
         # account for human or OCR mistakes. We only reject a column if the error ratio is bigger than the parameter
         # layer_identifier_acceptance_ratio specified in the config file.

--- a/src/stratigraphy/sidebar/layer_identifier_sidebar_extractor.py
+++ b/src/stratigraphy/sidebar/layer_identifier_sidebar_extractor.py
@@ -68,10 +68,11 @@ class LayerIdentifierSidebarExtractor:
 
         result = []
         # Remove columns that are fully contained in a longer column
-        # Also check which columns do not follow a logical progression. Values should ascend numerically and
-        # alphabetically (e.g. 2 < 3a < 3b < 5 is valid). Some errors are tolerated to account for human or OCR
-        # mistakes (e.g. geoquat/validation/9394.pdf). We only reject a column if the error ratio is bigger than the
-        # parameter layer_identifier_acceptance_ratio specified in the config file.
+        # Also check that the columns are mostly ascending, both numerically and alphabetically (e.g. 2 < 3a < 3b
+        # < 5 is valid). Some errors are tolerated, as the indicators (especially in Geneva) sometimes carry a 
+        # semantic meaning instead of being strictly ordered (e.g. geoquat/validation/9394.pdf), and we also need to
+        # account for human or OCR mistakes. We only reject a column if the error ratio is bigger than the parameter
+        # layer_identifier_acceptance_ratio specified in the config file.
         for sidebar in sidebars_by_length:
             if (
                 not any(result_sidebar.rect().contains(sidebar.rect()) for result_sidebar in result)

--- a/src/stratigraphy/sidebar/layer_identifier_sidebar_extractor.py
+++ b/src/stratigraphy/sidebar/layer_identifier_sidebar_extractor.py
@@ -68,7 +68,10 @@ class LayerIdentifierSidebarExtractor:
 
         result = []
         # Remove columns that are fully contained in a longer column
-        # Also remove columns that do not follow a logical progression (e.g. 2 < 3a < 3b < 5 is valid)
+        # Also check which columns do not follow a logical progression. Values should ascend numerically and
+        # alphabetically (e.g. 2 < 3a < 3b < 5 is valid). Some errors are tolerated to account for human or OCR
+        # mistakes (e.g. geoquat/validation/9394.pdf). We only reject a column if the error ratio is bigger than the
+        # parameter layer_identifier_acceptance_ratio specified in the config file.
         for sidebar in sidebars_by_length:
             if (
                 not any(result_sidebar.rect().contains(sidebar.rect()) for result_sidebar in result)

--- a/src/stratigraphy/sidebar/layer_identifier_sidebar_extractor.py
+++ b/src/stratigraphy/sidebar/layer_identifier_sidebar_extractor.py
@@ -68,8 +68,12 @@ class LayerIdentifierSidebarExtractor:
 
         result = []
         # Remove columns that are fully contained in a longer column
+        # Also remove columns that do not follow a logical progression (e.g. 2 < 3a < 3b < 5 is valid)
         for sidebar in sidebars_by_length:
-            if not any(result_sidebar.rect().contains(sidebar.rect()) for result_sidebar in result):
+            if (
+                not any(result_sidebar.rect().contains(sidebar.rect()) for result_sidebar in result)
+                and sidebar.has_regular_progression()
+            ):
                 result.append(sidebar)
 
         return result

--- a/tests/test_layer_identifier_sidebar.py
+++ b/tests/test_layer_identifier_sidebar.py
@@ -1,0 +1,33 @@
+"""Test suite for the LayerIdentifierSidebar module."""
+
+import pytest
+from stratigraphy.sidebar.layer_identifier_sidebar import LayerIdentifierSidebar
+from stratigraphy.sidebar.sidebarentry import LayerIdentifierEntry
+
+
+@pytest.mark.parametrize(
+    "entries,expected",
+    [
+        (["1)", "2)", "3)", "4)"], True),  # Pure numeric
+        (["a)", "b)", "c)"], True),  # Pure alphabet
+        (["1)", "2)", "3a)", "3b)", "4)", "5)"], True),  # Valid mixed
+        (["1)", "2)", "2a)", "2b)", "3)", "4a)", "4b)", "5)"], True),  # Complex valid
+        (["1)", "2)", "1)", "3)", "4)"], True),  # Valid but with 1 intervals invalid, but still bigger than ratio
+        (["1)", "e)", "3)", "4)", "5)", "6)"], True),  # Valid, simulate wrong extraction, but still bigger than ratio
+        (["2a2)", "2a4)", "3a)"], True),  # valid, with key of depth 3
+        (["1)", "2)", "12)"], True),  # valid, why the conversion to int is needed
+        (["1)", "3)", "2)"], False),  # Out-of-order
+        (["1)", "1)", "1)"], False),  # No progression
+        (["m)", "m)", "m)"], False),  # Simulate the case where the letter m) standing for meter is detected.
+        (["1)", "2)", "2)", "2)", "3)", "3)", "4)"], False),  # Too many invalid transitions
+        (["2a2)", "2a1)", "3a)"], False),  # invalid, with key of depth 3
+    ],
+)
+def test_has_regular_progression(entries, expected):
+    """Test the has_regular_progression method of the LayerIdentifierSidebar.
+
+    It detects if a layer identifier sidebar, like 1), 2), 3) is valid or not. This test is usefull because some
+    entries in the document might look like sidebar but actually are not.
+    """
+    sidebar = LayerIdentifierSidebar([LayerIdentifierEntry(rect=None, value=value) for value in entries])
+    assert sidebar.has_regular_progression() == expected


### PR DESCRIPTION
Resolves #119 

This PR adds a check to LayerIdentifierSidebar that rejects sidebars which do not follow a logical progression (e.g., 2 < 3a < 3b < 5 is valid). This check is necessary to prevent the columns of letter "m)" (indicating meters) in the file deepwell Arsch from being mistakenly identified as a sidebar.

Additionally, it rejects some sidebars in the files 12318, 5878, and 9394 in geoquat. All of these rejections are correct and result in slight improvements to the metrics. No other changes have been made for Zurich, deepwell, or Nagra.

The try-except block is used to handle cases where letters are mistakenly extracted as numbers, which would cause crashes during comparison (in B147 and 680). These cases do not impact the desired behavior.

This PR also changes the ordering of identified sidebars: they are now returned sorted by highest score first instead of lowest. This change ensures that when PDFs span multiple pages, the best identified borehole per page is retained. This behavior is desired for deepwell Arsch and geoquat/validation/A114067, and likely beneficial in other cases as well. Note that this last modification slightly lowers the groundwater recall for reasons that remain unclear, but the change is considered correct and intentional. 
This change won't be needed after issue #153 is resolved, as it should merge boreholes that are similar. A list of the pdf's that cause problem can also be found in this issue.