### PR TITLE
Feat/issue 258/follow up table like structures

### DIFF
--- a/config/matching_params.yml
+++ b/config/matching_params.yml
@@ -5,6 +5,8 @@ left_line_length_threshold: 7
 img_template_probability_threshold: 0.62
 min_num_layers: 2
 
+material_description_column_width: 0.08
+
 depth_column_params:  # these params should be optimized as soon as there is reliable evaluation data
   noise_count_threshold: 1.25
   noise_count_offset: 2.5

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -128,13 +128,19 @@ class MaterialDescriptionRectWithSidebarExtractor:
                     if index not in table_groups:
                         table_groups[index] = []
                     table_groups[index].append(pair)
-                else:
+
+                elif pair.score_match >= 0:
                     non_table_pairs.append(pair)
 
             # Keep pairs that meet criteria per table
             for _, pairs in table_groups.items():
-                # Filter by score threshold
-                qualifying_pairs = [p for p in pairs if p.score_match >= 0]
+                qualifying_pairs = [
+                    p
+                    for p in pairs
+                    if p.score_match >= 0
+                    and p.material_description_rect.width
+                    > self.params["material_description_column_width"] * self.page_width
+                ]
                 table_filtered_pairs.extend(qualifying_pairs)
 
             # Add all non-table pairs


### PR DESCRIPTION
Partially addresses https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/258.

We implement a combined filtering method that uses table structures to find potential duplicates and filter them based on score_match parameter, implementing the previous threshold. In cases where no table structures are identified we fall back on the previous logic. It creates simplification by combining the various steps into one logic.

https://github.com/swisstopo/swissgeol-boreholes-dataextraction/blob/41bfbd73628a03ea277fa142659d72caba5cea77/src/extraction/features/extract.py#L117-L148

We improve on the following boreholes, where we are able to identify multiple structures:

- 268124232-bp.pdf
- 675245009-bp.pdf
- 681249142-bp.pdf 
- 684252058-bp.pdf - partial improvements (better on the material description extraction but we loose depth layer)

We reduce a bit the accuracy on: 
- (Geoquat) 13080.pdf - incorrect sidebar association
- (Geoquat) 14273.pdf - incorrect sidebar association
- (Geoquat) A11403.pdf - keyword extraction issue
- (Geoquat) A1304.pdf - additional table structure
- (Geoquat) A263.pdf - additional table structure

I believe the downsides for geoquat dataset (around -0.4%) comes from our deduplication logic, which now is removed in order to simplify and allow for multiple boreholes structures when a table structure is present. In the long run I think this might be beneficial as it allows for more flexibility. The decreased accuracy inn geoquat can be addressed with new issue or expending the solution for this ticket. 