### PR TITLE
#230: cleanup unused method 

### DIFF
--- a/src/extraction/features/utils/geometry/geometric_line_utilities.py
+++ b/src/extraction/features/utils/geometry/geometric_line_utilities.py
@@ -14,32 +14,6 @@ from .linesquadtree import LinesQuadTree
 logger = logging.getLogger(__name__)
 
 
-def is_point_on_line(line: Line, point: Point, tol: int = 10) -> bool:
-    """Check if a point is on a line.
-
-    The check is done by calculating the slope and y-intercept of the line and then checking if the point satisfies
-    the equation of the line with some margin tol. Since the lines is only a line segments, the function also checks
-    if the point is between the start and end points of the segment.
-
-    Args:
-        line (Line): a line segment
-        point (Point): any point
-        tol (int, optional): Tolerance to check if point is on the line. Defaults to 10.
-
-    Returns:
-        bool: True if the point is on the line (within the allowed tolerance), False otherwise.
-    """
-    x_start = np.min([line.start.x, line.end.x])
-    x_end = np.max([line.start.x, line.end.x])
-    y_start = np.min([line.start.y, line.end.y])
-    y_end = np.max([line.start.y, line.end.y])
-
-    # Check if the point satisfies the equation of the line
-    return (line.distance_to(point) < tol) and (
-        (x_start - tol <= point.x <= x_end + tol) and (y_start - tol <= point.y <= y_end + tol)
-    )
-
-
 def is_point_near_line(line: Line, point: Point, segment_extension_tol: int = 10, perpendicular_tol: int = 3) -> bool:
     """Check if a point is near a line segment.
 

--- a/tests/test_geometric_line_utilities.py
+++ b/tests/test_geometric_line_utilities.py
@@ -11,7 +11,6 @@ from extraction.features.utils.geometry.geometric_line_utilities import (
     _merge_lines,
     _odr_regression,
     is_point_near_line,
-    is_point_on_line,
     merge_parallel_lines_quadtree,
 )
 from extraction.features.utils.geometry.geometry_dataclasses import Line, Point
@@ -161,22 +160,6 @@ def test_are_close(line1, line2, tol, expected):  # noqa: D103
     assert _are_close(line1, line2, tol) == expected
 
 
-def test_is_point_on_line():  # noqa: D103
-    line = Line(Point(0, 0), Point(100, 100))
-
-    # Test with a point that is on the line
-    point = Point(55.5, 55.5)
-    assert is_point_on_line(line, point, tol=1), "The point should be on the line"
-
-    # Test with a point that is not on the line
-    point = Point(10, 0)
-    assert not is_point_on_line(line, point, tol=5), "The point should not be on the line"
-
-    # Test with a point that is close to the line, within the tolerance
-    point = Point(50, 55)
-    assert is_point_on_line(line, point, tol=6), "The point should be on the line within the tolerance"
-
-
 def test_merge_parallel_lines_quadtree():  # noqa: D103
     lines = [
         Line(Point(0, 0), Point(1, 1)),  # line 1
@@ -198,6 +181,11 @@ def test_merge_parallel_lines_quadtree():  # noqa: D103
         (Line(Point(0, 0), Point(10, 0)), Point(21, 0), 10, 3, False),
         # Point is just outside segment range, but within tol
         (Line(Point(0, 0), Point(10, 0)), Point(20, 0), 10, 3, True),
+        # Tests with a diagonal line
+        (Line(Point(0, 0), Point(100, 100)), Point(55.5, 55.5), 1, 1, True),
+        (Line(Point(0, 0), Point(100, 100)), Point(0, 5), 1, 1, False),
+        (Line(Point(0, 0), Point(100, 100)), Point(100, 95), 1, 1, False),
+        (Line(Point(0, 0), Point(100, 100)), Point(100, 95), 10, 10, True),
     ],
 )
 def test_is_point_near_line(line, point, tol, tol_line, expected):  # noqa: D103


### PR DESCRIPTION
Follow-up for https://github.com/swisstopo/swissgeol-boreholes-dataextraction/pull/237

Removes the method `is_point_on_line` that was no longer used in the code (except for unit tests).

The test cases have been preserved (in slightly adapted form) as unit tests for the new method `is_point_near_line`.