### PR TITLE
layers-bb-mismatch

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -5,7 +5,7 @@ left_line_length_threshold: 7
 duplicate_similarity_threshold: 0.5
 layer_identifier_acceptance_ratio: 0.5
 img_template_probability_threshold: 0.62
-min_num_layers: 1
+min_num_layers: 2
 
 depth_column_params:  # these params should be optimized as soon as there is reliable evaluation data
   noise_count_threshold: 1.25

--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -5,6 +5,7 @@ left_line_length_threshold: 7
 duplicate_similarity_threshold: 0.5
 layer_identifier_acceptance_ratio: 0.5
 img_template_probability_threshold: 0.62
+min_num_layers: 1
 
 depth_column_params:  # these params should be optimized as soon as there is reliable evaluation data
   noise_count_threshold: 1.25

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -115,7 +115,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             self._create_borehole_from_pair(pair)
             for pair in sorted(non_duplicated_pairs, key=lambda pair: pair.score_match, reverse=True)
         ]
-        return [borehole for borehole in boreholes if len(borehole.predictions) > self.params["min_num_layers"]]
+        return [borehole for borehole in boreholes if len(borehole.predictions) >= self.params["min_num_layers"]]
 
     def _find_intersecting_indices(
         self, material_descriptions_sidebar_pairs: list[MaterialDescriptionRectWithSidebar]


### PR DESCRIPTION
resolves #211 

This PR aims to address mismatches in layer extraction by refining the logic used in the extraction process.

In _get_interval_block_pairs, the filtering for boreholes with less than 2 layers was removed, as this check was not deleting the correct bounding box.
In process_page, boreholes are now filtered based on the number of layers using the min_num_layers parameter.