### PR TITLE
Fix/issue 147/keywords by language

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -200,7 +200,6 @@ groundwater_fp_keys:
     - Grundwasser-          
     - Grundwasserfassung   
     - GW/ # makes it possible to avoid false positives like "GW/" from the USCS Nomenclature columns     
-    - GW- # same 
 
 groundwater_unit_keys:
   de:

--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -150,77 +150,90 @@ material_description:
       - core drilling
       - drilling radius
 
-
 coordinate_keys:
-  - Koordinaten
-  - Koordinate
-  - Koord.
-  - coordinates
-  - coordinate
-  - coordonnées
-  - coordonn
-
-coordinate_fp_keys:
-
-
-groundwater_fp_keys:
-  - Wasserstau
-  - Grundwasser-
-  - Grundwasserfassung
-  - GW/  # makes it possible to avoid false positives like "GW/" from the USCS Nomenclature columns
+  de:
+    - Koordinaten        
+    - Koordinate         
+    - Koord.             
+  en:
+    - coordinates        
+    - coordinate         
+  fr:
+    - coordonnées        
+    - coordonn           
 
 groundwater_keys:
-  # German
-  - Wasserspiegel
-  - Wasserstand
-  - Grundwasserspiegel
-  - GW
-  - GWSP
-  - Gwsp
-  - gwsp
-  - G.W.Sp 
-  - GW.SP.
-  - W.SP.
-  - W.SP
-  - W SP
-  - Gr.W.spiegel
-  - GrW Sp
-  - Wsp
-  - GW-Spiegel
-  - Grundwasser
-  - Spiegel
+  de:
+    - Wasserspiegel
+    - Wasserstand
+    - Grundwasserspiegel
+    - GW
+    - GWSP
+    - Gwsp
+    - gwsp
+    - G.W.Sp 
+    - GW.SP.
+    - W.SP.
+    - W.SP
+    - W SP
+    - Gr.W.spiegel
+    - GrW Sp
+    - Wsp
+    - GW-Spiegel
+    - Grundwasser
+    - Spiegel           
+  fr:
+    - nappe phréatique
+    - nappe
+    - nappe d'eau
+    - nappe d'eau souterraine
+    - venue d'eau
+    - niveau d'eau
+  en:
+    - groundwater   
+    - ground-water
+    - ground-water level
 
-  # French
-  - nappe phréatique
-  - nappe
-  - nappe d'eau
-  - nappe d'eau souterraine
-  - venue d'eau
-  - niveau d'eau
-
-  # English
-  - groundwater
+groundwater_fp_keys:
+  de:
+    - Wasserstau            
+    - Grundwasser-          
+    - Grundwasserfassung   
+    - GW/ # makes it possible to avoid false positives like "GW/" from the USCS Nomenclature columns     
+    - GW- # same 
 
 groundwater_unit_keys:
-  # German
-  - m ü. M.
-  - müM
-  - M.ü.T.
-  - MüT
-  - M.u.T.
-  - MuT
-  - m.u.T.
+  de:
+    - m ü. M.            
+    - müM
+    - M.ü.T.
+    - MüT
+    - M.u.T.
+    - MuT
+    - m.u.T.
+  
+  fr:
+    - m/mer
 
 elevation_keys:
-  # German
-  - Kote OK Terrain
-  - Höhenlage
-  - Höhe
-  - Kote
-  - OK Terrain
-  - OKT
-  - Ansatzhöhe
-  - Terrainkote
+  de:
+    - Kote OK Terrain   
+    - Höhenlage        
+    - Höhe            
+    - Kote           
+    - OK Terrain    
+    - OKT          
+    - Ansatzhöhe 
+    - Terrainkote
+    - Terrainhöhe
 
-elevation_fp_keys:
+  fr:
+    - Terrain H
+    - H
+    - Altitude Terrain
+    - Altitude
+    - Alt. Terrain
+
+  en:
+    - Surface level
 

--- a/src/app/api/v1/endpoints/extract_data.py
+++ b/src/app/api/v1/endpoints/extract_data.py
@@ -68,15 +68,16 @@ def extract_data(extract_data_request: ExtractDataRequest) -> ExtractDataRespons
         if words:
             text_lines.append(TextLine(words))
 
-    # Detect the language of the textlines
-    language = detect_language_of_text(
-        " ".join([text.text for text in text_lines]),
-        matching_params["default_language"],
-        matching_params["material_description"].keys(),
-    )
-
     # Extract the information based on the format type
     if extract_data_request.format == FormatTypes.COORDINATES:
