### PR TITLE
settle on satisfactory version after extensive iteration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "nltk",
     "rdflib",
     "pyinstrument==5.0.1",
+    "shapely==2.1.1",
 ]
 
 [project.optional-dependencies]

--- a/src/extraction/elimination/non_borehole_rejection.py
+++ b/src/extraction/elimination/non_borehole_rejection.py
@@ -89,7 +89,6 @@ def is_borehole_page(text_lines: list[TextLine], language: str) -> bool:
     Returns:
         bool: True if the page is a borehole page, False otherwise.
     """
-    """Classifies Page as Text Page based on word density in TextBlocks and average words per TextLine."""
     if not text_lines:
         return False
     words_per_line = [len(line.words) for line in text_lines]
@@ -115,6 +114,10 @@ def is_borehole_page(text_lines: list[TextLine], language: str) -> bool:
             material_words += 1
     material_words_ratio = material_words / total_words if total_words else 0.0
 
+    # Lillemor's rule
+    # return not (word_density > 0.5 and mean_words_per_line > 3 and material_words_ratio < 0.015)
+
+    # Thresholds obtained by fitting a decision tree and simplifying the classification rules
     return (material_words_ratio <= 0.06 and (mean_words_per_line <= 2.08 or word_density <= 0.39)) or (
         material_words_ratio > 0.06 and mean_words_per_line >= 1.20
     )

--- a/src/extraction/elimination/non_borehole_rejection.py
+++ b/src/extraction/elimination/non_borehole_rejection.py
@@ -1,0 +1,120 @@
+"""Module for detecting and rejecting non-borehole pages based on text content."""
+
+import string
+
+import numpy as np
+import pymupdf
+from shapely.geometry import box
+from shapely.ops import unary_union
+
+from extraction.features.utils.text.textblock import TextBlock
+from extraction.features.utils.text.textline import TextLine
+from utils.file_utils import read_params
+
+matching_params = read_params("matching_params.yml")
+
+
+def overlaps(line, line2) -> bool:
+    """Check if two text lines overlap."""
+    vertical_margin = 15
+    ref_rect = pymupdf.Rect(
+        line.rect.x0,
+        line.rect.y0 - vertical_margin,
+        line.rect.x1,
+        line.rect.y1 + vertical_margin,
+    )
+    return ref_rect.intersects(line2.rect)
+
+
+def adjacent_lines(lines: list[TextLine]) -> list[set[int]]:
+    """Find adjacent lines that overlap."""
+    result = [set() for _ in lines]
+    for index, line in enumerate(lines):
+        for index2, line2 in enumerate(lines):
+            if index2 > index and overlaps(line, line2):
+                result[index].add(index2)
+                result[index2].add(index)
+    return result
+
+
+def apply_transitive_closure(data: list[set[int]]) -> bool:
+    """Apply transitive closure to the adjacency list."""
+    found_new_relation = False
+    for index, adjacent_indices in enumerate(data):
+        new_adjacent_indices = set()
+        for adjacent_index in adjacent_indices:
+            new_adjacent_indices.update(
+                new_index for new_index in data[adjacent_index] if new_index not in data[index]
+            )
+
+        for new_adjacent_index in new_adjacent_indices:
+            data[index].add(new_adjacent_index)
+            data[new_adjacent_index].add(index)
+            found_new_relation = True
+    return found_new_relation
+
+
+def create_text_blocks(text_lines: list[TextLine]) -> list[TextBlock]:
+    """Sort lines into TextBlocks."""
+    data = adjacent_lines(text_lines)
+
+    while apply_transitive_closure(data):
+        pass
+
+    blocks: list[TextBlock] = []
+    remaining_indices = {index for index, _ in enumerate(data)}
+    for index, adjacent_indices in enumerate(data):
+        if index in remaining_indices:
+            selected_indices = adjacent_indices
+            selected_indices.add(index)
+            blocks.append(TextBlock([text_lines[selected_index] for selected_index in sorted(list(selected_indices))]))
+            remaining_indices.difference_update(selected_indices)
+
+    return blocks
+
+
+def get_union_areas(rects: list[pymupdf.Rect]) -> float:
+    """Compute total non-overlapping area from list of bounding box rects."""
+    shapes = [box(rect.x0, rect.y0, rect.x1, rect.y1) for rect in rects]
+    return unary_union(shapes).area if shapes else 0
+
+
+def is_borehole_page(text_lines: list[TextLine], language: str) -> bool:
+    """Determine if a page is a borehole page based on text content.
+
+    Args:
+        text_lines (list[TextLine]): The text lines extracted from the page.
+        language (str): The language of the text content.
+
+    Returns:
+        bool: True if the page is a borehole page, False otherwise.
+    """
+    """Classifies Page as Text Page based on word density in TextBlocks and average words per TextLine."""
+    if not text_lines:
+        return False
+    words_per_line = [len(line.words) for line in text_lines]
+    mean_words_per_line = np.mean(words_per_line)
+
+    text_blocks = create_text_blocks(text_lines)
+    block_union = get_union_areas([block.rect for block in text_blocks])
+    if block_union == 0:
+        return False
+    word_union = get_union_areas(
+        [word.rect for block in text_blocks for line in block.lines for word in line.words if len(line.words) > 1]
+    )
+    word_density = word_union / block_union
+
+    all_text_words = [word for line in text_lines for word in line.words]
+    total_words = 0
+    material_words = 0
+    for word in all_text_words:
+        if not word.text.strip(string.punctuation).isalpha():
+            continue
+        total_words += 1
+        if TextLine([word]).is_description(matching_params["material_description"], language):
+            material_words += 1
+    material_words_ratio = material_words / total_words if total_words else 0.0
+
+    return (material_words_ratio <= 0.06 and (mean_words_per_line <= 2.08 or word_density <= 0.39)) or (
+        material_words_ratio > 0.06 and mean_words_per_line >= 1.20
+    )

--- a/src/extraction/features/utils/text/textline.py
+++ b/src/extraction/features/utils/text/textline.py
@@ -50,7 +50,8 @@ class TextLine(RectWithPageMixin):
         self.rect_with_page = RectWithPage(rect, words[0].page_number)
         self.words = words
 
-    def _get_stemmer(self, language: str) -> SnowballStemmer:
+    @classmethod
+    def _get_stemmer(cls, language: str) -> SnowballStemmer:
         """Get the appropriate stemmer for the given language.
 
         Args:
