### PR TITLE
Fixes to the bedrock config files for USCS and Lithology classification.

### DIFF
--- a/config/bedrock/bedrock_config_lithology.yml
+++ b/config/bedrock/bedrock_config_lithology.yml
@@ -1,7 +1,7 @@
 # Config file for unconsolidated soil classification
 # Prompt file and version
 prompts_file: bedrock/lithology_classification_prompts.yml
-prompt_version: baseline
+prompt_version: v1
 
 # Pattern file and parameter version
 pattern_file: bedrock/lithology_classification_patterns_bedrock.yml

--- a/config/bedrock/bedrock_config_uscs.yml
+++ b/config/bedrock/bedrock_config_uscs.yml
@@ -5,7 +5,7 @@ prompt_version: v7
 
 # Pattern file and parameter version
 pattern_file: bedrock/uscs_classification_patterns_bedrock.yml
-pattern_version: v1
+pattern_version: baseline
 
 # temperature - answer creativity for the LLM model
 temperature: 0.0

--- a/src/scripts/get_files.py
+++ b/src/scripts/get_files.py
@@ -4,8 +4,9 @@ from pathlib import Path
 
 import boto3
 import click
-from stratigraphy import DATAPATH
 from tqdm import tqdm
+
+from stratigraphy import DATAPATH
 
 
 @click.command()

--- a/src/scripts/get_files.py
+++ b/src/scripts/get_files.py
@@ -6,7 +6,7 @@ import boto3
 import click
 from tqdm import tqdm
 
-from stratigraphy import DATAPATH
+from extraction import DATAPATH
 
 
 @click.command()


### PR DESCRIPTION
Fixes issues with https://github.com/swisstopo/swissgeol-boreholes-dataextraction/pull/234 where incorrect config file references where supplied to the AWS Bedrock classifier pipeline. 