+        # Detect the language of the textlines.
+        # Note: language is detected only from textlines inside the user-defined bounding box, not the whole document.
+        # If more confidence is needed, consider using the entire document to infer the language.
+        language = detect_language_of_text(
+            " ".join([text.text for text in text_lines]),
+            matching_params["default_language"],
+            matching_params["material_description"].keys(),
+        )
         # Extract the coordinates and bounding box
         extracted_coords: ExtractCoordinatesResponse | None = extract_coordinates(
             extract_data_request, text_lines, language

--- a/src/stratigraphy/data_extractor/data_extractor.py
+++ b/src/stratigraphy/data_extractor/data_extractor.py
@@ -110,17 +110,18 @@ class DataExtractor(ABC):
 
     preprocess_replacements: dict[str, str] = {}
 
-    def __init__(self):
+    def __init__(self, language: str):
         """Initializes the DataExtractor object.
 
         Args:
-            feature_name (str): The name of the feature to extract.
+            language (str): the language of the document.
         """
         if not self.feature_name:
             raise ValueError("Feature name must be specified.")
 
-        self.feature_keys = read_params("matching_params.yml")[f"{self.feature_name}_keys"]
-        self.feature_fp_keys = read_params("matching_params.yml")[f"{self.feature_name}_fp_keys"] or []
+        params = read_params("matching_params.yml")
+        self.feature_keys = params[f"{self.feature_name}_keys"][language]
+        self.feature_fp_keys = params.get(f"{self.feature_name}_fp_keys", {}).get(language, [])
 
     def preprocess(self, value: str) -> str:
         """Preprocesses the value before searching for the feature.

--- a/src/stratigraphy/groundwater/groundwater_extraction.py
+++ b/src/stratigraphy/groundwater/groundwater_extraction.py
@@ -191,8 +191,13 @@ class GroundwaterLevelExtractor(DataExtractor):
 
     preprocess_replacements = {",": ".", "'": ".", "o": "0", "\n": " ", "ü": "u"}
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, language):
+        """Initializes the GroundwaterLevelExtractor object.
+
+        Args:
+            language (str): the language of the document.
+        """
+        super().__init__(language)
 
         self.is_searching_groundwater_illustration = os.getenv("IS_SEARCHING_GROUNDWATER_ILLUSTRATION") == "True"
         if self.is_searching_groundwater_illustration:

--- a/src/stratigraphy/main.py
+++ b/src/stratigraphy/main.py
@@ -255,7 +255,7 @@ def start_pipeline(
         with fitz.Document(in_path) as doc:
             # Extract metadata
             file_metadata = FileMetadata.from_document(doc)
-            metadata = MetadataInDocument.from_document(doc)
+            metadata = MetadataInDocument.from_document(doc, file_metadata.language)
 
             # Save the predictions to the overall predictions object, initialize common variables
             layers_with_bb_in_document = LayersInDocument([], filename)
@@ -276,7 +276,7 @@ def start_pipeline(
                 processed_page_results = LayersInDocument(extracted_boreholes, filename)
 
                 # Extract the groundwater levels
-                groundwater_extractor = GroundwaterLevelExtractor()
+                groundwater_extractor = GroundwaterLevelExtractor(file_metadata.language)
                 groundwater_entries = groundwater_extractor.extract_groundwater(
                     page_number=page_number, lines=text_lines, document=doc
                 )

--- a/src/stratigraphy/metadata/language_detection.py
+++ b/src/stratigraphy/metadata/language_detection.py
@@ -35,6 +35,20 @@ def detect_language_of_document(doc: fitz.Document, default_language: str, suppo
         str: The detected language of the document. One of supported_languages.
     """
     text = extract_text_from_document(doc)
+    return detect_language_of_text(text, default_language, supported_languages)
+
+
+def detect_language_of_text(text: str, default_language: str, supported_languages: list) -> str:
+    """Detects the language of a text.
+
+    Args:
+        text (str): The text to detect the language of.
+        default_language (str): The default language to use if the language detection fails.
+        supported_languages (list): A list of supported languages.
+
+    Returns:
+        str: The detected language of the document. One of supported_languages.
+    """
     try:
         language = detect(text)
     except LangDetectException:

--- a/src/stratigraphy/metadata/metadata.py
+++ b/src/stratigraphy/metadata/metadata.py
@@ -35,21 +35,22 @@ class MetadataInDocument:
     coordinates: list[FeatureOnPage[Coordinate]]
 
     @classmethod
-    def from_document(cls, document: fitz.Document) -> "MetadataInDocument":
+    def from_document(cls, document: fitz.Document, language: str) -> "MetadataInDocument":
         """Create a MetadataInDocument object from a document.
 
         Args:
             document (fitz.Document): The document.
+            language (str): The language of the document.
 
         Returns:
             MetadataInDocument: The metadata object.
         """
         # Extract the coordinates of the borehole
-        coordinate_extractor = CoordinateExtractor()
+        coordinate_extractor = CoordinateExtractor(language)
         coordinates = coordinate_extractor.extract_coordinates(document=document)
 
         # Extract the elevation information
-        elevation_extractor = ElevationExtractor()
+        elevation_extractor = ElevationExtractor(language)
         elevations = elevation_extractor.extract_elevation(document=document)
 
         return cls(elevations=elevations, coordinates=coordinates)


### PR DESCRIPTION
Resolves #147

Sort the keywords by language in the Yaml file. This is cleanier, and also avoids some false positives.

For example, false positives removed in geoquat/validation from A289 (Kappe not matched as nappe anymore),  1007 (GW not matched, as documents is in french), 2536 (GW not matched, as document is in french).