@@ -64,7 +65,8 @@ class TextLine(RectWithPageMixin):
         stemmer_lang = stemmer_languages.get(language, "german")
         return SnowballStemmer(stemmer_lang)
 
-    def _stem_text(self, stemmer: SnowballStemmer, text: str) -> set:
+    @classmethod
+    def _stem_text(cls, stemmer: SnowballStemmer, text: str) -> set:
         """Stem the text using the provided stemmer.
 
         Args:

--- a/src/extraction/main.py
+++ b/src/extraction/main.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from extraction import DATAPATH
 from extraction.annotations.draw import draw_predictions, plot_tables
 from extraction.annotations.plot_utils import plot_lines
+from extraction.elimination.non_borehole_rejection import is_borehole_page
 from extraction.evaluation.benchmark.score import evaluate_all_predictions
 from extraction.features.extract import extract_page
 from extraction.features.groundwater.groundwater_extraction import (
@@ -284,6 +285,12 @@ def start_pipeline(
 
                 text_lines = extract_text_lines(page)
                 geometric_lines = extract_lines(page, line_detection_params)
+
+                if not is_borehole_page(text_lines, file_metadata.language):
+                    logger.info(
+                        f"Document {in_path}, page {page_index} (0-based) is not a borehole. Skipping extraction"
+                    )
+                    continue
 
                 # Detect table structures on the page
                 table_structures = detect_table_structures(


### PR DESCRIPTION
Resolves #225 and resolves #226 

This PR introduces a feature to automatically detect and skip non-borehole pages during the extraction pipeline, implementing a text-based classification system to filter out irrelevant pages before processing.

The approach presented in #226, which leverages the assumption that non-borehole documents containing borehole-related keywords may include more verbs, did not work for two main reasons:
1. Many non-borehole documents do not actually contain a significant number of verbs, making the approach ineffective in such cases.
2. Identifying verbs reliably is difficult without using a more powerful LLM. NLTK lacks support for languages other than English, and SpaCy often misclassifies adjectives as verbs, which distorts the counts.

For completeness, here are some of the code snippets I used to test this approach.
```python
import spacy

# need python -m spacy download fr_core_news_sm
nlp_fr = spacy.load("fr_core_news_sm")
# need python -m spacy download de_core_news_lg
nlp_de = spacy.load("de_core_news_lg") # trying out the large (lg) model for german

def extract_finite_verbs(text, lang="de"):
    """Extract finite verbs from the text."""
    model_map = {"de": "de_core_news_lg", "fr": "fr_core_news_sm"} 
    nlp = spacy.load(model_map[lang])
    doc = nlp(text)

    return [
        token.text
        for token in doc
        if token.pos_ in ("VERB", "AUX")
        and token.morph.get("VerbForm") == ["Fin"]
        and token.is_alpha
        and (token.dep_ == "ROOT" or token.head.pos_ in ("VERB", "AUX") or token.dep_ in ("aux", "cop"))
    ]
    
stemmer = TextLine._get_stemmer(language)
verbs = extract_finite_verbs(
    " ".join(stemmed for w in all_text_words for stemmed in TextLine._stem_text(stemmer, w.text)), language
)

# continue by computing a ratio with the verbs detected
```

Regarding #225, I don’t see how identifying depth indications earlier would make a difference, since this step is already performed during the borehole extraction stage of the pipeline. If a borehole depths is detected later during the pipeline, it will still be captured at this stage. Therefore, this approach would not eliminate any other boreholes detected in the false positive documents.

## Lillemor's approach
After discussing with Lillemor, I decided to build on her idea and reuse the baseline classifier functions from the `assets` repo. In particular, I kept the three features she extracted and implemented a rule-based classifier to identify potential boreholes before running the extraction step.

Lillemor originally applied the following rule to detect text documents:
```python
is_borehole = not (word_density > 0.5 and mean_words_per_line > 3 and material_words_ratio < 0.015)
```

This rule is conservative: it eliminates few true positives while letting more non-borehole documents pass through. The results were:

zurich : Only page 2 of 267123120-bp.pdf was rejected, which is correct since it contains no borehole.

geoquat : A7111.pdf is rejected as it is very blurry , page 2 of 5111.pdf is incorrectly rejected

false_positives : 10 documents incorrectly detected as boreholes: '24361_8.pdf', '1062_7.pdf', '45004_8.pdf', 'Berichte_NAB_08-021_289.pdf', 'Berichte_NAB_08-025_EWS_20.pdf', '24131_28.pdf', '29192_19.pdf', '45004_7.pdf', 'Berichte_NAB_08-025_EWS_8.pdf', '1677_11.pdf'

Deepwells: Tested on a few PDFs; performance was poor as expected due to the extensive text describing each Sp. entry.

## My approach
Lillemor’s rule used clear and practical thresholds that already worked well. To keep the same idea while making the thresholds slightly more data-driven, I trained a simple decision tree on the false_positive, geoquat/val, and zurich datasets. From this, I extracted decision rules, simplified the tree, and derived the following if-condition:
```python
is_borehole = (
    (material_words_ratio <= 0.06 and (mean_words_per_line <= 2.08 or word_density <= 0.39)) 
    or (material_words_ratio > 0.06 and mean_words_per_line >= 1.20)
)
```

Testing this rule-based classifier produced the following results:

Zurich: Only page 2 of 267123120-bp.pdf was rejected, which is correct since it contains no borehole.

Geoquat: Mixed results. Some files were correctly rejected or accepted, while others were flagged incorrectly due to text-heavy pages. Specifically, V69.pdf, 1007.pdf, and page 2 of 5111.pdf were incorrectly rejected. On the other hand, A7111.pdf and 8366.pdf (page 2) were correctly rejected, as they did not contain any boreholes.

False Positives: Out of 30 files in the false positive folder, only 4 were identified as containing boreholes: 24361_8.pdf, Berichte_NAB_08-021_289.pdf, 29192_19.pdf, Berichte_NAB_08-025_EWS_8.pdf.

Deepwells: Similarly, the performance was poor due to the extensive text describing each Sp. entry.

I did not implement a full pipeline to train the decision tree; the following lines were added to the main function for training the decision tree:
```python
files_with_labels = []
for label_folder in os.listdir(input_directory): # folder containing all datasets in subfolders
    folder_path = os.path.join(input_directory, label_folder)
      for filename in os.listdir(folder_path):
          file_path = os.path.join(folder_path, filename)
          files_with_labels.append((filename, label_folder))

feats = []
labels = []
for filename, subfolder in files_with_labels: # main loop
	in_path = os.path.join(root, subfolder, filename)
	...
	# the function is_borehole_page was modified to return the features material_words_ratio, mean_words_per_line, word_density (or 0,0,0)
	feats.append(is_borehole_page(text_lines, file_metadata.language))
        labels.append(not subfolder.startswith("0_"))
        ...

import numpy as np
from sklearn.metrics import classification_report, confusion_matrix
from sklearn.tree import DecisionTreeClassifier, export_text

clf = DecisionTreeClassifier(max_depth=3)
clf.fit(feats, labels)
print(export_text(clf, feature_names=["word_density", "mean_words_per_line", "material_words_ratio"]))
y_pred = clf.predict(feats)
cm = confusion_matrix(labels, y_pred)
print(cm)
report = classification_report(labels, y_pred, digits=3, output_dict=True)
print(report)
```
## Summary 
Overall, my rule-based classifier performs reasonably well and reduces false positives, but it struggles with text-heavy documents like those in the Deepwells dataset. Lillemor's approach is more conservative, rejecting fewer true positives, which may be more important depending on the use case. Both methods face challenges with text-heavy borehole documents, suggesting that using a rejection step at all might be risky, as it could result in missing too many actual boreholes.