### PR TITLE
Reduce docker image size

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,7 @@ AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_ENDPOINT=your_endpoint_url
 AWS_S3_BUCKET=your_bucket_name
+AWS_DEFAULT_REGION=your_default_region
 
 ANTHROPIC_VERSION="bedrock_api_version"
 ANTHROPIC_MODEL_ID="your_model_id"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,13 +18,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Set environment variables
         run: |
           echo VERSION=$(cat VERSION).$GITHUB_RUN_NUMBER >> $GITHUB_ENV
           echo BASE_IMAGE_NAME=$REGISTRY/$(echo ${GITHUB_REPOSITORY,,}) >> $GITHUB_ENV
           echo COMMITED_AT=$(git show -s --format=%cI `git rev-parse HEAD`) >> $GITHUB_ENV
-
+      
       - name: Debug build environment
         run: |
           echo "=== ARCHITECTURE ==="
@@ -33,16 +32,18 @@ jobs:
           echo "=== DOCKER INFO ==="
           docker info
           echo ""
-          echo "=== PYTHON VERSION ==="
-          python --version
-          echo ""
           echo "=== DISK SPACE BEFORE BUILD ==="
           df -h
           echo ""
-          echo "=== COMPARING REQUIREMENTS ==="
-          pip-compile --generate-hashes pyproject.toml
-          head -20 requirements.txt
-
+          echo "=== BUILD CONTEXT SIZE ==="
+          du -sh .
+          echo ""
+          echo "=== DOCKERFILE CONTENT ==="
+          cat Dockerfile
+          echo ""
+          echo "=== PYTHON VERSION ==="
+          python3 --version
+          
       - name: Collect Docker image metadata (api)
         id: meta-api
         uses: docker/metadata-action@v5
@@ -64,7 +65,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner  }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      
       - name: Build and push Docker image (api)
         uses: docker/build-push-action@v5
         with:
@@ -76,7 +77,25 @@ jobs:
           labels: ${{ steps.meta-api.outputs.labels }}
           cache-from: type=registry,ref=${{ env.BASE_IMAGE_NAME }}-api:edge
           cache-to: type=inline
-
+      
+      # DEBUG: Check final image size
+      - name: Check Docker image size and layers
+        run: |
+          echo "=== FINAL IMAGE SIZE ==="
+          docker images ${{ env.BASE_IMAGE_NAME }}-api:edge
+          echo ""
+          echo "=== DOCKER HISTORY (layer sizes) ==="
+          docker history ${{ env.BASE_IMAGE_NAME }}-api:edge --format "table {{.CreatedBy}}\t{{.Size}}" | head -20
+          echo ""
+          echo "=== TOTAL IMAGE SIZE ==="
+          docker image inspect ${{ env.BASE_IMAGE_NAME }}-api:edge --format='{{.Size}}' | numfmt --to=iec
+          echo ""
+          echo "=== DISK SPACE AFTER BUILD ==="
+          df -h
+          echo ""
+          echo "=== DOCKER SYSTEM INFO ==="
+          docker system df
+          
       - name: Create GitHub pre-release
         run: |
           gh api \

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -23,27 +23,6 @@ jobs:
           echo VERSION=$(cat VERSION).$GITHUB_RUN_NUMBER >> $GITHUB_ENV
           echo BASE_IMAGE_NAME=$REGISTRY/$(echo ${GITHUB_REPOSITORY,,}) >> $GITHUB_ENV
           echo COMMITED_AT=$(git show -s --format=%cI `git rev-parse HEAD`) >> $GITHUB_ENV
-      
-      - name: Debug build environment
-        run: |
-          echo "=== ARCHITECTURE ==="
-          uname -a
-          echo ""
-          echo "=== DOCKER INFO ==="
-          docker info
-          echo ""
-          echo "=== DISK SPACE BEFORE BUILD ==="
-          df -h
-          echo ""
-          echo "=== BUILD CONTEXT SIZE ==="
-          du -sh .
-          echo ""
-          echo "=== DOCKERFILE CONTENT ==="
-          cat Dockerfile
-          echo ""
-          echo "=== PYTHON VERSION ==="
-          python3 --version
-          
       - name: Collect Docker image metadata (api)
         id: meta-api
         uses: docker/metadata-action@v5
