### PR TITLE
handle missing values in ground_truth layers.

### DIFF
--- a/src/classification/utils/data_loader.py
+++ b/src/classification/utils/data_loader.py
@@ -54,7 +54,14 @@ def load_data(json_path: Path, file_subset_directory: Path | None) -> list[Layer
     for filename, boreholes in data.items():
         if filename_subset is not None and filename not in filename_subset:
             continue
-        all_text = " ".join([lay["material_description"] for bh in boreholes for lay in bh["layers"]])
+        all_text = " ".join(
+            [
+                lay["material_description"]
+                for bh in boreholes
+                for lay in bh["layers"]
+                if lay["material_description"] is not None
+            ]
+        )
         language = detect_language_of_text(
             all_text, classification_params["default_language"], classification_params["supported_language"]
         )

--- a/src/extraction/evaluation/benchmark/ground_truth.py
+++ b/src/extraction/evaluation/benchmark/ground_truth.py
@@ -36,7 +36,7 @@ class GroundTruth:
                         "depth_interval": layer["depth_interval"],
                     }
                     for layer in layers
-                    if parse_text(layer["material_description"]) != ""
+                    if layer["material_description"] is not None and parse_text(layer["material_description"]) != ""
                 ]
                 self.ground_truth[file_name][borehole_index]["metadata"] = borehole_data["metadata"]
                 self.ground_truth[file_name][borehole_index]["groundwater"] = borehole_data["groundwater"]


### PR DESCRIPTION
Ground truth data now can have NoneType as material description in contrast to solely string as previously. Thus the small adjustment in the loading of the ground truth is needed to handle NoneType inputs in Layers.