### PR TITLE
Feat/issue 121/extract vertical lines

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
                 //"example/example_borehole_profile.pdf",
                 //"data/subset_zurich",
                 //"data/zurich",
-                "data/zurich/695265010-bp.pdf",
+                "data/zurich/267123021-bp.pdf"
+                //"data/zurich/695265010-bp.pdf",
                 // "data/zurich/268123018-bp.pdf", // 2 bh, one with gw
                 // "data/zurich/269126084-bp.pdf", // 2 gw in the same borehole
                 // "data/zurich/267125339-bp.pdf", //groundwater detected

--- a/src/extraction/annotations/plot_utils.py
+++ b/src/extraction/annotations/plot_utils.py
@@ -77,45 +77,22 @@ def _convert_line_to_grid(line: Line, scale_factor: float) -> Line:
 
 
 def plot_lines(page: pymupdf.Page, non_vertical_lines: list[Line], vertical_lines: list[Line] = None, 
-               scale_factor: float = 2.0) -> np.ndarray:
-    """Plot detected lines on a page image.
+               scale_factor: float = 2) -> cv2.COLOR_RGB2BGR:
+    """Given a page object and the lines detected in the page, plot the page with the detected lines.
 
     Args:
-        page (pymupdf.Page): The page to plot lines on.
-        non_vertical_lines (list[Line]): The non-vertical lines to plot.
-        vertical_lines (list[Line], optional): The vertical lines to plot. Defaults to None.
-        scale_factor (float, optional): The scale factor. Defaults to 2.0.
-
-    Returns:
-        np.ndarray: The image with the lines drawn on it.
+        page (pymupdf.Page): The page to draw the lines in.
+        lines (ArrayLike): The lines detected in the pdf.
+        scale_factor (float, optional): The scale factor to apply to the pdf. Defaults to 2.
     """
-    pix = page.get_pixmap(matrix=pymupdf.Matrix(scale_factor, scale_factor))
-    img = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.h, pix.w, 3)
-    img_copy = img.copy()
+    open_cv_img = convert_page_to_opencv_img(page, scale_factor=scale_factor)
 
-    # Draw non-vertical lines in one color (green)
-    for line in non_vertical_lines:
-        cv2.line(
-            img_copy,
-            (int(line.start.x), int(line.start.y)),
-            (int(line.end.x), int(line.end.y)),
-            (0, 255, 0),
-            2,
-        )
+    open_cv_img = _draw_lines(open_cv_img, non_vertical_lines, scale_factor=scale_factor)
 
-    # Draw vertical lines in a different color (red)
     if vertical_lines:
-        for line in vertical_lines:
-            cv2.line(
-                img_copy,
-                (int(line.start.x), int(line.start.y)),
-                (int(line.end.x), int(line.end.y)),
-                (0, 0, 255),
-                2,
-            )
+        open_cv_img = _draw_lines(open_cv_img, vertical_lines, scale_factor=scale_factor)
 
-    return img_copy
-
+    return open_cv_img
 
 def plot_single_line_set(page: pymupdf.Page, lines: list[Line], scale_factor: float = 2.0) -> np.ndarray:
     """Plot a single set of lines (backward compatibility).

--- a/src/extraction/annotations/plot_utils.py
+++ b/src/extraction/annotations/plot_utils.py
@@ -76,14 +76,19 @@ def _convert_line_to_grid(line: Line, scale_factor: float) -> Line:
     return Line(start, end)
 
 
-def plot_lines(page: pymupdf.Page, non_vertical_lines: list[Line], vertical_lines: list[Line] = None, 
-               scale_factor: float = 2) -> cv2.COLOR_RGB2BGR:
+def plot_lines(
+    page: pymupdf.Page, non_vertical_lines: list[Line], vertical_lines: list[Line] = None, scale_factor: float = 2
+) -> cv2.COLOR_RGB2BGR:
     """Given a page object and the lines detected in the page, plot the page with the detected lines.
 
     Args:
         page (pymupdf.Page): The page to draw the lines in.
-        lines (ArrayLike): The lines detected in the pdf.
+        non_vertical_lines (list[Line]): The non-vertical lines to plot.
+        vertical_lines (list[Line], optional): The vertical lines to plot. Defaults to None.
         scale_factor (float, optional): The scale factor to apply to the pdf. Defaults to 2.
+
+    Returns:
+        open_cv_img: The page image with the lines drawn on it.
     """
     open_cv_img = convert_page_to_opencv_img(page, scale_factor=scale_factor)
 
