### PR TITLE
check for intersections between material descriptions and sidebars

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -2,6 +2,7 @@
 block_line_ratio: 0.20
 min_block_clearance: 10
 left_line_length_threshold: 7
+duplicate_similarity_threshold: 0.5
 layer_identifier_acceptance_ratio: 0.5
 img_template_probability_threshold: 0.62
 

--- a/src/extraction/annotations/draw.py
+++ b/src/extraction/annotations/draw.py
@@ -97,18 +97,19 @@ def draw_predictions(
                             page.derotation_matrix,
                             [layer for layer in bh_layers.layers if layer.material_description.page == page_number],
                         )
-                        shape.commit()  # Commit all the drawing operations to the page
 
-                        tmp_file_path = out_directory / f"{filename}_page{page_number}.png"
-                        pymupdf.utils.get_pixmap(page, matrix=pymupdf.Matrix(2, 2), clip=page.rect).save(tmp_file_path)
+                    shape.commit()  # Commit all the drawing operations to the page
 
-                        if mlflow_tracking:  # This is only executed if MLFlow tracking is enabled
-                            try:
-                                import mlflow
+                    tmp_file_path = out_directory / f"{filename}_page{page_number}.png"
+                    pymupdf.utils.get_pixmap(page, matrix=pymupdf.Matrix(2, 2), clip=page.rect).save(tmp_file_path)
 
-                                mlflow.log_artifact(tmp_file_path, artifact_path="pages")
-                            except NameError:
-                                logger.warning("MLFlow could not be imported. Skipping logging of artifact.")
+                    if mlflow_tracking:  # This is only executed if MLFlow tracking is enabled
+                        try:
+                            import mlflow
+
+                            mlflow.log_artifact(tmp_file_path, artifact_path="pages")
+                        except NameError:
+                            logger.warning("MLFlow could not be imported. Skipping logging of artifact.")
 
         except (FileNotFoundError, pymupdf.FileDataError) as e:
             logger.error("Error opening file %s: %s", filename, e)

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -97,7 +97,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             item for index, item in enumerate(material_descriptions_sidebar_pairs) if index not in to_delete
         ]
 
-        # remoove pairs that have all depths equal to None (only if there is more than one pair).
+        # remove pairs that have all depths equal to None (only if there is more than one pair).
         to_delete = self._find_no_depths_indices(filtered_pairs)
         filtered_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
 

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -97,8 +97,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             item for index, item in enumerate(material_descriptions_sidebar_pairs) if index not in to_delete
         ]
 
-        # remove pairs that have all depths equal to None (only if they is more than one pair).
-        to_delete = self._find_no_depths_indices(filtered_pairs)
+        # remove pairs that have all depths equal to None (only if there is more than one pair).
         filtered_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
 
         # remove pairs that are likely duplicates of others.

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -200,7 +200,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             [interval.depth_interval for interval in self._get_interval_block_pairs(pair)] for pair in filtered_pairs
         ]
 
-        # create sets with all the depths appeating in the interval list
+        # create sets with all the depths appearing in the interval list
         all_depths_set = []
         for interval_list in all_interval_lists:
             depth_set = set()

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -100,7 +100,8 @@ class MaterialDescriptionRectWithSidebarExtractor:
         # remove pairs that have all depths equal to None (only if there is more than one pair).
         filtered_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
 
-        # remove pairs that are likely duplicates of others.
+        # remove pairs that are likelly duplicates of others.
+        to_delete = self._find_duplicated_pairs_indices(filtered_pairs)
         non_duplicated_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
 
         # We order the boreholes with the highest score first. When one borehole is actually present in the ground

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -91,7 +91,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             pair for pair in material_descriptions_sidebar_pairs if pair.score_match >= 0
         ]
 
-        # remoooove pairs that have any of their elements (sidebar, material description) intersecting with others.
+        # remove pairs that have any of their elements (sidebar, material description) intersecting with others.
         to_delete = self._find_intersecting_indices(material_descriptions_sidebar_pairs)
         filtered_pairs = [
             item for index, item in enumerate(material_descriptions_sidebar_pairs) if index not in to_delete

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -91,7 +91,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             pair for pair in material_descriptions_sidebar_pairs if pair.score_match >= 0
         ]
 
