### PR TITLE
simplify matching with regex, correct wrong references

### DIFF
--- a/config/classification_params.yml
+++ b/config/classification_params.yml
@@ -1,4 +1,4 @@
 default_language: "de"
 supported_language: ["de", "fr", "en", "it"]
 
-reference_key_words: ["wie", "do", "dito", "idem"]
+reference_key_words: ["wie", "do", "dito", "idem", "same as"]

--- a/src/classification/utils/data_formatter.py
+++ b/src/classification/utils/data_formatter.py
@@ -196,7 +196,7 @@ def resolve_reference(
     key_words = "|".join([re.escape(kw) for kw in classification_params["reference_key_words"]])
     key_word_query = rf"^[\s\-]*(?:{key_words})\b"  # contains the capturing group
     depth_query = r"(\d+(?:[.,]\d+)?)"
-    unit_query = r"(?:\s*(?=[müMN])?[müMN])?\b"  #  non-consuming lookahead
+    unit_query = r"(?:\s*(?:[müMN][.\s]*)+)?\b"
     total_query = (
         rf"{key_word_query}"  # match the keyword
         rf"(?:(?:[\s.]|Sp)*-?"  # open optional non-capturing group and allow for various separators (./Sp./-)

--- a/src/classification/utils/data_formatter.py
+++ b/src/classification/utils/data_formatter.py
@@ -194,7 +194,7 @@ def resolve_reference(
         str: The resolved material description, with references replaced by actual descriptions.
     """
     key_words = "|".join([re.escape(kw) for kw in classification_params["reference_key_words"]])
-    key_word_query = rf"^[\s\-]*(?:{key_words})\b"
+    key_word_query = rf"^[\s\-]*(?:{key_words})\b"  # contains the capturing group
     depth_query = r"(\d+(?:[.,]\d+)?)"
     unit_query = r"(?:\s*(?=[müMN])?[müMN])?\b"  #  non-consuming lookahead
     total_query = (

--- a/src/classification/utils/data_formatter.py
+++ b/src/classification/utils/data_formatter.py
@@ -193,51 +193,38 @@ def resolve_reference(
     Returns:
         str: The resolved material description, with references replaced by actual descriptions.
     """
-    matched_kw = None
-    for kw in classification_params["reference_key_words"]:
-        from_start = r"^[\s\-]*(" + re.escape(kw) + r")"
-        match = re.match(from_start, material_description, re.IGNORECASE)
-        if match:
-            matched_kw = match.group()  # Actual matched part from material_description
-            break
+    key_words = "|".join([re.escape(kw) for kw in classification_params["reference_key_words"]])
+    key_word_query = rf"^[\s\-]*(?:{key_words})\b"
+    depth_query = r"(\d+(?:[.,]\d+)?)"
+    unit_query = r"(?:\s*(?=[müMN])?[müMN])?\b"  #  non-consuming lookahead
+    total_query = (
+        rf"{key_word_query}"  # match the keyword
+        rf"(?:(?:[\s.]|Sp)*-?"  # open optional non-capturing group and allow for various separators (./Sp./-)
+        rf"{depth_query}{unit_query}"  # match the first depth with its optional unit
+        rf"(?:[\s-]*"  # open second optional non-capturing group and allow for various separators
+        rf"{depth_query}{unit_query})?)?"  # match the second depth with its optional unit
+    )
 
-    if not matched_kw:
-        return material_description  # No reference found, return as is
+    match = re.match(total_query, material_description, re.IGNORECASE)
+    if not match:
+        return material_description
     if not previous_layers:
         logger.warning(f"Reference keyword found but no previous layer exists: '{material_description}'")
         return material_description
-    # Extract the depth references from the material description
-    depth_str_references = re.findall(r"\d+(?:[.,]\d+)?\s*m?", material_description)
-    depth_str_references = depth_str_references[:2]  # only the first two can be references
-
-    last_str_depth = depth_str_references[-1].strip() if depth_str_references else None
-    if not last_str_depth:
+    if not match.group(1):  # no depth reference, fallback to the previous layer
         referenced_layer = previous_layers[-1]
     else:
-        # Adjust for "Spulprobe" depth format
-        last_depth_pos = material_description.find(last_str_depth)
-        sp_match = re.search(r"[Ss]p", material_description[:last_depth_pos])
-        if sp_match:
-            last_str_depth = depth_str_references[0].strip()  # with Sp, only the first depth is relevant
-
-        # clean the first depth reference.
-        clean_depth_reference = float(depth_str_references[0].replace(",", ".").replace("m", "").strip())
+        clean_depth_reference = float(match.group(1).replace(",", ".").strip())
 
         def match_layer(layer, depths_to_match):
-            if layer["depth_interval"] is None:
-                return False  # No reference found - fallback to previous layer
-            return layer["depth_interval"]["start"] == depths_to_match
+            return layer["depth_interval"]["start"] == depths_to_match if layer["depth_interval"] else False
 
         referenced_layer = next(
             (layer for layer in reversed(previous_layers) if match_layer(layer, clean_depth_reference)),
             previous_layers[-1],  # Fallback to last previous layer
         )
 
-    # Replace the reference in the material description with the actual description of the referenced layer
-    pattern = rf"^.*?{re.escape(last_str_depth) if depth_str_references else re.escape(matched_kw)}"
-
-    # Replace it
-    return re.sub(pattern, referenced_layer["material_description"], material_description).strip()
+    return referenced_layer["material_description"] + material_description[match.end() :]
 
 
 def format_data(descriptions_path: Path, ground_truth_path: Path | None) -> tuple:

--- a/tests/classification/test_data_formatter.py
+++ b/tests/classification/test_data_formatter.py
@@ -22,9 +22,13 @@ def previous_layers():  # noqa: D103
         ("Do but finer.", "Gravel, coarse but finer."),
         ("Dolomite, light grey", "Dolomite, light grey"),
         ("Dirt with 1.0-2.0m depth", "Dirt with 1.0-2.0m depth"),
+        ("wie 2.0 m.ü.M", "Clay, grey, soft"),
+        ("wie 2.0 ", "Clay, grey, soft "),  # extra space should not be matched
+        ("wie 2.0 mit viel stein.", "Clay, grey, soft mit viel stein."),  # the "m" of "mit" should not be matched
     ],
 )
 def test_resolve_reference(description, expected, previous_layers):
     """Test reference resolution with various scenarios."""
     result = resolve_reference(description, previous_layers)
+    print(f"Input: {description}, Resolved: {result}, Expected: {expected}")
     assert result == expected

--- a/tests/classification/test_data_formatter.py
+++ b/tests/classification/test_data_formatter.py
@@ -1,0 +1,30 @@
+"""Tests for the resolve_reference function in data_formatter module."""
+
+import pytest
+
+from classification.utils.data_formatter import resolve_reference
+
+
+@pytest.fixture
+def previous_layers():  # noqa: D103
+    return [
+        {"material_description": "Sand, brown, medium-grained", "depth_interval": {"start": 1.0, "end": 2.0}},
+        {"material_description": "Clay, grey, soft", "depth_interval": {"start": 2.0, "end": 3.0}},
+        {"material_description": "Gravel, coarse", "depth_interval": {"start": 3.0, "end": 4.0}},
+    ]
+
+
+@pytest.mark.parametrize(
+    "description,expected",
+    [
+        ("Silt, dark grey", "Silt, dark grey"),
+        ("Same as 2.0m, but darker", "Clay, grey, soft, but darker"),
+        ("Do but finer.", "Gravel, coarse but finer."),
+        ("Dolomite, light grey", "Dolomite, light grey"),
+        ("Dirt with 1.0-2.0m depth", "Dirt with 1.0-2.0m depth"),
+    ],
+)
+def test_resolve_reference(description, expected, previous_layers):
+    """Test reference resolution with various scenarios."""
+    result = resolve_reference(description, previous_layers)
+    assert result == expected

--- a/tests/classification/test_data_formatter.py
+++ b/tests/classification/test_data_formatter.py
@@ -30,5 +30,4 @@ def previous_layers():  # noqa: D103
 def test_resolve_reference(description, expected, previous_layers):
     """Test reference resolution with various scenarios."""
     result = resolve_reference(description, previous_layers)
-    print(f"Input: {description}, Resolved: {result}, Expected: {expected}")
     assert result == expected


### PR DESCRIPTION
Resolves #254 

This PR simplifies the reference resolution logic in the data formatter by consolidating regex patterns and fixing incorrect reference handling. The changes aim to make the code more maintainable while correcting bugs in depth reference extraction.

- Consolidates multiple regex operations into a single comprehensive pattern
- Fixes incorrect handling of some depth references (like matching the word Dolomites, or matching depths appearing in the middle of the description).
- Simplifies the string replacement logic for resolved references