### PR TITLE
Changes to the _test_s3_client() implementation using head_bucket

### DIFF
--- a/src/app/common/aws.py
+++ b/src/app/common/aws.py
@@ -63,19 +63,12 @@ def _test_s3_client(s3_client: boto3.client):
     Args:
         s3_client (boto3.client): The S3 client.
     """
+    if config.bucket_name is None:
+        raise HTTPException(status_code=500, detail="AWS S3 bucket name must be defined.") from None
+
     try:
-        if config.bucket_name:
-            # Test bucket access with a lightweight operation
-            s3_client.head_bucket(Bucket=config.bucket_name)
-
-        else:
-            # Test basic S3 connectivity by listing buckets (requires s3:ListAllMyBuckets permissions)
-            logger.warning(
-                "No S3 bucket configured, S3 connectivity test will be carried out with listing buckets. "
-                "Ensure that the s3:ListAllMyBuckets permissions are available."
-            )
-            s3_client.list_buckets()
-
+        # Test bucket access with a lightweight operation
+        s3_client.head_bucket(Bucket=config.bucket_name)
     except ClientError as e:
         error_code = e.response["Error"]["Code"]
         error_message = e.response["Error"]["Message"]


### PR DESCRIPTION
Addresses: https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/294

In order to avoid the failure due to missing permissions with `list_buckets` method we implement a default check using `head_bucket` as described in the AWS documentation: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html

The fallback to `s3_client.list_buckets()` is kept for instances where `config.bucket_name` might not exist:

https://github.com/swisstopo/swissgeol-boreholes-dataextraction/blob/ac110f6bbac77d27032b2d02230740e65f378c78/src/app/common/aws.py#L60-L79

It is I think quite an unlikely case and if we feel that this condition might not be possible, we can remove the if-else statement.