### PR TITLE
Fix/issue 117/perrin layouts improvement

### DIFF
--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -82,7 +82,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
         if material_description_rect_without_sidebar:
             material_descriptions_sidebar_pairs.append(
                 MaterialDescriptionRectWithSidebar(
-                    sidebar=None, material_description_rect=material_description_rect_without_sidebar
+                    sidebar=None, material_description_rect=material_description_rect_without_sidebar, lines=self.lines
                 )
             )
 
@@ -111,9 +111,62 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
         # We order the boreholes with the highest score first. When one borehole is actually present in the ground
         # truth, but more than one are detected, we want the most correct to be assigned
-        return [
+        boreholes = [
             self._create_borehole_from_pair(pair)
             for pair in sorted(non_duplicated_pairs, key=lambda pair: pair.score_match, reverse=True)
+        ]
+        return [borehole for borehole in boreholes if borehole.predictions]
+
+    def process_page_old(self) -> list[ExtractedBorehole]:
+        """Process a single page of a pdf.
+
+        Finds all descriptions and depth intervals on the page and matches them.
+
+        TODO: Ideally, one function does one thing. This function does a lot of things. It should be split into
+        smaller functions.
+
+        Returns:
+            ProcessPageResult: a list of the extracted layers and a list of relevant bounding boxes.
+        """
+        material_descriptions_sidebar_pairs = self._find_layer_identifier_sidebar_pairs()
+        material_descriptions_sidebar_pairs.extend(self._find_depth_sidebar_pairs_old())
+
+        material_description_rect_without_sidebar = self._find_material_description_column_old(sidebar=None)
+        if material_description_rect_without_sidebar:
+            material_descriptions_sidebar_pairs.append(
+                MaterialDescriptionRectWithSidebar(
+                    sidebar=None, material_description_rect=material_description_rect_without_sidebar, lines=self.lines
+                )
+            )
+
+        material_descriptions_sidebar_pairs.sort(key=lambda pair: pair.score_match_old)  # lowest score first
+
+        material_descriptions_sidebar_pairs = [
+            pair for pair in material_descriptions_sidebar_pairs if pair.score_match_old >= 0
+        ]
+
+        # remove pairs that have any of their elements (sidebar, material description) intersecting with others.
+        to_delete = self._find_intersecting_indices(material_descriptions_sidebar_pairs)
+        filtered_pairs = [
+            item for index, item in enumerate(material_descriptions_sidebar_pairs) if index not in to_delete
+        ]
+
+        # remove pairs with no sidebar if there is more than one pair.
+        to_delete = (
+            [] if len(filtered_pairs) <= 1 else [i for i, pair in enumerate(filtered_pairs) if not pair.sidebar]
+        )
+
+        filtered_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
+
+        # remove pairs that are likely duplicates of others.
+        to_delete = self._find_duplicated_pairs_indices(filtered_pairs)
+        non_duplicated_pairs = [item for index, item in enumerate(filtered_pairs) if index not in to_delete]
+
+        # We order the boreholes with the highest score first. When one borehole is actually present in the ground
+        # truth, but more than one are detected, we want the most correct to be assigned
+        return [
+            self._create_borehole_from_pair(pair)
+            for pair in sorted(non_duplicated_pairs, key=lambda pair: pair.score_match_old, reverse=True)
         ]
 
     def _find_intersecting_indices(
@@ -285,7 +338,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             material_description_rect = self._find_material_description_column(layer_identifier_sidebar)
             if material_description_rect:
                 material_descriptions_sidebar_pairs.append(
-                    MaterialDescriptionRectWithSidebar(layer_identifier_sidebar, material_description_rect)
+                    MaterialDescriptionRectWithSidebar(layer_identifier_sidebar, material_description_rect, self.lines)
                 )
         return material_descriptions_sidebar_pairs
 
@@ -297,6 +350,44 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
         words = sorted([word for line in self.lines for word in line.words], key=lambda word: word.rect.y0)
         a_to_b_sidebars = AToBSidebarExtractor.find_in_words(words)
+        used_entry_rects = []
+
+        for column in a_to_b_sidebars:
+            for entry in column.entries:
+                used_entry_rects.extend([entry.start.rect, entry.end.rect])
+
+        # create sidebars with noise count
+        sidebars_noise: list[SidebarNoise] = [
+            SidebarNoise(sidebar=sidebar, noise_count=noise_count(sidebar, line_rtree)) for sidebar in a_to_b_sidebars
+        ]
+        sidebars_noise.extend(
+            AAboveBSidebarExtractor.find_in_words(
+                words, line_rtree, used_entry_rects, sidebar_params=self.params["depth_column_params"]
+            )
+        )
+
+        for sidebar_noise in sidebars_noise:
+            material_description_rect = self._find_material_description_column(sidebar_noise.sidebar)
+            if material_description_rect:
+                material_descriptions_sidebar_pairs.append(
+                    MaterialDescriptionRectWithSidebar(
+                        sidebar=sidebar_noise.sidebar,
+                        material_description_rect=material_description_rect,
+                        lines=self.lines,
+                        noise_count=sidebar_noise.noise_count,
+                    )
+                )
+
+        return material_descriptions_sidebar_pairs
+
+    def _find_depth_sidebar_pairs_old(self) -> list[MaterialDescriptionRectWithSidebar]:
+        material_descriptions_sidebar_pairs = []
+        line_rtree = rtree.index.Index()
+        for line in self.lines:
+            line_rtree.insert(id(line), (line.rect.x0, line.rect.y0, line.rect.x1, line.rect.y1), obj=line)
+
+        words = sorted([word for line in self.lines for word in line.words], key=lambda word: word.rect.y0)
+        a_to_b_sidebars = AToBSidebarExtractor.find_in_words_old(words)
         used_entry_rects = []
         for column in a_to_b_sidebars:
             for entry in column.entries:
@@ -319,6 +410,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
                     MaterialDescriptionRectWithSidebar(
                         sidebar=sidebar_noise.sidebar,
                         material_description_rect=material_description_rect,
+                        lines=self.lines,
                         noise_count=sidebar_noise.noise_count,
                     )
                 )
@@ -326,6 +418,122 @@ class MaterialDescriptionRectWithSidebarExtractor:
         return material_descriptions_sidebar_pairs
 
     def _find_material_description_column(self, sidebar: Sidebar | None) -> pymupdf.Rect | None:
+        """Find the material description column given a depth column.
+
+        Args:
+            sidebar (Sidebar | None): The sidebar to be associated with the material descriptions.
+
+        Returns:
+            pymupdf.Rect | None: The material description column.
+        """
+        if sidebar:
+            above_sidebar = [
+                line
+                for line in self.lines
+                if x_overlap(line.rect, sidebar.rect()) and line.rect.y0 < sidebar.rect().y0
+            ]
+
+            min_y0 = max(line.rect.y0 for line in above_sidebar) if above_sidebar else -1
+
+            def check_y0_condition(y0):
+                return y0 > min_y0 and y0 < sidebar.rect().y1
+        else:
+
+            def check_y0_condition(y0):
+                return True
+
+        candidate_description = [line for line in self.lines if check_y0_condition(line.rect.y0)]
+        is_description = [
+            line
+            for line in candidate_description
+            if line.is_description(self.params["material_description"][self.language])
+        ]
+
+        if len(candidate_description) == 0:
+            return
+
+        description_clusters = []
+        while len(is_description) > 0:
+            coverage_by_generating_line = [
+                [other for other in is_description if x_overlap_significant_smallest(line.rect, other.rect, 0.4)]
+                for line in is_description
+            ]
+
+            def filter_coverage(coverage):
+                if coverage:
+                    min_x0 = min(line.rect.x0 for line in coverage)
+                    max_x1 = max(line.rect.x1 for line in coverage)
+                    # how did we determine the 0.4? Should it be a parameter? What would it do if we were to change it?
+                    x0_threshold = max_x1 - 0.4 * (max_x1 - min_x0)
+                    return [line for line in coverage if line.rect.x0 < x0_threshold]
+                else:
+                    return []
+
+            coverage_by_generating_line = [filter_coverage(coverage) for coverage in coverage_by_generating_line]
+            max_coverage = max(coverage_by_generating_line, key=len)
+            description_clusters.append(max_coverage)
+            is_description = [line for line in is_description if line not in max_coverage]
+
+        candidate_rects = []
+
+        for cluster in description_clusters:
+            best_y0 = min([line.rect.y0 for line in cluster])
+            best_y1 = max([line.rect.y1 for line in cluster])
+
+            min_description_x0 = min(
+                [
+                    line.rect.x0 - 0.01 * line.rect.width for line in cluster
+                ]  # How did we determine the 0.01? Should it be a parameter? What would it do if we were to change it?
+            )
+            max_description_x0 = max(
+                [
+                    line.rect.x0 + 0.2 * line.rect.width for line in cluster
+                ]  # How did we determine the 0.2? Should it be a parameter? What would it do if we were to change it?
+            )
+            good_lines = [
+                line
+                for line in candidate_description
+                if line.rect.y0 >= best_y0 and line.rect.y1 <= best_y1
+                if min_description_x0 < line.rect.x0 < max_description_x0
+            ]
+            best_x0 = min([line.rect.x0 for line in good_lines])
+            best_x1 = max([line.rect.x1 for line in good_lines])
+
+            # expand to include entire last block
+            def is_below(best_x0, best_y1, line):
+                # How did we determine the constants 5 and 10?
+                # Should they be parameters?
+                # What would happen do if we were to change them?
+                return (
+                    (line.rect.x0 > best_x0 - 5)
+                    and (line.rect.x0 < (best_x0 + best_x1) / 2)  # noqa B023
+                    and (line.rect.y0 < best_y1 + 10)
+                    and (line.rect.y1 > best_y1)
+                )
+
+            continue_search = True
+            while continue_search:
+                line = next((line for line in self.lines if is_below(best_x0, best_y1, line)), None)
+                if line:
+                    best_x0 = min(best_x0, line.rect.x0)
+                    best_x1 = max(best_x1, line.rect.x1)
+                    best_y1 = line.rect.y1
+                else:
+                    continue_search = False
+
+            candidate_rects.append(pymupdf.Rect(best_x0, best_y0, best_x1, best_y1))
+
+        if len(candidate_rects) == 0:
+            return None
+        if sidebar:
+            return max(
+                candidate_rects,
+                key=lambda rect: MaterialDescriptionRectWithSidebar(sidebar, rect, self.lines).score_match,
+            )
+        else:
+            return candidate_rects[0]
+
+    def _find_material_description_column_old(self, sidebar: Sidebar | None) -> pymupdf.Rect | None:
         """Find the material description column given a depth column.
 
         Args:
@@ -436,7 +644,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
         if sidebar:
             return max(
                 candidate_rects,
-                key=lambda rect: MaterialDescriptionRectWithSidebar(sidebar, rect).score_match,
+                key=lambda rect: MaterialDescriptionRectWithSidebar(sidebar, rect, self.lines).score_match_old,
             )
         else:
             return candidate_rects[0]
@@ -459,9 +667,17 @@ def process_page(
     Returns:
         list[ExtractedBorehole]: Extracted borehole layers from the page.
     """
-    return MaterialDescriptionRectWithSidebarExtractor(
+    new = MaterialDescriptionRectWithSidebarExtractor(
         text_lines, geometric_lines, language, page_number, **matching_params
     ).process_page()
+
+    old = MaterialDescriptionRectWithSidebarExtractor(
+        text_lines, geometric_lines, language, page_number, **matching_params
+    ).process_page_old()
+
+    if new != old:
+        print("DIIIIIF", new, old)
+    return new
 
 
 def match_columns(

--- a/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
+++ b/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
@@ -33,8 +33,12 @@ class MaterialDescriptionRectWithSidebar:
         - negatively influenced by vertical distance between the top of the sidebar and the top of the material
           descriptions, and the vertical distance between the bottom of the sidebar and the bottom of the material
           descriptions
+        - positively influenced by the number of text lines contained in the material decription rectangle
+        - increased by a fix a bonus for being a valid sidebar-material pair (usefull when comparing against pairs that
+          don't have a sidebar, only a material description rectangle)
         The resulting score is also reduced if the sidebar has a high noise count (many unrelated tokens in between
-        the extracted depths values).
+        the extracted depths values). This noise is not taken into account if the sidebar is extracted from text (if it
+        is of type LayerIdentifierSidebar or AtoBSidebar).
 
         Pairs without a sidebar receive a default score of 0.
 

--- a/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
+++ b/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
@@ -52,7 +52,7 @@ class MaterialDescriptionRectWithSidebar:
 
         height = sidebar_bottom - sidebar_top
 
-        geometry_score = self.material_description_rect.width - 1.75 * x_distance + height - 2 * y_distance
+        geometry_score = self.material_description_rect.width - 1.64 * x_distance + height - 2 * y_distance
 
         noise_coef = 10.0 if isinstance(self.sidebar, AAboveBSidebar) else 0.0
         noise_penalty_multiplier = math.pow(0.8, noise_coef * self.noise_count / len(self.sidebar.entries))

--- a/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
+++ b/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
@@ -22,42 +22,6 @@ class MaterialDescriptionRectWithSidebar:
     noise_count: int = 0
 
     @property
-    def score_match_old(self) -> float:
-        """Scores the match between a sidebar and a material description.
-
-        For pairs that have a sidebar, the score is
-        - positively influenced by the width of the material description bounding box
-        - negatively influenced by the horizontal distance between (the right-hand-side of) the sidebar and (the
-          left-hand-side of) the material descriptions
-        - positively influenced by the height of the sidebar
-        - negatively influenced by vertical distance between the top of the sidebar and the top of the material
-          descriptions, and the vertical distance between the bottom of the sidebar and the bottom of the material
-          descriptions
-        The resulting score is also reduced if the sidebar has a high noise count (many unrelated tokens in between
-        the extracted depths values).
-
-        Pairs without a sidebar receive a default score of 0.
-
-        Returns:
-            float: The score of the match. Better matches have a higher score value.
-        """
-        if self.sidebar:
-            rect = self.sidebar.rect()
-            top = rect.y0
-            bottom = rect.y1
-            right = rect.x1
-            x_distance = abs(right - self.material_description_rect.x0)
-            y_distance = abs(top - self.material_description_rect.y0) + abs(bottom - self.material_description_rect.y1)
-
-            height = bottom - top
-
-            return (self.material_description_rect.width - x_distance + height - 2 * y_distance) * math.pow(
-                0.8, 10 * self.noise_count / len(self.sidebar.entries)
-            )
-        else:
-            return 0
-
-    @property
     def score_match(self) -> float:
         """Scores the match between a sidebar and a material description.
 

--- a/src/extraction/features/stratigraphy/sidebar/extractor/a_to_b_sidebar_extractor.py
+++ b/src/extraction/features/stratigraphy/sidebar/extractor/a_to_b_sidebar_extractor.py
@@ -87,6 +87,7 @@ def get_most_detailed_intervals(intervals: list[AToBInterval]) -> list[AToBInter
     Returns:
         list[AToBInterval]: The ordered list
     """
+    intervals = intervals.copy()  # don't mutate the original object
     # Sort intervals by depth (interval close to the surface first) and thickness (small interval first).
     intervals.sort(key=lambda x: (x.start.value, x.end.value))
 

--- a/src/extraction/features/stratigraphy/sidebar/extractor/a_to_b_sidebar_extractor.py
+++ b/src/extraction/features/stratigraphy/sidebar/extractor/a_to_b_sidebar_extractor.py
@@ -74,58 +74,6 @@ class AToBSidebarExtractor:
         # return unique sidebars by comparing each intervals.
         return list({tuple(sb.entries): sb for sb in sidebars + detailed_sidebars}.values())
 
-    def find_in_words_old(all_words: list[TextWord]) -> list[AToBSidebar]:
-        """Finds all AToBSidebars.
-
-        Generates a list of AToBDepthColumnEntry objects by finding consecutive pairs of DepthColumnEntry objects.
-        Different columns are grouped together in LayerDepthColumn objects. Finally, a list of AToBSidebars objects,
-        one for each column, is returned.
-
-        A layer corresponds to a material layer. The layer is defined using a start and end point (e.g. 1.10-1.60m).
-        The start and end points are represented as DepthColumnEntry objects.
-
-        Args:
-            all_words (list[TextWord]): List of all TextWord objects.
-
-        Returns:
-            list[AToBSidebar]: List of all AToBSidebars identified.
-        """
-        entries = DepthColumnEntryExtractor.find_in_words(all_words, include_splits=True)
-
-        def find_pair(entry: DepthColumnEntry) -> DepthColumnEntry | None:  # noqa: D103
-            min_y0 = entry.rect.y0 - entry.rect.height / 2
-            max_y0 = entry.rect.y0 + entry.rect.height / 2
-            for other in entries:
-                if entry == other:
-                    continue
-                if other.value <= entry.value:
-                    continue
-                combined_width = entry.rect.width + other.rect.width
-                if not entry.rect.x0 <= other.rect.x0 <= entry.rect.x0 + combined_width:
-                    continue
-                if not min_y0 <= other.rect.y0 <= max_y0:
-                    continue
-                in_between_text = " ".join(
-                    [
-                        word.text
-                        for word in all_words
-                        if entry.rect.x0 < word.rect.x0 < other.rect.x0 and min_y0 <= word.rect.y0 <= max_y0
-                    ]
-                )
-                if re.fullmatch(r"\W*m?\W*", in_between_text):
-                    return other
-
-        pairs = [(entry, find_pair(entry)) for entry in entries]
-        intervals = [AToBInterval(first, second) for first, second in pairs if second]
-        clusters = Cluster[AToBInterval].create_clusters(intervals, lambda interval: interval.rect)
-
-        return [
-            sidebar_segment
-            for cluster in clusters
-            for sidebar_segment in AToBSidebar(cluster.entries).break_on_mismatch()
-            if sidebar_segment.is_valid()
-        ]
-
 
 def get_most_detailed_intervals(intervals: list[AToBInterval]) -> list[AToBInterval]:
     """Takes a list of intervals and returns the most detailed list of intervals.

--- a/src/extraction/features/stratigraphy/sidebar/extractor/a_to_b_sidebar_extractor.py
+++ b/src/extraction/features/stratigraphy/sidebar/extractor/a_to_b_sidebar_extractor.py
@@ -59,6 +59,65 @@ class AToBSidebarExtractor:
         pairs = [(entry, find_pair(entry)) for entry in entries]
         intervals = [AToBInterval(first, second) for first, second in pairs if second]
         clusters = Cluster[AToBInterval].create_clusters(intervals, lambda interval: interval.rect)
+        merged_clusters = Cluster[AToBInterval].merge_close_clusters(clusters)
+        clusters.extend(merged_clusters)
+
+        detailed_sidebars = [AToBSidebar(get_most_detailed_intervals(clust.entries)) for clust in clusters]
+        detailed_sidebars = [detailed_sidebar for detailed_sidebar in detailed_sidebars if detailed_sidebar.is_valid()]
+        sidebars = [
+            sidebar_segment
+            for cluster in clusters
+            for sidebar_segment in AToBSidebar(cluster.entries).break_on_mismatch()
+            if sidebar_segment.is_valid()
+        ]
+
+        # return unique sidebars by comparing each intervals.
+        return list({tuple(sb.entries): sb for sb in sidebars + detailed_sidebars}.values())
+
+    def find_in_words_old(all_words: list[TextWord]) -> list[AToBSidebar]:
+        """Finds all AToBSidebars.
+
+        Generates a list of AToBDepthColumnEntry objects by finding consecutive pairs of DepthColumnEntry objects.
+        Different columns are grouped together in LayerDepthColumn objects. Finally, a list of AToBSidebars objects,
+        one for each column, is returned.
+
+        A layer corresponds to a material layer. The layer is defined using a start and end point (e.g. 1.10-1.60m).
+        The start and end points are represented as DepthColumnEntry objects.
+
+        Args:
+            all_words (list[TextWord]): List of all TextWord objects.
+
+        Returns:
+            list[AToBSidebar]: List of all AToBSidebars identified.
+        """
+        entries = DepthColumnEntryExtractor.find_in_words(all_words, include_splits=True)
+
+        def find_pair(entry: DepthColumnEntry) -> DepthColumnEntry | None:  # noqa: D103
+            min_y0 = entry.rect.y0 - entry.rect.height / 2
+            max_y0 = entry.rect.y0 + entry.rect.height / 2
+            for other in entries:
+                if entry == other:
+                    continue
+                if other.value <= entry.value:
+                    continue
+                combined_width = entry.rect.width + other.rect.width
+                if not entry.rect.x0 <= other.rect.x0 <= entry.rect.x0 + combined_width:
+                    continue
+                if not min_y0 <= other.rect.y0 <= max_y0:
+                    continue
+                in_between_text = " ".join(
+                    [
+                        word.text
+                        for word in all_words
+                        if entry.rect.x0 < word.rect.x0 < other.rect.x0 and min_y0 <= word.rect.y0 <= max_y0
+                    ]
+                )
+                if re.fullmatch(r"\W*m?\W*", in_between_text):
+                    return other
+
+        pairs = [(entry, find_pair(entry)) for entry in entries]
+        intervals = [AToBInterval(first, second) for first, second in pairs if second]
+        clusters = Cluster[AToBInterval].create_clusters(intervals, lambda interval: interval.rect)
 
         return [
             sidebar_segment
@@ -66,3 +125,45 @@ class AToBSidebarExtractor:
             for sidebar_segment in AToBSidebar(cluster.entries).break_on_mismatch()
             if sidebar_segment.is_valid()
         ]
+
+
+def get_most_detailed_intervals(intervals: list[AToBInterval]) -> list[AToBInterval]:
+    """Takes a list of intervals and returns the most detailed list of intervals.
+
+    This is done by finding the list of intervals that can be continued from one to the other, that contains the most
+    details and that reach the biggest depth.
+
+    Args:
+        intervals (list[AToBInterval]): The list of intervals.
+
+    Returns:
+        list[AToBInterval]: The ordered list
+    """
+    # Sort intervals by depth (interval close to the surface first) and thickness (small interval first).
+    intervals.sort(key=lambda x: (x.start.value, x.end.value))
+
+    current_intervals = [intervals[0]]
+    processed_intervals = {intervals[0]}
+    most_detailed_intervals = []  # stores the deepest list of continued interval found so far
+
+    while current_intervals:
+        current_interval = current_intervals[-1]
+        found = False
+        for interval in intervals:
+            if interval in processed_intervals:
+                continue
+            # from the current (deepest) interval, look for interval that starts with the ending value (we stop at
+            # the first interval found as they are sorted, so we will get the smallest one). We also ensure that the
+            # interval found is below the current, to remove any noise.
+            if current_interval.end.value == interval.start.value and current_interval.rect.y0 <= interval.rect.y0:
+                current_intervals.append(interval)
+                processed_intervals.add(interval)
+                found = True
+                break
+        if not found:
+            # if we did not found an interval to continue the search, we store the result if it is the best so far,
+            # and continue the search from the previous interval, by poping the last added.
+            if not most_detailed_intervals or current_intervals[-1].end.value > most_detailed_intervals[-1].end.value:
+                most_detailed_intervals = current_intervals.copy()
+            current_intervals.pop()
+    return most_detailed_intervals

--- a/src/extraction/features/stratigraphy/sidebar/utils/cluster.py
+++ b/src/extraction/features/stratigraphy/sidebar/utils/cluster.py
@@ -51,10 +51,10 @@ class Cluster(abc.ABC, Generic[EntryT]):
         """Iteratively merge clusters that are close to each other.
 
         Args:
-            clusters: A list of Cluster objects to merge.
+            clusters (list[Cluster[EntryT]]): A list of Cluster objects to merge.
 
         Returns:
-            A list of merged Cluster objects.
+            list[Cluster[EntryT]]: A list of merged Cluster objects.
         """
         current_clusters = clusters.copy()  # Make a copy to avoid mutating the input
 

--- a/src/extraction/features/stratigraphy/sidebar/utils/cluster.py
+++ b/src/extraction/features/stratigraphy/sidebar/utils/cluster.py
@@ -6,7 +6,11 @@ from collections.abc import Callable
 from typing import Generic, Self, TypeVar
 
 import pymupdf
-from extraction.features.utils.geometry.util import x_overlap_significant_largest
+from extraction.features.utils.geometry.util import (
+    compute_outer_rect,
+    x_distance_with_y_constraint,
+    x_overlap_significant_largest,
+)
 
 EntryT = TypeVar("EntryT")
 
@@ -41,3 +45,50 @@ class Cluster(abc.ABC, Generic[EntryT]):
                 clusters.append(Cluster(entry_to_rect(entry), [entry], entry_to_rect))
 
         return clusters
+
+    @classmethod
+    def merge_close_clusters(cls, clusters: list["Cluster[EntryT]"]) -> list["Cluster[EntryT]"]:
+        """Iteratively merge clusters that are close to each other.
+
+        Args:
+            clusters: A list of Cluster objects to merge.
+
+        Returns:
+            A list of merged Cluster objects.
+        """
+        current_clusters = clusters.copy()  # Make a copy to avoid mutating the input
+
+        while True:
+            # Flag to track if any merges occurred in this pass
+            merged_occurred = False
+            new_clusters = []
+
+            while current_clusters:
+                base_cluster = current_clusters.pop(0)  # take first cluster
+                entries = base_cluster.entries.copy()
+                rect = compute_outer_rect(entries)
+
+                # Check remaining clusters for potential merges
+                remains = []
+                for other in current_clusters:
+                    other_rect = compute_outer_rect(other.entries)
+                    dist = x_distance_with_y_constraint(rect, other_rect, 0.6)
+                    if dist is not None and dist <= 100.0:
+                        # Merge with base cluster
+                        entries += other.entries
+                        rect = compute_outer_rect(entries)
+                        merged_occurred = True
+                    else:
+                        remains.append(other)
+
+                # Add the (potentially) merged cluster to new list
+                new_clusters.append(cls(rect, entries, base_cluster.entry_to_rect))
+                # Continue with remaining unmerged clusters
+                current_clusters = remains
+
+            # If no merges happened this pass, we're done
+            if not merged_occurred:
+                return new_clusters
+
+            # Otherwise, do another pass with the new clusters
+            current_clusters = new_clusters

--- a/src/extraction/features/utils/geometry/util.py
+++ b/src/extraction/features/utils/geometry/util.py
@@ -1,12 +1,54 @@
 """This module contains general utility functions for the stratigraphy module."""
 
+from collections.abc import Callable
+
 import pymupdf
 from numpy.typing import ArrayLike
 
 from .geometry_dataclasses import Line, Point
 
 
-def x_overlap(rect1: pymupdf.Rect, rect2: pymupdf.Rect) -> float:  # noqa: D103
+def axis_overlap(rect1: pymupdf.Rect, rect2: pymupdf.Rect, axis: str) -> float:
+    """Calculate the overlap between two rectangles along a given axis ('x' or 'y').
+
+    Args:
+        rect1 (pymupdf.Rect): First rectangle.
+        rect2 (pymupdf.Rect): Second rectangle.
+        axis (str): Axis along which to calculate overlap ('x' or 'y').
+
+    Returns:
+        float: The overlap between the two rectangles.
+    """
+    if axis == "x":
+        a0, a1 = rect1.x0, rect1.x1
+        b0, b1 = rect2.x0, rect2.x1
+    elif axis == "y":
+        a0, a1 = rect1.y0, rect1.y1
+        b0, b1 = rect2.y0, rect2.y1
+    else:
+        raise ValueError("Axis must be 'x' or 'y'.")
+
+    if a0 < b1 and b0 < a1:
+        return min(a1, b1) - max(a0, b0)
+    else:
+        return 0.0
+
+
+def axis_overlap_significant(
+    rect1: pymupdf.Rect,
+    rect2: pymupdf.Rect,
+    axis: str,
+    level: float,
+    side_length_func: Callable[[float, float], float],
+) -> bool:
+    """Check if axis overlap is significant based on a comparison of rectangle sizes."""
+    size1 = rect1.width if axis == "x" else rect1.height
+    size2 = rect2.width if axis == "x" else rect2.height
+    return axis_overlap(rect1, rect2, axis) > level * side_length_func(size1, size2)
+
+
+# Now, small wrappers to be nice:
+def x_overlap(rect1: pymupdf.Rect, rect2: pymupdf.Rect) -> float:
     """Calculate the x overlap between two rectangles.
 
     Args:
@@ -16,13 +58,23 @@ def x_overlap(rect1: pymupdf.Rect, rect2: pymupdf.Rect) -> float:  # noqa: D103
     Returns:
         float: The x overlap between the two rectangles.
     """
-    if (rect1.x0 < rect2.x1) and (rect2.x0 < rect1.x1):
-        return min(rect1.x1, rect2.x1) - max(rect1.x0, rect2.x0)
-    else:
-        return 0
+    return axis_overlap(rect1, rect2, axis="x")
 
 
-def x_overlap_significant_smallest(rect1: pymupdf.Rect, rect2: pymupdf.Rect, level: float) -> bool:  # noqa: D103
+def y_overlap(rect1: pymupdf.Rect, rect2: pymupdf.Rect) -> float:
+    """Calculate the y overlap between two rectangles.
+
+    Args:
+        rect1 (pymupdf.Rect): First rectangle.
+        rect2 (pymupdf.Rect): Second rectangle.
+
+    Returns:
+        float: The y overlap between the two rectangles.
+    """
+    return axis_overlap(rect1, rect2, axis="y")
+
+
+def x_overlap_significant_smallest(rect1: pymupdf.Rect, rect2: pymupdf.Rect, level: float) -> bool:
     """Check if the x overlap between two rectangles is significant relative to the width of the narrowest one.
 
     Args:
@@ -33,10 +85,10 @@ def x_overlap_significant_smallest(rect1: pymupdf.Rect, rect2: pymupdf.Rect, lev
     Returns:
         bool: True if the x overlap is significant, otherwise False.
     """
-    return x_overlap(rect1, rect2) > level * min(rect1.width, rect2.width)
+    return axis_overlap_significant(rect1, rect2, axis="x", level=level, side_length_func=min)
 
 
-def x_overlap_significant_largest(rect1: pymupdf.Rect, rect2: pymupdf.Rect, level: float) -> bool:  # noqa: D103
+def x_overlap_significant_largest(rect1: pymupdf.Rect, rect2: pymupdf.Rect, level: float) -> bool:
     """Check if the x overlap between two rectangles is significant relative to the width of the widest one.
 
     Args:
@@ -47,7 +99,35 @@ def x_overlap_significant_largest(rect1: pymupdf.Rect, rect2: pymupdf.Rect, leve
     Returns:
         bool: True if the x overlap is significant, otherwise False.
     """
-    return x_overlap(rect1, rect2) > level * max(rect1.width, rect2.width)
+    return axis_overlap_significant(rect1, rect2, axis="x", level=level, side_length_func=max)
+
+
+def y_overlap_significant_smallest(rect1: pymupdf.Rect, rect2: pymupdf.Rect, level: float) -> bool:
+    """Check if the y overlap between two rectangles is significant relative to the length of the narrowest one.
+
+    Args:
+        rect1 (pymupdf.Rect): First rectangle.
+        rect2 (pymupdf.Rect): Second rectangle.
+        level (float): Level of significance.
+
+    Returns:
+        bool: True if the y overlap is significant, otherwise False.
+    """
+    return axis_overlap_significant(rect1, rect2, axis="y", level=level, side_length_func=min)
+
+
+def y_overlap_significant_largest(rect1: pymupdf.Rect, rect2: pymupdf.Rect, level: float) -> bool:
+    """Check if the y overlap between two rectangles is significant relative to the length of the widest one.
+
+    Args:
+        rect1 (pymupdf.Rect): First rectangle.
+        rect2 (pymupdf.Rect): Second rectangle.
+        level (float): Level of significance.
+
+    Returns:
+        bool: True if the y overlap is significant, otherwise False.
+    """
+    return axis_overlap_significant(rect1, rect2, axis="y", level=level, side_length_func=max)
 
 
 def line_from_array(line: ArrayLike, scale_factor: float) -> Line:
@@ -64,3 +144,65 @@ def line_from_array(line: ArrayLike, scale_factor: float) -> Line:
     start = Point(int(line[0][0] / scale_factor), int(line[0][1] / scale_factor))
     end = Point(int(line[0][2] / scale_factor), int(line[0][3] / scale_factor))
     return Line(start, end)
+
+
+def compute_rect_distance(rect1: pymupdf.Rect, rect2: pymupdf.Rect) -> float:
+    """Calculate the minimum distance between two rectangles.
+
+    Args:
+        rect1 (pymupdf.Rect): The first rectangle.
+        rect2 (pymupdf.Rect): The second rectangle.
+
+    Returns:
+        float: The shortest distance between the two rectangles.
+    """
+    if rect1.intersects(rect2):
+        return 0.0
+
+    dx: float = max(rect2.x0 - rect1.x1, rect1.x0 - rect2.x1, 0)
+    dy: float = max(rect2.y0 - rect1.y1, rect1.y0 - rect2.y1, 0)
+
+    return (dx**2 + dy**2) ** 0.5
+
+
+def x_distance_with_y_constraint(rect1: pymupdf.Rect, rect2: pymupdf.Rect, y_level: float = 0.7) -> float | None:
+    """Compute the horizontal distance between two rectangles if their vertical overlap is significant.
+
+    Args:
+        rect1 (pymupdf.Rect): First rectangle.
+        rect2 (pymupdf.Rect): Second rectangle.
+        y_level (float): Threshold for vertical overlap significance (default 0.7).
+
+    Returns:
+        float | None: x distance if condition met, otherwise None.
+    """
+    if not y_overlap_significant_smallest(rect1, rect2, y_level):
+        return None
+
+    if rect1.x1 <= rect2.x0:
+        return rect2.x0 - rect1.x1
+    elif rect2.x1 <= rect1.x0:
+        return rect1.x0 - rect2.x1
+    else:
+        return 0.0
+
+
+def compute_outer_rect(entries: list) -> pymupdf.Rect:
+    """Compute the outer rectangle that contains all rectangles of each entry.
+
+    Args:
+        entries (list): List of objects having a 'rect' attribute (pymupdf.Rect).
+
+    Returns:
+        pymupdf.Rect: The minimal rectangle containing all input rectangles.
+    """
+    if not entries:
+        raise ValueError("Entries list is empty.")
+
+    # Start with the first rect
+    outer_rect: pymupdf.Rect = entries[0].rect
+
+    for entry in entries[1:]:
+        outer_rect |= entry.rect  # Expand the outer_rect to include entry.rect
+
+    return outer_rect


### PR DESCRIPTION
resolves #117 

The goal of this PR is to improve the (visual) detection of boreholes in the files 7317.pdf and 5793.pdf.
To achieve this, new logic has been implemented to find the most detailed and continuous interval list.
Here is a list of the changes:

- Add detailed_sidebars, which are potential sidebars made from the most detailed continued intervals.

- Add a merging of clusters to allow detection of detailed_sidebars that span entries from two distinct entry clusters (see picture: clusters in red, entries that could be part of a detailed sidebar in blue).
This idea, that sidebars can be composed of entries from different clusters, motivated the redefinition of the scoring function (because the noise term no longer made sense).

- Rework of the scoring function:
   - Deactivated the noise term for sidebars other than AAboveBSidebar (since they are extracted from text patches, and the noise will inherently be higher).
   - Added a bonus term to prioritise material descriptions that have a sidebar, over those that do not have any depth associated.
   - Now takes into account the number of lines inside the material description rectangle, as descriptions with more text are more likely to be the correct choice.
   - Tweak the coefficient for the x-distance penalty (now 1.64; require <= 1.64 to improve on 269126143).

- In the _find_material_description_column function, tweak a parameter (required overlap of 0.4 instead of 0.5) to achieve better clustering of text entries (to avoid missing the first row of 5793.pdf).

- Do overall refactoring of some utility functions, without changing their behavior.

<img width="325" alt="image" src="https://github.com/user-attachments/assets/30ed3d27-ab92-4ffd-a212-4fdce6ccc23a" />

---

Below is the list of all document impacted, along with a small description explaining the changes, and if they are good or bad:
### geoquat

12327.pdf: good ✅ layeridentifier sidebar instead of bad depth column 

A11294.pdf : ✅ depth column is detected

B258.pdf : ground water not detected in depth column ✅ 

A11120.pdf : good, did not break description lines✅

8367.pdf : a to b better ✅ (does not take complete (6.3-6.7) because geometric score of straight sidebar is just too better)

5793.pdf: a to b better ✅ in description rect finder needed to change param to 0.4 instead o~~f 0.5~~ for clustering to detection of  1st layer 0-0.2 chaussée

680.pdf actually much cleaner, Layer identifier dominates✅

A76.pdf: better, one more layer identified (thanks to 0.4 in entry clustering)✅

1506.pdf better, correct Layer identifier found (not the one in the column) ✅

13080.pdf : BAD❌ deriaz: 2 boreholes detected, correct sidebar is not chosen because big overlap between rects (so x_distance is big, because the right side of description is far from the left side of sidebar), thus not all depth entry are identified. This causes the 2nd detected borehole not being tagged as duplicated and being not deleted → impact all the metrics, as 2 borehole detected instead of 1

3501.pdf: better✅, 4.3-5.3 missed, because geom score of straight sidebar is just too better)

7317.pdf a to b better ✅

A213.pdf : find depth (better than before, no depth)✅ but miss the first line because mat_descr_rect does not contain it

2537.pdf: pas mal ✅ 6.3 - 7.3 missed because the other straight sidebar has higher score

### zurich

267125439-bp.pdf : bad ❌, a second borehole with 1 entry is detected (probably the old scoring function was optimized for this file)

268124125-bp.pdf : bad ❌, some change on page 3, document is so messy
