### PR TITLE
Feat/issue 228/page rect object

### DIFF
--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -519,12 +519,12 @@ class LayerMaterialDescriptionSchema(BaseModel):
             text=prediction.feature.text,
             bounding_boxes=[
                 BoundingBoxWithPage(
-                    page_number=line_feature.page,
+                    page_number=line_feature.page_number,
                     x0=line_feature.rect.x0,
                     y0=line_feature.rect.y0,
                     x1=line_feature.rect.x1,
                     y1=line_feature.rect.y1,
-                ).rescale_factor(*pdf_img_scalings[line_feature.page - 1])
+                ).rescale_factor(*pdf_img_scalings[line_feature.page_number - 1])
                 for line_feature in prediction.feature.lines
             ],
         )
@@ -579,7 +579,7 @@ class BoreholeLayerSchema(BaseModel):
             else None
         )
         # the page number of Layer is the same for both depth entries
-        layer_page_number = prediction.material_description.page
+        layer_page_number = prediction.material_description.page_number
         start = (
             LayerDepthSchema.from_prediction(prediction.depths.start, pdf_img_scalings, layer_page_number)
             if prediction.depths and prediction.depths.start

--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -579,7 +579,7 @@ class BoreholeLayerSchema(BaseModel):
             else None
         )
         # the page number of Layer is the same for both depth entries
