### PR TITLE
improve handling of edge cases in geometry methods

### DIFF
--- a/src/extraction/features/stratigraphy/sidebar/classes/a_above_b_sidebar.py
+++ b/src/extraction/features/stratigraphy/sidebar/classes/a_above_b_sidebar.py
@@ -130,6 +130,9 @@ class AAboveBSidebar(Sidebar[DepthColumnEntry]):
 
     def make_ascending(self):
         """Adjust entries in this sidebar for an ascending order."""
+        if not self.entries:
+            return self
+
         median_value = np.median(np.array([entry.value for entry in self.entries]))
 
         for i, entry in enumerate(self.entries):

--- a/src/extraction/features/utils/geometry/geometry_dataclasses.py
+++ b/src/extraction/features/utils/geometry/geometry_dataclasses.py
@@ -58,10 +58,16 @@ class Line:
         Returns:
             float: The distance of the point to the line.
         """
-        return np.abs(
-            (self.end.x - self.start.x) * (self.start.y - point.y)
-            - (self.start.x - point.x) * (self.end.y - self.start.y)
-        ) / np.sqrt((self.end.x - self.start.x) ** 2 + (self.end.y - self.start.y) ** 2)
+        if self.length == 0:
+            return self.start.distance_to(point)
+        else:
+            return (
+                np.abs(
+                    (self.end.x - self.start.x) * (self.start.y - point.y)
+                    - (self.start.x - point.x) * (self.end.y - self.start.y)
+                )
+                / self.length
+            )
 
     @property
     def slope(self) -> float:

--- a/src/extraction/features/utils/geometry/util.py
+++ b/src/extraction/features/utils/geometry/util.py
@@ -141,8 +141,9 @@ def line_from_array(line: ArrayLike, scale_factor: float) -> Line:
     Returns:
         Line: The converted line.
     """
-    start = Point(int(line[0][0] / scale_factor), int(line[0][1] / scale_factor))
-    end = Point(int(line[0][2] / scale_factor), int(line[0][3] / scale_factor))
+    start = Point(line[0][0] / scale_factor, line[0][1] / scale_factor)
+    end = Point(line[0][2] / scale_factor, line[0][3] / scale_factor)
+
     return Line(start, end)
 
 

--- a/tests/test_aabovebsidebar.py
+++ b/tests/test_aabovebsidebar.py
@@ -89,6 +89,9 @@ def test_aabovebsidebar_makeascending():  # noqa: D103
     # ensure a "noise" value "0.0" does not influence the result
     run_test([1.0, 2.0, 3.0, 0.0, 4.0], [1.0, 2.0, 3.0, 0.0, 4.0])
 
+    # edge case
+    run_test([], [])
+
 
 def test_generate_alternatives():
     """Test generate_alternatives function for alternative options to OCR mistakes."""

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -8,8 +8,13 @@ from extraction.features.utils.geometry.geometry_dataclasses import Line, Point
 def test_distance_to():  # noqa: D103
     line = Line(Point(0, 0), Point(0, 1))
     point = Point(1, 0)
-    distance = line.distance_to(point)
-    assert pytest.approx(distance) == 1, "The distance should be approximately 1"
+    assert pytest.approx(line.distance_to(point)) == 1, "The distance should be approximately 1"
+
+    line = Line(Point(0, 0), Point(0, 0))
+    point = Point(1, 0)
+    assert pytest.approx(line.distance_to(point)) == 1, "The distance to a line of length 0 should be 1"
+    point = Point(0, 0)
+    assert pytest.approx(line.distance_to(point)) == 0, "The distance to a line of length 0 should be 0"
 
 
 def test_slope():  # noqa: D103


### PR DESCRIPTION
Get rid of some warning messages from numpy, e.g. when processing Geoquat file A11276.pdf .

The fact that we had some lines of length 0, comes from the rounding of line coordinates in the `line_from_array` method, which I have now removed.

The more accurate line coordinates (floats instead of integers) lead to minor changes in the metrics.

For Zürich, we have minor improvements for 267125339-bp.pdf, 677250019-bp.pdf and 687250019-bp.pdf and a minor drop in accuracy for 680244002-bp.pdf (which is a scan of a boreprofile on [graph paper](https://en.wikipedia.org/wiki/Graph_paper), which understandably is confusing the line detection algorithms, since we've never optimized for this case).
For GeoQuat, we have a minor improvement for A8415.pdf and a minor drop in accuracy for A8236.pdf (where non-straight lines are confusing the algorithm regardless of the precision of the line detection).

Overall, we have a 0.1% improvement in F1 for Zurich and a 0.01% drop in F1 for GeoQuat. None of the individual accuracy drops are directly caused by the changes in this PR, but they rather have unrelated root causes. So I don't see any reason not to use the more accuracy line coordinates.