@@ -65,7 +44,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner  }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
       - name: Build and push Docker image (api)
         uses: docker/build-push-action@v5
         with:
@@ -89,9 +67,6 @@ jobs:
           echo ""
           echo "=== TOTAL IMAGE SIZE ==="
           docker image inspect ${{ env.BASE_IMAGE_NAME }}-api:v${{ env.VERSION }} --format='{{.Size}}' | numfmt --to=iec
-          echo ""
-          echo "=== DISK SPACE AFTER BUILD ==="
-          df -h
           echo ""
           echo "=== DOCKER SYSTEM INFO ==="
           docker system df

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -78,24 +78,24 @@ jobs:
           cache-from: type=registry,ref=${{ env.BASE_IMAGE_NAME }}-api:edge
           cache-to: type=inline
       
-      # DEBUG: Check final image size
+      # Check final image size
       - name: Check Docker image size and layers
         run: |
           echo "=== FINAL IMAGE SIZE ==="
-          docker images ${{ env.BASE_IMAGE_NAME }}-api:edge
+          docker images ${{ env.BASE_IMAGE_NAME }}-api:v${{ env.VERSION }}
           echo ""
           echo "=== DOCKER HISTORY (layer sizes) ==="
-          docker history ${{ env.BASE_IMAGE_NAME }}-api:edge --format "table {{.CreatedBy}}\t{{.Size}}" | head -20
+          docker history ${{ env.BASE_IMAGE_NAME }}-api:v${{ env.VERSION }} --format "table {{.CreatedBy}}\t{{.Size}}" | head -20
           echo ""
           echo "=== TOTAL IMAGE SIZE ==="
-          docker image inspect ${{ env.BASE_IMAGE_NAME }}-api:edge --format='{{.Size}}' | numfmt --to=iec
+          docker image inspect ${{ env.BASE_IMAGE_NAME }}-api:v${{ env.VERSION }} --format='{{.Size}}' | numfmt --to=iec
           echo ""
           echo "=== DISK SPACE AFTER BUILD ==="
           df -h
           echo ""
           echo "=== DOCKER SYSTEM INFO ==="
           docker system df
-          
+
       - name: Create GitHub pre-release
         run: |
           gh api \

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,6 +25,24 @@ jobs:
           echo BASE_IMAGE_NAME=$REGISTRY/$(echo ${GITHUB_REPOSITORY,,}) >> $GITHUB_ENV
           echo COMMITED_AT=$(git show -s --format=%cI `git rev-parse HEAD`) >> $GITHUB_ENV
 
+      - name: Debug build environment
+        run: |
+          echo "=== ARCHITECTURE ==="
+          uname -a
+          echo ""
+          echo "=== DOCKER INFO ==="
+          docker info
+          echo ""
+          echo "=== PYTHON VERSION ==="
+          python --version
+          echo ""
+          echo "=== DISK SPACE BEFORE BUILD ==="
+          df -h
+          echo ""
+          echo "=== COMPARING REQUIREMENTS ==="
+          pip-compile --generate-hashes pyproject.toml
+          head -20 requirements.txt
+
       - name: Collect Docker image metadata (api)
         id: meta-api
         uses: docker/metadata-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,13 @@ WORKDIR /app
 COPY pyproject.toml /app/
 
 # Install pip-tools and use it to resolve dependencies