-        # remove pairs that have any of their elements (sidebar, material description) intersecting with others.
+        # remoooove pairs that have any of their elements (sidebar, material description) intersecting with others.
         to_delete = self._find_intersecting_indices(material_descriptions_sidebar_pairs)
         filtered_pairs = [
             item for index, item in enumerate(material_descriptions_sidebar_pairs) if index not in to_delete

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -98,9 +98,10 @@ class MaterialDescriptionRectWithSidebarExtractor:
         ]
 
         # remove pairs that have all depths equal to None (only if there is more than one pair).
+        to_delete = self._find_no_depths_indices(filtered_pairs)
         filtered_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
 
-        # remove pairs that are likelly duplicates of others.
+        # remove pairs that are likely duplicates of others.
         to_delete = self._find_duplicated_pairs_indices(filtered_pairs)
         non_duplicated_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
 

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -97,7 +97,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             item for index, item in enumerate(material_descriptions_sidebar_pairs) if index not in to_delete
         ]
 
-        # remove pairs that have all depths equal to None (only if there is more than one pair).
+        # remoove pairs that have all depths equal to None (only if there is more than one pair).
         to_delete = self._find_no_depths_indices(filtered_pairs)
         filtered_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
 

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -101,8 +101,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
         to_delete = self._find_no_depths_indices(filtered_pairs)
         filtered_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
 
-        # remove pairs that are likelly duplicates of others.
-        to_delete = self._find_duplicated_pairs_indices(filtered_pairs)
+        # remove pairs that are likely duplicates of others.
         non_duplicated_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
 
         # We order the boreholes with the highest score first. When one borehole is actually present in the ground


### PR DESCRIPTION
## This PR resolves #130 

This issue was not reproducible anymore, the overlapping inside deepwell 3EK5LEG800_bp_19940601_Arsch93-18.pdf was already resolved by PR#174, and no similar problems existed in the datasets. I implemented a quick solution anyway, as this problem could appear in some other pdf unseen yet.

## This PR also resolves #153 

Some additional checks are applied to filter out material descriptions with sidebars before validating them as actual boreholes.

The first check removes any pair that contains no depth information (i.e.all depth values are None). This affects the following files:

GeoQuat
- False positives removed (good): 14225.pdf, A11406.pdf, 1488.pdf, 14273.pdf
- True positive removed (bad): A1304.pdf: According to the ground truth, this file contains three boreholes. One is correctly detected. The second borehole is removed at this stage because its depth column was not detected during extraction, leaving it without any depth values (see image below). The third borehole is not detected at all.

Zurich
- False positives removed (good): 695265010-bp.pdf : A column of incorrect numbers is removed. The main borehole isn’t detected in this file, as it is rotated).

Overall, this check seems justified. The only true positive removed is due to an error in the extraction pipeline, which fails to detect a depth column, rather than a flaw in the check itself.

---

The second check finds duplicates in the pairs. It affects the following files:
GeoQuat
- False positives removed (good): 8366.pdf, 13080.pdf, 7317.pdf

This check is only beneficial.

---

Among the list provided in issue #153, the following document remains false positives and here the reason why:
- 5872.pdf: thickness of layers column is detected instead of depth.
- A263.pdf : a series of explanation containing diameter numbers is detected as Sidebar (because it contains 1), ...5) ).
- 7703.pdf: compactness column is detected as a borehole.
- 684252058-bp.pdf: water infiltration is detected instead of depth, this breaks the borehole into 2 incorrect parts.
- 268124125-bp.pdf: humidity column detected

All those issue are related to incorrect depth column extraction and not to duplication, so issue #153 is effectively resolved.

Also note that:
- 9394.pdf was already resolved by  PR#174

<img width="574" alt="image" src="https://github.com/user-attachments/assets/5d067ca3-828b-437c-8e1b-87e5cb5c8f4b" />