### PR TITLE
Feat/issue 195/identification of borehole profiles (Stijn's approach)

### DIFF
--- a/config/table_detection_params.yml
+++ b/config/table_detection_params.yml
@@ -2,10 +2,7 @@
 min_line_length: 20
 
 # Angle requirements - degrees of tolerance for classification for horizontal/vertical lines
-angle_tolerance: 5
-
-# Distance from page edge to ignore "scan artifacts"
-page_boundary_margin: 5
+angle_tolerance: 10
 
 # Confidence threshold for table detection
 min_confidence: 0.6

--- a/src/app/api/v1/endpoints/extract_stratigraphy.py
+++ b/src/app/api/v1/endpoints/extract_stratigraphy.py
@@ -10,6 +10,7 @@ from app.common.schemas import (
 from extraction.features.extract import extract_page
 from extraction.features.stratigraphy.layer.layer import LayersInDocument
 from extraction.features.utils.geometry.line_detection import extract_lines
+from extraction.features.utils.table_detection import detect_table_structures
 from extraction.features.utils.text.extract_text import extract_text_lines
 from utils.file_utils import read_params
 from utils.language_detection import detect_language_of_document
@@ -50,10 +51,20 @@ def extract_stratigraphy(filename: str) -> ExtractStratigraphyResponse:
         text_lines = extract_text_lines(page)
         geometric_lines = extract_lines(page, line_detection_params)
 
+        # Detect table structures on the page
+        # TODO avoid code duplication with main.py
+        page_rect = page.rect
+        page_width = page_rect.width
+        page_height = page_rect.height
+        table_structures = detect_table_structures(
+            geometric_lines=geometric_lines, page_width=page_width, page_height=page_height, text_lines=text_lines
+        )
+
         page_layers = extract_page(
             layers_with_bb_in_document,
             text_lines,
             geometric_lines,
+            table_structures,
             language,
             page_index,
             document,

--- a/src/extraction/features/utils/table_detection.py
+++ b/src/extraction/features/utils/table_detection.py
@@ -1,12 +1,13 @@
 """This module contains functionalities to detect table like structures."""
 
+import dataclasses
 import logging
 from dataclasses import dataclass
 
 import pymupdf
 
 from extraction.features.stratigraphy.layer.page_bounding_boxes import MaterialDescriptionRectWithSidebar
-from extraction.features.utils.geometry.geometry_dataclasses import Line, Point
+from extraction.features.utils.geometry.geometry_dataclasses import Line
 from utils.file_utils import read_params
 
 logger = logging.getLogger(__name__)
@@ -21,57 +22,6 @@ class TableStructure:
     vertical_lines: list[Line]
     confidence: float
     line_density: float
-
-    def contains_rect(self, rect: pymupdf.Rect) -> bool:
-        """Check if a rectangle is within this table structure."""
-        return (
-            self.bounding_rect.x0 <= rect.x0
-            and rect.x1 <= self.bounding_rect.x1
-            and self.bounding_rect.y0 <= rect.y0
-            and rect.y1 <= self.bounding_rect.y1
-        )
-
-    def to_json(self) -> dict:
-        """Convert the TableStructure object to a JSON serializable format."""
-        return {
-            "bounding_rect": [
-                self.bounding_rect.x0,
-                self.bounding_rect.y0,
-                self.bounding_rect.x1,
-                self.bounding_rect.y1,
-            ],
-            "horizontal_lines": [
-                [[line.start.x, line.start.y], [line.end.x, line.end.y]] for line in self.horizontal_lines
-            ],
-            "vertical_lines": [
-                [[line.start.x, line.start.y], [line.end.x, line.end.y]] for line in self.vertical_lines
-            ],
-            "confidence": self.confidence,
-            "line_density": self.line_density,
-        }
-
-    @classmethod
-    def from_json(cls, data: dict) -> "TableStructure":
-        """Create a TableStructure object from a JSON dictionary."""
-        # Reconstruct horizontal lines
-        horizontal_lines = [
-            Line(start=Point(coords[0][0], coords[0][1]), end=Point(coords[1][0], coords[1][1]))
-            for coords in data["horizontal_lines"]
-        ]
-
-        # Reconstruct vertical lines
-        vertical_lines = [
-            Line(start=Point(coords[0][0], coords[0][1]), end=Point(coords[1][0], coords[1][1]))
-            for coords in data["vertical_lines"]
-        ]
-
-        return cls(
-            bounding_rect=pymupdf.Rect(*data["bounding_rect"]),
-            horizontal_lines=horizontal_lines,
-            vertical_lines=vertical_lines,
-            confidence=data["confidence"],
-            line_density=data["line_density"],
-        )
 
 
 def detect_table_structures(
@@ -92,23 +42,20 @@ def detect_table_structures(
 
     # Filter and classify lines
     filtered_lines = _filter_significant_lines(geometric_lines, config, page_width, page_height)
-    horizontal_lines, vertical_lines = _separate_by_orientation(filtered_lines, config)
-
-    # Need substantial line structure for a table
-    if len(horizontal_lines) < 4 or len(vertical_lines) < 2:
-        return []
+    structure_lines = _separate_by_orientation(filtered_lines, config)
 
     # Find the dominant table structure
-    table_candidate = _find_dominant_table_structure(
-        horizontal_lines, vertical_lines, config, page_width, page_height, text_lines
-    )
-
-    if table_candidate and table_candidate.confidence >= config.get("min_confidence"):
-        logger.info(f"Detected table structure (confidence: {table_candidate.confidence:.3f})")
-        return [table_candidate]
-
-    logger.info("No significant table structure found")
-    return []
+    table_candidates = _find_table_structures(structure_lines, config, page_width, page_height, text_lines)
+    table_candidates = [
+        table
+        for table in table_candidates
+        if len(table.horizontal_lines) >= 3
+        if len(table.vertical_lines) >= 1
+        if table.confidence >= config.get("min_confidence")
+    ]
+    for table in table_candidates:
+        logger.info(f"Detected table structure (confidence: {table.confidence:.3f})")
+    return table_candidates
 
 
 def _filter_significant_lines(
@@ -116,60 +63,107 @@ def _filter_significant_lines(
 ) -> list[Line]:
     """Filter to keep only significantly long lines that could form table structures."""
     min_length = config.get("min_line_length")
-    margin = config.get("page_boundary_margin")
 
-    def is_significant(line: Line) -> bool:
-        """Check if a line is significant based on length and page boundaries."""
-        # Skip very short lines
-        if line.length < min_length:
-            return False
-
-        # Check if any endpoint too close to the edge
-        if page_width and page_height:
-            xs = (line.start.x, line.end.x)
-            ys = (line.start.y, line.end.y)
-            if any(x <= margin or x >= page_width - margin for x in xs):
-                return False
-            if any(y <= margin or y >= page_height - margin for y in ys):
-                return False
-
-        return True
-
-    return [line for line in lines if is_significant(line)]
+    return [line for line in lines if line.length > min_length]
 
 
-def _separate_by_orientation(lines: list[Line], config: dict) -> tuple[list[Line], list[Line]]:
+def _separate_by_orientation(lines: list[Line], config: dict) -> list["StructureLine"]:
     """Separate lines into horizontal and vertical based on angle and tolerance."""
     angle_tolerance = config.get("angle_tolerance")
-    horizontal_lines = []
-    vertical_lines = []
+    structure_lines = []
 
     for line in lines:
         angle = abs(line.angle)
 
         # Horizontal lines (close to 0° or 180°)
         if angle <= angle_tolerance or angle >= (180 - angle_tolerance):
-            horizontal_lines.append(line)
+            structure_lines.append(
+                StructureLine(
+                    start=min(line.start.x, line.end.x),
+                    end=max(line.start.x, line.end.x),
+                    position=(line.start.y + line.end.y) / 2,
+                    is_vertical=False,
+                    line=line,
+                )
+            )
         # Vertical lines (close to 90°)
         elif angle - 90 <= angle_tolerance:
-            vertical_lines.append(line)
+            structure_lines.append(
+                StructureLine(
+                    start=min(line.start.y, line.end.y),
+                    end=max(line.start.y, line.end.y),
+                    position=(line.start.x + line.end.x) / 2,
+                    is_vertical=True,
+                    line=line,
+                )
+            )
 
-    return horizontal_lines, vertical_lines
+    return structure_lines
 
 
-def _find_dominant_table_structure(
-    horizontal_lines: list[Line],
-    vertical_lines: list[Line],
+@dataclasses.dataclass
+class StructureLine:
+    """Helper class for representing horizontal and vertical lines in a table structure."""
+
+    start: float
+    end: float
+    position: float
+    is_vertical: bool
+    line: Line
+
+    def connects_with(self, other: "StructureLine", tolerance: float = 10.0) -> bool:
+        # TODO docstring and unit tests
+        if self.is_vertical == other.is_vertical:
+            position_ok = abs(self.position - other.position) < tolerance
+            start_end_ok = (self.start - tolerance <= min(other.start, other.end) <= self.end + tolerance) or (
+                self.start - tolerance <= max(other.start, other.end) <= self.end + tolerance
+            )
+            return position_ok and start_end_ok
+        else:
+            return (self.start - tolerance < other.position < self.end + tolerance) and (
+                other.start - tolerance < self.position < other.end + tolerance
+            )
+
+
+def _find_table_structures(
+    lines: list[StructureLine],
     config: dict,
     page_width: float = None,
     page_height: float = None,
     text_lines: list = None,
-) -> TableStructure | None:
-    """Find the single dominant table structure on the page."""
-    # Find the overall bounding box of all significant lines
-    all_lines = horizontal_lines + vertical_lines
-    if not all_lines:
-        return None
+) -> list[TableStructure]:
+    """Find the all table structures on the page."""
+    line_partitions = []
+
+    while lines:
+        current_partition = []
+        unprocessed = [lines.pop()]
+        while unprocessed:
+            current_line = unprocessed.pop()
+            remaining_lines = []
+            for line in lines:
+                if current_line.connects_with(line):
+                    unprocessed.append(line)
+                else:
+                    remaining_lines.append(line)
+            current_partition.append(current_line)
+            lines = remaining_lines
+        line_partitions.append(current_partition)
+
+    return [_create_table_structure(lines, config, page_width, page_height, text_lines) for lines in line_partitions]
+
+
+def _create_table_structure(
+    lines: list[StructureLine],
+    config: dict,
+    page_width: float = None,
+    page_height: float = None,
+    text_lines: list = None,
+) -> TableStructure:
+    """Create a table structure from a collection of connected lines."""
+    all_lines: list[Line] = [line.line for line in lines]
+    horizontal_lines: list[Line] = [line.line for line in lines if not line.is_vertical]
+    vertical_lines: list[Line] = [line.line for line in lines if line.is_vertical]
 
     # Calculate bounding box of all lines
     min_x = min(min(line.start.x, line.end.x) for line in all_lines)
@@ -180,100 +174,23 @@ def _find_dominant_table_structure(
     # Create initial bounding rectangle
     bounding_rect = pymupdf.Rect(min_x, min_y, max_x, max_y)
 
-    # Refine the rectangle to focus on the densest region
-    refined_rect = _refine_table_bounds(bounding_rect, horizontal_lines, vertical_lines)
-
-    # Filter lines that contribute to this table
-    table_horizontal_lines = _get_lines_in_rect(horizontal_lines, refined_rect, is_horizontal=True)
-    table_vertical_lines = _get_lines_in_rect(vertical_lines, refined_rect, is_horizontal=False)
-
     # Calculate metrics
-    area = refined_rect.width * refined_rect.height
-    line_density = len(table_horizontal_lines + table_vertical_lines) / (area / 10000)  # normalize the area
+    area = bounding_rect.width * bounding_rect.height
+    # normalize the area
+    line_density = len(horizontal_lines + vertical_lines) / (area / 10000) if area > 0 else 0
 
     # Calculate confidence based on structure quality
     confidence = _calculate_structure_confidence(
-        refined_rect, table_horizontal_lines, table_vertical_lines, config, page_width, page_height, text_lines
+        bounding_rect, horizontal_lines, vertical_lines, config, page_width, page_height, text_lines
     )
 
     return TableStructure(
-        bounding_rect=refined_rect,
-        horizontal_lines=table_horizontal_lines,
-        vertical_lines=table_vertical_lines,
+        bounding_rect=bounding_rect,
+        horizontal_lines=horizontal_lines,
+        vertical_lines=vertical_lines,
         confidence=confidence,
         line_density=line_density,
     )
-
-
-def _refine_table_bounds(
-    initial_rect: pymupdf.Rect, horizontal_lines: list[Line], vertical_lines: list[Line]
-) -> pymupdf.Rect:
-    """Refine the table bounds to focus on the main structure."""
-    # Find the main vertical boundaries (longest or most central vertical lines)
-    if len(vertical_lines) >= 2:
-        # Sort by length and position to find structural lines
-        v_sorted = sorted(vertical_lines, key=lambda line: line.length, reverse=True)
-        main_verticals = v_sorted[: min(10, len(v_sorted))]  # Top 10 longest
-
-        # Get x-coordinates of main vertical lines
-        x_positions = []
-        for line in main_verticals:
-            x_pos = (line.start.x + line.end.x) / 2
-            x_positions.append(x_pos)
-
-        if x_positions:
-            refined_min_x = min(x_positions) - 10  # Small buffer
-            refined_max_x = max(x_positions) + 10.0  # Small buffer
-        else:
-            refined_min_x = initial_rect.x0
-            refined_max_x = initial_rect.x1
-    else:
-        refined_min_x = initial_rect.x0
-        refined_max_x = initial_rect.x1
-
-    # Find the main horizontal boundaries
-    if len(horizontal_lines) >= 2:
-        # Sort by position to find top and bottom structural lines
-        h_sorted = sorted(horizontal_lines, key=lambda line: (line.start.y + line.end.y) / 2)
-        top_line = h_sorted[0]
-        bottom_line = h_sorted[-1]
-
-        refined_min_y = min(top_line.start.y, top_line.end.y) - 5
-        refined_max_y = max(bottom_line.start.y, bottom_line.end.y) + 5
-    else:
-        refined_min_y = initial_rect.y0
-        refined_max_y = initial_rect.y1
-
-    return pymupdf.Rect(refined_min_x, refined_min_y, refined_max_x, refined_max_y)
-
-
-def _get_lines_in_rect(
-    lines: list[Line], rect: pymupdf.Rect, is_horizontal: bool, tolerance: float = 10.0
-) -> list[Line]:
-    """Get lines that intersect with or are contained in the rectangle."""
-    region_lines = []
-
-    for line in lines:
-        if is_horizontal:
-            # For horizontal lines, check if they span across the rect width
-            line_y = (line.start.y + line.end.y) / 2
-            if (
-                rect.y0 - tolerance <= line_y <= rect.y1 + tolerance
-                and max(line.start.x, line.end.x) >= rect.x0
-                and min(line.start.x, line.end.x) <= rect.x1
-            ):
-                region_lines.append(line)
-        else:
-            # For vertical lines, check if they span across the rect height
-            line_x = (line.start.x + line.end.x) / 2
-            if (
-                rect.x0 - tolerance <= line_x <= rect.x1 + tolerance
-                and max(line.start.y, line.end.y) >= rect.y0
-                and min(line.start.y, line.end.y) <= rect.y1
-            ):
-                region_lines.append(line)
-
-    return region_lines
 
 
 def _calculate_structure_confidence(
@@ -319,38 +236,8 @@ def _calculate_structure_confidence(
     return min(1.0, total_confidence)
 
 
-def filter_extraction_pairs_by_tables(
-    material_description_pairs: list["MaterialDescriptionRectWithSidebar"],
-    table_structures: list[TableStructure],
-    proximity_buffer: float = 50.0,
-) -> list["MaterialDescriptionRectWithSidebar"]:
-    """Filter material description pairs by table structures.
-
-    Keeps pairs that are either inside table structures or within proximity of them.
-    Falls back to all pairs if no table structures are detected.
-
-    Args:
-        material_description_pairs: List of MaterialDescriptionRectWithSidebar objects
-        table_structures: List of detected table structures
-        proximity_buffer: Distance in pixels for "close to table" consideration
-
-    Returns:
-        Filtered list of material description pairs
-    """
-    if not material_description_pairs:
-        return material_description_pairs
-
-    filtered_pairs = []
-
-    for pair in material_description_pairs:
-        if _is_pair_relevant_to_tables(pair, table_structures, proximity_buffer):
-            filtered_pairs.append(pair)
-
-    return filtered_pairs
-
-
-def _is_pair_relevant_to_tables(
-    pair: "MaterialDescriptionRectWithSidebar", table_structures: list[TableStructure], proximity_buffer: float
+def _pair_conflicts_with_tables(
+    pair: "MaterialDescriptionRectWithSidebar", table_structures: list[TableStructure], proximity_buffer: float = 50
 ) -> bool:
     """Check if a material description pair is relevant to any table structure.
 
@@ -366,46 +253,32 @@ def _is_pair_relevant_to_tables(
     sidebar_rect = pair.sidebar.rect() if pair.sidebar else None
 
     for table in table_structures:
-        # Check if material description is inside or near table
-        if _is_rect_relevant_to_table(material_rect, table, proximity_buffer):
+        # Check if rectangle is within proximity buffer of table
+        expanded_table_rect = pymupdf.Rect(
+            table.bounding_rect.x0 - proximity_buffer,
+            table.bounding_rect.y0 - proximity_buffer,
+            table.bounding_rect.x1 + proximity_buffer,
+            table.bounding_rect.y1 + proximity_buffer,
+        )
+        shrunk_table_rect = pymupdf.Rect(
+            table.bounding_rect.x0 + proximity_buffer,
+            table.bounding_rect.y0 + proximity_buffer,
+            table.bounding_rect.x1 - proximity_buffer,
+            table.bounding_rect.y1 - proximity_buffer,
+        )
+
+        material_rect_inside = expanded_table_rect.contains(material_rect)
+        material_rect_outside = not shrunk_table_rect.intersects(material_rect)
+        if not (material_rect_inside or material_rect_outside):
             return True
 
-        # Check if sidebar is inside or near table
-        if sidebar_rect and _is_rect_relevant_to_table(sidebar_rect, table, proximity_buffer):
-            return True
+        # Note: we currently allow the material rect to be inside the table and the sidebar rect to be outside,
+        # or vice versa. Otherwise, we get bad results for e.g. 267124180-bp.pdf.
+        if sidebar_rect:
+            sidebar_rect_inside = expanded_table_rect.contains(sidebar_rect)
+            sidebar_rect_outside = not shrunk_table_rect.intersects(sidebar_rect)
+            if not (sidebar_rect_inside or sidebar_rect_outside):
+                return True
 
-    return False
-
-
-def _is_rect_relevant_to_table(rect: pymupdf.Rect, table: TableStructure, proximity_buffer: float) -> bool:
-    """Check if a rectangle is inside or near a table structure.
-
-    Args:
-        rect: Rectangle to check
-        table: Table structure
-        proximity_buffer: Distance threshold for proximity
-
-    Returns:
-        True if rectangle is inside table or within proximity buffer
-    """
-    table_rect = table.bounding_rect
-
-    # Check if rectangle is inside table
-    if table.contains_rect(rect):
-        return True
-
-    # Check if rectangle is within proximity buffer of table
-    expanded_table_rect = pymupdf.Rect(
-        table_rect.x0 - proximity_buffer,
-        table_rect.y0 - proximity_buffer,
-        table_rect.x1 + proximity_buffer,
-        table_rect.y1 + proximity_buffer,
-    )
-
-    # Check for any overlap with expanded table area
-    return not (
-        rect.x1 < expanded_table_rect.x0
-        or rect.x0 > expanded_table_rect.x1
-        or rect.y1 < expanded_table_rect.y0
-        or rect.y0 > expanded_table_rect.y1
-    )
+        # no conflict
+        return False


### PR DESCRIPTION
@letao Here are my ideas so far

- Partition lines into connected groups when identifying table structures.
- Visualize the table structures in the same way that we visualize the detected lines, without the need to add them to the JSON output in the predictions.
- Visualize all detected table structures once, regardless of whether they are associated with a borehole or not.
- Change the way we use table structures when filtering sidebar-material-description-pairs (still a lot of potential for further optimizations)
- Allow lines again that are at the edge of a page (hopefully, dealing with scan artifacts is no longer necessary, as they are unlikely to be connected to an actual table structure.
- Remove the `_refine_table_bounds`  and `_get_lines_in_rect` methods, which no longer seem necessary, and in some cases (especially Geneva/Deriaz layouts) sometimes seem to make the table structure too small (part of the material descriptions get cut off)
- Introduce a `StructureLine` helper class to make the code a bit cleaner
- Add some TODOs where further work is needed.