-RUN pip install --no-cache-dir pip-tools \
-    && pip-compile --generate-hashes \
-    && pip-sync
+RUN pip install --no-cache-dir .
 
 # Curl installation step for health check
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && \
+    apt-get install -y curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy the rest of the application source code into the container
 COPY ./src /app/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ WORKDIR /app
 COPY pyproject.toml /app/
 
 # Install pip-tools and use it to resolve dependencies
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir pip-tools \
+    && pip-compile --generate-hashes \
+    && pip-sync
 
 # Curl installation step for health check
 RUN apt-get update && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,6 @@ dependencies = [
     "nltk",
     "rdflib",
     "pyinstrument==5.0.1",
-    "transformers",
-    "datasets",
-    "torch",
-    "accelerate",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,6 @@ dependencies = [
     "numpy<2",
     "rtree",
     "nltk",
-    "transformers",
-    "datasets",
-    "torch",
-    "accelerate",
     "rdflib",
     "pyinstrument==5.0.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dependencies = [
     "numpy<2",
     "rtree",
     "nltk",
+    "transformers",
+    "datasets",
+    "torch",
+    "accelerate",
     "rdflib",
     "pyinstrument==5.0.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ dependencies = [
     "nltk",
     "rdflib",
     "pyinstrument==5.0.1",
+    "transformers",
+    "datasets",
+    "torch",
+    "accelerate",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,6 @@ dependencies = [
     "numpy<2",
     "rtree",
     "nltk",
-    "transformers",
-    "datasets",
-    "torch",
-    "accelerate",
     "rdflib",
     "pyinstrument==5.0.1",
 ]
@@ -47,7 +43,11 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest==8.1.1",
-    "pytest-cov==5.0.0"
+    "pytest-cov==5.0.0",
+    "transformers",
+    "datasets",
+    "torch",
+    "accelerate",
 ]
 lint = [
     "pre-commit==3.6.2",

--- a/src/classification/classifiers/aws_bedrock_classifier.py
+++ b/src/classification/classifiers/aws_bedrock_classifier.py
@@ -45,7 +45,9 @@ class AWSBedrockClassifier(Classifier):
         """
         self.init_config(classification_system)
         self.classification_system = classification_system
-        self.bedrock_client = boto3.client(service_name="bedrock-runtime", region_name=os.environ.get("AWS_DEFAULT_REGION"))
+        self.bedrock_client = boto3.client(
+            service_name="bedrock-runtime", region_name=os.environ.get("AWS_DEFAULT_REGION")
+        )
         self.anthropic_version = os.environ.get("ANTHROPIC_VERSION")
         self.model_id = os.environ.get("ANTHROPIC_MODEL_ID")
 

--- a/src/classification/classifiers/aws_bedrock_classifier.py
+++ b/src/classification/classifiers/aws_bedrock_classifier.py
@@ -45,7 +45,7 @@ class AWSBedrockClassifier(Classifier):
         """
         self.init_config(classification_system)
         self.classification_system = classification_system
-        self.bedrock_client = boto3.client(service_name="bedrock-runtime", region_name=os.environ.get("AWS_REGION"))
+        self.bedrock_client = boto3.client(service_name="bedrock-runtime", region_name=os.environ.get("AWS_DEFAULT_REGION"))
         self.anthropic_version = os.environ.get("ANTHROPIC_VERSION")
         self.model_id = os.environ.get("ANTHROPIC_MODEL_ID")
 


### PR DESCRIPTION
This PR modifies the Dockerfile to significantly reduce image size and improve build performance.

Changes:
By replacing the pip-tools installation approach (pip-compile + pip-sync) with a simpler  `pip install --no-cache-dir .`, I was able to reduce the image size.

Additionally, I tried to remove the heavy packages: transformers, datasets, torch, accelerate

Results:
With pip-tools:
~10 GB image on GitHub Actions, ~3 GB locally

With pip install .:
~6.37 GB on GitHub, ~2.22 GB locally

After removing heavy packages:
~714 MB on GitHub, ~1.12 GB locally

Trade-offs:
The image is much smaller and builds faster. However, we lose some of the reproducibility benefits from pip-sync, such as precise version locking and hash checking.

I'm not sure if this trade-off is good enough or if we should keep the approach with pip-sync.