-        layer_page_number = prediction.material_description.p_rect.page_number
+        layer_page_number = prediction.material_description.page
         start = (
             LayerDepthSchema.from_prediction(prediction.depths.start, pdf_img_scalings, layer_page_number)
             if prediction.depths and prediction.depths.start

--- a/src/extraction/annotations/draw.py
+++ b/src/extraction/annotations/draw.py
@@ -69,19 +69,19 @@ def draw_predictions(
                         groundwaters = borehole_predictions.groundwater_in_borehole
                         bh_layers = borehole_predictions.layers_in_borehole
 
-                        if coordinates is not None and page_number == coordinates.page:
+                        if coordinates is not None and page_number == coordinates.page_number:
                             draw_feature(
                                 shape,
                                 coordinates.rect * page.derotation_matrix,
                                 coordinates.feature.is_correct,
                                 "purple",
                             )
-                        if elevation is not None and page_number == elevation.page:
+                        if elevation is not None and page_number == elevation.page_number:
                             draw_feature(
                                 shape, elevation.rect * page.derotation_matrix, elevation.feature.is_correct, "blue"
                             )
                         for groundwater_entry in groundwaters.groundwater_feature_list:
-                            if page_number == groundwater_entry.page:
+                            if page_number == groundwater_entry.page_number:
                                 draw_feature(
                                     shape,
                                     groundwater_entry.rect * page.derotation_matrix,
@@ -96,7 +96,11 @@ def draw_predictions(
                         draw_material_descriptions(
                             shape,
                             page.derotation_matrix,
-                            [layer for layer in bh_layers.layers if layer.material_description.page == page_number],
+                            [
+                                layer
+                                for layer in bh_layers.layers
+                                if layer.material_description.page_number == page_number
+                            ],
                         )
 
                     shape.commit()  # Commit all the drawing operations to the page

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -364,7 +364,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
         if len(candidate_description) == 0:
             return []
 
-        description_clusters = []
+        description_clusters: list[list[TextLine]] = []
         while len(is_description) > 0:
             # 0.4 instead of 0.5 slightly improves geoquat/validation/A76.pdf
             coverage_by_generating_line = [
@@ -372,7 +372,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 for line in is_description
             ]
 
-            def filter_coverage(coverage):
+            def filter_coverage(coverage: list[TextLine]) -> list[TextLine]:
                 if coverage:
                     min_x0 = min(line.rect.x0 for line in coverage)
                     max_x1 = max(line.rect.x1 for line in coverage)
@@ -405,7 +405,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             best_x1 = max([line.rect.x1 for line in good_lines])
 
             # expand to include entire last block
-            def is_below(best_x0, best_y1, line):
+            def is_below(best_x0, best_y1, line: TextLine):
                 return (
                     (line.rect.x0 > best_x0 - 5)
                     and (line.rect.x0 < (best_x0 + best_x1) / 2)  # noqa: B023

--- a/src/extraction/features/metadata/coordinate_extraction.py
+++ b/src/extraction/features/metadata/coordinate_extraction.py
@@ -244,7 +244,7 @@ class CoordinateExtractor(DataExtractor):
 
     @staticmethod
     def _match_text_with_rect(
-        lines: list[TextLine], pattern: regex.Regex, preprocess=lambda x: x
+        lines: list[TextLine], pattern: regex.Pattern, preprocess=lambda x: x
     ) -> list[(regex.Match, pymupdf.Rect)]:
         full_text = ""
         lines_with_position = []
@@ -257,7 +257,7 @@ class CoordinateExtractor(DataExtractor):
 
         results = []
         for match in pattern.finditer(full_text):
-            match_lines = [
+            match_lines: list[TextLine] = [
                 entry["line"]
                 for entry in lines_with_position
                 if entry["end"] >= match.start() and entry["start"] < match.end()

--- a/src/extraction/features/predictions/predictions.py
+++ b/src/extraction/features/predictions/predictions.py
@@ -222,7 +222,7 @@ class BoreholeListBuilder:
                 assert borehole_index not in borehole_index_to_matched_elem_index
                 assert available_elements
                 # if multiple element are bound to the same borehole, always pick the highest on the page
-                best_element = min(available_elements, key=lambda elem: (elem.page, elem.rect.y0))
+                best_element = min(available_elements, key=lambda elem: (elem.page_number, elem.rect.y0))
                 # fill the mapping borehole_index -> element and remove the element from the element list
                 borehole_index_to_matched_elem_index[borehole_index] = best_element
                 element_list.remove(best_element)
@@ -231,7 +231,7 @@ class BoreholeListBuilder:
 
     def _compute_distance(self, feat: FeatureOnPage, bounding_boxes: list[PageBoundingBoxes]) -> float:
         """Computes the distance between a FeatureOnPage objects and the bounding boxes of one borehole."""
-        bbox = next((bbox for bbox in bounding_boxes if bbox.page == feat.page), None)
+        bbox = next((bbox for bbox in bounding_boxes if bbox.page == feat.page_number), None)
         if bbox is None:
             # the current boreholes layers don't appear on the page where the element is
             return float("inf")

--- a/src/extraction/features/utils/data_extractor.py
+++ b/src/extraction/features/utils/data_extractor.py
@@ -11,6 +11,7 @@ from typing import Generic, Self, TypeVar
 import pymupdf
 import regex
 
+from extraction.features.utils.geometry.geometry_dataclasses import RectWithPage, RectWithPageMixin
 from extraction.features.utils.text.textline import TextLine
 from utils.file_utils import read_params
 
@@ -49,13 +50,12 @@ class ExtractedFeature(metaclass=ABCMeta):
 T = TypeVar("T", bound=ExtractedFeature)
 
 
-@dataclass
-class FeatureOnPage(Generic[T]):
+class FeatureOnPage(Generic[T], RectWithPageMixin):
     """Class for an extracted feature, together with the page and where on that page the feature was extracted from."""
 
-    feature: T
-    rect: pymupdf.Rect  # The rectangle that contains the extracted information
-    page: int  # The page number of the PDF document
+    def __init__(self, feature: T, rect: pymupdf.Rect, page: int):
+        self.feature = feature
+        self.rect_with_page = RectWithPage(rect, page)
 
     def to_json(self) -> dict:
         """Converts the object to a dictionary.
@@ -66,7 +66,7 @@ class FeatureOnPage(Generic[T]):
         result = self.feature.to_json()
         result.update(
             {
-                "page": self.page if self.page else None,
+                "page": self.page_number if self.page_number else None,
                 "rect": [self.rect.x0, self.rect.y0, self.rect.x1, self.rect.y1] if self.rect else None,
             }
         )

--- a/src/extraction/features/utils/geometry/geometry_dataclasses.py
+++ b/src/extraction/features/utils/geometry/geometry_dataclasses.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
+from typing import Protocol
 
 import numpy as np
 import pymupdf
@@ -115,3 +116,21 @@ class RectWithPage:
 
     rect: pymupdf.Rect
     page_number: int
+
+
+class SupportsRectWithPage(Protocol):
+    """Protocol to ensure that a class has a rect_with_page attribute."""
+
+    rect_with_page: RectWithPage
+
+
+class RectWithPageMixin:
+    """Mixin class to facilitate the access to the rect and page_number of a SupportsRectWithPage object."""
+
+    @property
+    def rect(self: SupportsRectWithPage):
+        return self.rect_with_page.rect
+
+    @property
+    def page_number(self: SupportsRectWithPage):
+        return self.rect_with_page.page_number

--- a/src/extraction/features/utils/geometry/geometry_dataclasses.py
+++ b/src/extraction/features/utils/geometry/geometry_dataclasses.py
@@ -107,3 +107,11 @@ class BoundingBox:
     @classmethod
     def from_json(cls, data) -> BoundingBox:
         return cls(rect=pymupdf.Rect(data))
+
+
+@dataclass
+class RectWithPage:
+    """Dataclass to store a rectangle and the page number it appears on."""
+
+    rect: pymupdf.Rect
+    page_number: int

--- a/src/extraction/features/utils/text/textblock.py
+++ b/src/extraction/features/utils/text/textblock.py
@@ -12,6 +12,7 @@ from extraction.features.utils.data_extractor import (
     ExtractedFeature,
     FeatureOnPage,
 )
+from extraction.features.utils.geometry.geometry_dataclasses import RectWithPage, RectWithPageMixin
 
 from .textline import TextLine
 
@@ -52,7 +53,7 @@ class MaterialDescription(ExtractedFeature):
 
 
 @dataclass
-class TextBlock:
+class TextBlock(RectWithPageMixin):
     """Class to represent a block of text in a PDF document.
 
     A TextBlock is a collection of Lines surrounded by Lines.
@@ -66,22 +67,20 @@ class TextBlock:
         self.line_count = len(self.lines)
         self.text = " ".join([line.text for line in self.lines])
         if self.line_count:
-            self.rect = pymupdf.Rect(
+            rect = pymupdf.Rect(
                 min(line.rect.x0 for line in self.lines),
                 min(line.rect.y0 for line in self.lines),
                 max(line.rect.x1 for line in self.lines),
                 max(line.rect.y1 for line in self.lines),
             )
         else:
-            self.rect = pymupdf.Rect()
+            rect = pymupdf.Rect()
 
         # go through all the lines and check if they are on the same page
         page_number_set = set(line.page_number for line in self.lines)
         assert len(page_number_set) < 2, "TextBlock spans multiple pages"
-        if page_number_set:
-            self.page_number = page_number_set.pop()
-        else:
-            self.page_number = None
+        page_number = page_number_set.pop() if page_number_set else None
+        self.rect_with_page = RectWithPage(rect, page_number)
 
     def concatenate(self, other: TextBlock) -> TextBlock:
         """Concatenate two text blocks.

--- a/src/extraction/features/utils/text/textline.py
+++ b/src/extraction/features/utils/text/textline.py
@@ -7,14 +7,14 @@ import re
 import pymupdf
 from nltk.stem.snowball import SnowballStemmer
 
-from extraction.features.utils.geometry.geometry_dataclasses import RectWithPage
+from extraction.features.utils.geometry.geometry_dataclasses import RectWithPage, RectWithPageMixin
 from extraction.features.utils.geometry.util import x_overlap_significant_largest
 from utils.file_utils import read_params
 
 material_description = read_params("matching_params.yml")["material_description"]
 
 
-class TextWord:
+class TextWord(RectWithPageMixin):
     """Class to represent a word on a specific location on a PDF page.
 
     A TextWord object consists of a pymupdf Rectangle object and a string.
@@ -26,19 +26,11 @@ class TextWord:
         self.rect_with_page = RectWithPage(rect, page)
         self.text = text
 
-    @property
-    def rect(self):
-        return self.rect_with_page.rect
-
-    @property
-    def page_number(self):
-        return self.rect_with_page.page_number
-
     def __repr__(self) -> str:
         return f"TextWord({self.rect}, {self.text})"
 
 
-class TextLine:
+class TextLine(RectWithPageMixin):
     """Class to represent TextLine objects.
 
     A TextLine object is a collection of DepthInterval objects.
@@ -57,17 +49,6 @@ class TextLine:
             rect.include_rect(word.rect)
         self.rect_with_page = RectWithPage(rect, words[0].page_number)
         self.words = words
-
-    @property
-    def rect(self):
-        return self.rect_with_page.rect
-
-    @property
-    def page_number(self):
-        return self.rect_with_page.page_number
-
-    # Doing so, I really dont see the point of creating a RectWithPage object, as it is directly abstracted and
-    # never accessed from outside the class.
 
     def is_description(self, material_description: dict, language: str):
         """Check if the line is a material description.

--- a/src/extraction/features/utils/text/textline.py
+++ b/src/extraction/features/utils/text/textline.py
@@ -7,6 +7,7 @@ import re
 import pymupdf
 from nltk.stem.snowball import SnowballStemmer
 
+from extraction.features.utils.geometry.geometry_dataclasses import RectWithPage
 from extraction.features.utils.geometry.util import x_overlap_significant_largest
 from utils.file_utils import read_params
 
@@ -22,9 +23,16 @@ class TextWord:
     """
 
     def __init__(self, rect: pymupdf.Rect, text: str, page: int):
-        self.rect = rect
+        self.rect_with_page = RectWithPage(rect, page)
         self.text = text
-        self.page_number = page
+
+    @property
+    def rect(self):
+        return self.rect_with_page.rect
+
+    @property
+    def page_number(self):
+        return self.rect_with_page.page_number
 
     def __repr__(self) -> str:
         return f"TextWord({self.rect}, {self.text})"
@@ -44,11 +52,22 @@ class TextLine:
             words (list[TextWord]): The words that make up the line.
             page_number (int): The page number of the line. The first page has idx 1.
         """
-        self.rect = pymupdf.Rect()
+        rect = pymupdf.Rect()
         for word in words:
-            self.rect.include_rect(word.rect)
+            rect.include_rect(word.rect)
+        self.rect_with_page = RectWithPage(rect, words[0].page_number)
         self.words = words
-        self.page_number = words[0].page_number
+
+    @property
+    def rect(self):
+        return self.rect_with_page.rect
+
+    @property
+    def page_number(self):
+        return self.rect_with_page.page_number
+
+    # Doing so, I really dont see the point of creating a RectWithPage object, as it is directly abstracted and
+    # never accessed from outside the class.
 
     def is_description(self, material_description: dict, language: str):
         """Check if the line is a material description.

--- a/tests/test_coordinate_extraction.py
+++ b/tests/test_coordinate_extraction.py
@@ -243,7 +243,7 @@ def test_CoordinateExtractor_get_coordinates_from_lines(text, expected):  # noqa
     expected_east, expected_north = expected
     assert coordinates[0].feature.east.coordinate_value == expected_east
     assert coordinates[0].feature.north.coordinate_value == expected_north
-    assert coordinates[0].page == 1
+    assert coordinates[0].page_number == 1
 
 
 def test_CoordinateExtractor_get_coordinates_from_lines_rect():  # noqa: D103
@@ -251,14 +251,14 @@ def test_CoordinateExtractor_get_coordinates_from_lines_rect():  # noqa: D103
     lines = _create_simple_lines(["start", "2600000 1200000", "end"])
     coordinates = extractor_de.get_coordinates_from_lines(lines, page=1)
     assert coordinates[0].rect == lines[1].rect
-    assert coordinates[0].page == 1
+    assert coordinates[0].page_number == 1
 
     lines = _create_simple_lines(["start", "2600000", "1200000", "end"])
     coordinates = extractor_de.get_coordinates_from_lines(lines, page=1)
     expected_rect = lines[1].rect
     expected_rect.include_rect(lines[2].rect)
     assert coordinates[0].rect == expected_rect
-    assert coordinates[0].page == 1
+    assert coordinates[0].page_number == 1
 
     # Example from 269126143-bp.pdf (a slash in the middle of the coordinates as misread by OCR as the digit 1)
     lines = _create_simple_lines(["269578211260032"])


### PR DESCRIPTION
Resolve #228

This PR introduces a unified RectWithPage object that encapsulates both a rectangle and its associated page number.
To simplify access, classes that hold a RectWithPage now inherit from a new RectWithPageMixin class, which exposes .rect and .page_number as @propertys. This allows continued use of .rect and .page_number directly on the object, without needing to access .rect_with_page.rect or .rect_with_page.page_number.

The PR also resolves the fallback page issue by providing the page_number of the `Layer` object (taken from its `FeatureOnPage[MaterialDescription]` attribute), which is, by construction, the same as the one in the `LayerDepthsEntry` object.