@@ -93,6 +98,7 @@ def plot_lines(page: pymupdf.Page, non_vertical_lines: list[Line], vertical_line
         open_cv_img = _draw_lines(open_cv_img, vertical_lines, scale_factor=scale_factor)
 
     return open_cv_img
+
 
 def plot_single_line_set(page: pymupdf.Page, lines: list[Line], scale_factor: float = 2.0) -> np.ndarray:
     """Plot a single set of lines (backward compatibility).

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -443,24 +443,29 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
 
 def process_page(
-    text_lines: list[TextLine], geometric_lines: list[Line], language: str, page_number: int, **matching_params: dict
+    text_lines: list[TextLine], 
+    geometric_lines: list[Line], 
+    language: str, 
+    page_number: int, 
+    vertical_lines: list[Line] = None,
+    **params: dict
 ) -> list[ExtractedBorehole]:
-    """Process a single PDF page and extract borehole information.
-
-    Acts as a simple interface to MaterialDescriptionRectWithSidebarExtractor without requiring direct class usage.
-
+    """Process a single page of a pdf.
+    
     Args:
         text_lines (list[TextLine]): All text lines on the page.
         geometric_lines (list[Line]): Geometric lines (e.g., from layout analysis).
+        vertical_lines (list[Line], optional): Vertical lines that might be useful for sidebar extraction.
         language (str): Language of the page (used in parsing).
         page_number (int): The page number (0-indexed).
-        **matching_params (dict): Additional parameters for the matching pipeline.
-
+        **params (dict): Additional parameters for the matching pipeline.
+        
     Returns:
         list[ExtractedBorehole]: Extracted borehole layers from the page.
     """
+    # For now, just ignore vertical_lines to maintain existing functionality
     return MaterialDescriptionRectWithSidebarExtractor(
-        text_lines, geometric_lines, language, page_number, **matching_params
+        text_lines, geometric_lines, language, page_number, **params
     ).process_page()
 
 

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -443,29 +443,24 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
 
 def process_page(
-    text_lines: list[TextLine], 
-    geometric_lines: list[Line], 
-    language: str, 
-    page_number: int, 
-    vertical_lines: list[Line] = None,
-    **params: dict
+    text_lines: list[TextLine], geometric_lines: list[Line], language: str, page_number: int, **matching_params: dict
 ) -> list[ExtractedBorehole]:
-    """Process a single page of a pdf.
-    
+    """Process a single PDF page and extract borehole information.
+
+    Acts as a simple interface to MaterialDescriptionRectWithSidebarExtractor without requiring direct class usage.
+
     Args:
         text_lines (list[TextLine]): All text lines on the page.
         geometric_lines (list[Line]): Geometric lines (e.g., from layout analysis).
-        vertical_lines (list[Line], optional): Vertical lines that might be useful for sidebar extraction.
         language (str): Language of the page (used in parsing).
         page_number (int): The page number (0-indexed).
-        **params (dict): Additional parameters for the matching pipeline.
-        
+        **matching_params (dict): Additional parameters for the matching pipeline.
+
     Returns:
         list[ExtractedBorehole]: Extracted borehole layers from the page.
     """
-    # For now, just ignore vertical_lines to maintain existing functionality
     return MaterialDescriptionRectWithSidebarExtractor(
-        text_lines, geometric_lines, language, page_number, **params
+        text_lines, geometric_lines, language, page_number, **matching_params
     ).process_page()
 
 

--- a/src/extraction/features/utils/geometry/geometric_line_utilities.py
+++ b/src/extraction/features/utils/geometry/geometric_line_utilities.py
@@ -14,6 +14,24 @@ from .linesquadtree import LinesQuadTree
 logger = logging.getLogger(__name__)
 
 
+def separate_vertical_lines(lines: list[Line], threshold: float = 0.1) -> tuple[list[Line], list[Line]]:
+    """Given a list of lines, separate vertical lines from non-vertical lines.
+
+    The algorithm identifies vertical lines as those whose absolute slope is larger than 1 / threshold.
+
+    Args:
+        lines (list[Line]): The input lines.
+        threshold (float, optional): The threshold to determine if a line is vertical. Defaults to 0.1.
+
+    Returns:
+        tuple[list[Line], list[Line]]: A tuple containing (non_vertical_lines, vertical_lines)
+    """
+    # Maintain original functionality for backward compatibility
+    non_vertical_lines = [line for line in lines if np.abs(line.slope) < 1 / threshold]
+    vertical_lines = [line for line in lines if np.abs(line.slope) >= 1 / threshold]
+    return non_vertical_lines, vertical_lines
+
+
 def drop_vertical_lines(lines: list[Line], threshold: float = 0.1) -> ArrayLike:
     """Given a list of lines, remove the lines that are close to vertical.
 
@@ -21,13 +39,13 @@ def drop_vertical_lines(lines: list[Line], threshold: float = 0.1) -> ArrayLike:
 
     Args:
         lines (ArrayLike): The lines to remove the vertical lines from.
-        threshold (float, optional): The threshold to determine if a line is vertical. The larger the threshold,
-                                     the fewer lines are considered. Defaults to 0.1.
+        threshold (float, optional): The threshold to determine if a line is vertical. Defaults to 0.1.
 
     Returns:
         ArrayLike: The lines with the vertical lines removed.
     """
-    return [line for line in lines if np.abs(line.slope) < 1 / threshold]
+    non_vertical_lines, _ = separate_vertical_lines(lines, threshold)
+    return non_vertical_lines
 
 
 def is_point_on_line(line: Line, point: Point, tol=10) -> ArrayLike:

--- a/src/extraction/features/utils/geometry/line_detection.py
+++ b/src/extraction/features/utils/geometry/line_detection.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 from numpy.typing import ArrayLike
 from utils.file_utils import read_params
 
-from .geometric_line_utilities import drop_vertical_lines, separate_vertical_lines, merge_parallel_lines_quadtree
+from .geometric_line_utilities import separate_vertical_lines, merge_parallel_lines_quadtree
 from .geometry_dataclasses import Line
 from .util import line_from_array
 
@@ -86,18 +86,3 @@ def extract_lines(page: pymupdf.Page, line_detection_params: dict) -> list[Line]
     )
 
     return merged_non_vertical_lines, merged_vertical_lines
-
-
-# Add backward compatibility wrapper
-def extract_non_vertical_lines(page: pymupdf.Page, line_detection_params: dict) -> list[Line]:
-    """Extract only non-vertical lines from a pdf page (backward compatibility).
-
-    Args:
-        page (pymupdf.Page): The page to extract lines from.
-        line_detection_params (dict): The parameters for the line detection algorithm.
-
-    Returns:
-        list[Line]: The detected non-vertical lines.
-    """
-    non_vertical_lines, _ = extract_lines(page, line_detection_params)
-    return non_vertical_lines

--- a/src/extraction/features/utils/geometry/line_detection.py
+++ b/src/extraction/features/utils/geometry/line_detection.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 from numpy.typing import ArrayLike
 from utils.file_utils import read_params
 
-from .geometric_line_utilities import separate_vertical_lines, merge_parallel_lines_quadtree
+from .geometric_line_utilities import merge_parallel_lines_quadtree, separate_vertical_lines
 from .geometry_dataclasses import Line
 from .util import line_from_array
 

--- a/src/extraction/features/utils/geometry/linesquadtree.py
+++ b/src/extraction/features/utils/geometry/linesquadtree.py
@@ -101,7 +101,7 @@ class LinesQuadTree:
     def _qtree_delete(self, point: Point, line_key: str):
         coordinates = (round(point.x), round(point.y))
         qtree_point = self.qtree.find(coordinates)
-        if qtree_point and line_key in qtree_point.data:
+        if qtree_point in qtree_point.data:
             qtree_point.data.remove(line_key)
             # If the data is now empty, then we could theoretically completely remove the point from the quad tree.
             # However, the current implementation from the quads library does not support removing points. Therefore,

--- a/src/extraction/features/utils/geometry/linesquadtree.py
+++ b/src/extraction/features/utils/geometry/linesquadtree.py
@@ -101,7 +101,7 @@ class LinesQuadTree:
     def _qtree_delete(self, point: Point, line_key: str):
         coordinates = (round(point.x), round(point.y))
         qtree_point = self.qtree.find(coordinates)
-        if qtree_point:
+        if qtree_point and line_key in qtree_point.data:
             qtree_point.data.remove(line_key)
             # If the data is now empty, then we could theoretically completely remove the point from the quad tree.
             # However, the current implementation from the quads library does not support removing points. Therefore,

--- a/src/extraction/main.py
+++ b/src/extraction/main.py
@@ -301,7 +301,12 @@ def start_pipeline(
                     if not mlflow_tracking:
                         logger.warning("MLFlow tracking is not enabled. MLFLow is required to store the images.")
                     else:
-                        img = plot_lines(page, geometric_lines, vertical_lines, scale_factor=line_detection_params["pdf_scale_factor"])
+                        img = plot_lines(
+                            page,
+                            geometric_lines,
+                            vertical_lines,
+                            scale_factor=line_detection_params["pdf_scale_factor"],
+                        )
                         mlflow.log_image(img, f"pages/{filename}_page_{page.number + 1}_lines.png")
 
             # create list of BoreholePrediction objects with all the separate lists

--- a/src/extraction/main.py
+++ b/src/extraction/main.py
@@ -271,7 +271,8 @@ def start_pipeline(
                 logger.info("Processing page %s", page_number)
 
                 text_lines = extract_text_lines(page)
-                geometric_lines = extract_lines(page, line_detection_params)
+                #geometric_lines = extract_lines(page, line_detection_params)
+                geometric_lines, vertical_lines = extract_lines(page, line_detection_params)
                 extracted_boreholes = process_page(
                     text_lines, geometric_lines, file_metadata.language, page_number, **matching_params
                 )
@@ -301,7 +302,7 @@ def start_pipeline(
                     if not mlflow_tracking:
                         logger.warning("MLFlow tracking is not enabled. MLFLow is required to store the images.")
                     else:
-                        img = plot_lines(page, geometric_lines, scale_factor=line_detection_params["pdf_scale_factor"])
+                        img = plot_lines(page, geometric_lines, vertical_lines, scale_factor=line_detection_params["pdf_scale_factor"])
                         mlflow.log_image(img, f"pages/{filename}_page_{page.number + 1}_lines.png")
 
             # create list of BoreholePrediction objects with all the separate lists

--- a/src/extraction/main.py
+++ b/src/extraction/main.py
@@ -271,7 +271,6 @@ def start_pipeline(
                 logger.info("Processing page %s", page_number)
 
                 text_lines = extract_text_lines(page)
-                #geometric_lines = extract_lines(page, line_detection_params)
                 geometric_lines, vertical_lines = extract_lines(page, line_detection_params)
                 extracted_boreholes = process_page(
                     text_lines, geometric_lines, file_metadata.language, page_number, **matching_params


### PR DESCRIPTION
Addresses https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/121

Extracts and plots vertical lines as part of the extract and plot the vertical lines as part of the extract_lines() function. The line extracted are currently not available as part of the process_page() function and only serves as illustrations in the artifacts. In future issues the lines can be passed to process_page() function where corresponding methods for their usage need to be developed:

https://github.com/swisstopo/swissgeol-boreholes-dataextraction/blob/bb4e64f9115ada2c3cc4a64de9e0742bdeabd656/src/extraction/main.py#L274-L278

To keep the compatibility with current approach the naming of the non_vertical lines is kept as geometric_lines in the main.py script

The lines are drawn automatically when the extraction pipeline is executed with the "-l" flag.