### PR TITLE
feat/issue-279/borehole-across-page

### DIFF
--- a/src/extraction/features/stratigraphy/layer/layer.py
+++ b/src/extraction/features/stratigraphy/layer/layer.py
@@ -2,15 +2,21 @@
 
 from dataclasses import dataclass
 
+import numpy as np
 import pymupdf
 
 from extraction.features.utils.data_extractor import ExtractedFeature
 from extraction.features.utils.geometry.geometry_dataclasses import RectWithPage, RectWithPageMixin
+from extraction.features.utils.geometry.util import x_overlap_significant_smallest
 from extraction.features.utils.text.textblock import MaterialDescription
 from utils.file_utils import parse_text
 
 from ..interval.interval import Interval
 from .page_bounding_boxes import PageBoundingBoxes
+
+DEPTHS_QUANTILE_SLACK = 0.1
+SIDEBAR_BBOX_OVERLAP = 0.5
+MAT_DESCR_BBOX_OVERLAP = 0.9
 
 
 class LayerDepthsEntry(RectWithPageMixin):
@@ -264,40 +270,181 @@ class LayersInDocument:
         self.filename = filename
 
     def assign_layers_to_boreholes(self, layer_predictions: list[ExtractedBorehole]):
-        """SIMPLIFICATION: currently assumes that if there is more than one page, there is a single borehole.
+        """Assign boreholes from the predictions to the existing boreholes.
 
-        This means that only pdfs with one page could contain more than one borehole.
-        This is the case for all example from zurich and geoquat,validation.
-        If we want to be more robust, a matching should be done to determine which layers goes with which borehole.
+        This method will attempt to match the predicted boreholes to the existing boreholes based on their positions
+        and continuity across pages. If a match is found, the layers are merged; otherwise, new boreholes are added.
 
         Args:
             layer_predictions (list[ExtractedBorehole]): List containing all boreholes with all layers
+
+        Note:
+            This method modifies the state of the object by updating the boreholes_layers_with_bb attribute.
         """
-        if not layer_predictions:
+        # 0. filtering of empty objects
+        if not layer_predictions or not any(lay.predictions for lay in layer_predictions):
             return
         if not self.boreholes_layers_with_bb:
-            # first page
             self.boreholes_layers_with_bb = layer_predictions
-        else:
-            # second page, use assumption, also for the bounding boxes
-            main_borehole = self.boreholes_layers_with_bb[0]
-            borehole_continuation = layer_predictions[0]
-            if (
-                (main_borehole.predictions and main_borehole.predictions[-1].depths)  # ensure depths exist
-                and main_borehole.predictions[-1].depths.start is not None  # start value is set
-                and main_borehole.predictions[-1].depths.end is None  # end value is None
-                and (borehole_continuation.predictions and borehole_continuation.predictions[0].depths)  # depths exist
-                and borehole_continuation.predictions[0].depths.start is None  # start value is None
-                and borehole_continuation.predictions[0].depths.end is not None  # end value is not None
-            ):
-                # if the last interval of the previous page is open-ended, and the first of this page has no start
-                # value, it probably means that they refer to the same layer.
-                main_borehole.predictions[-1] = self._build_spanning_layer(borehole_continuation.predictions[0])
-                borehole_continuation.predictions = borehole_continuation.predictions[1:]
-            main_borehole.bounding_boxes.extend(borehole_continuation.bounding_boxes)
-            main_borehole.predictions.extend(borehole_continuation.predictions)
+            return
+
+        current_page = layer_predictions[0].bounding_boxes[0].page  # all the layer_predictions come from one page
+
+        # 1. Out of the previously detected boreholes, determine which one should be continued.
+        borehole_to_extend = self._identify_borehole_to_extend(current_page)
+        if borehole_to_extend is None:
+            self.boreholes_layers_with_bb.extend(layer_predictions)
+            return
+
+        # 2. If there is more than one borehole on the current page, determine which one should extend the previous
+        borehole_continuation = self._identify_borehole_continuation(layer_predictions)
+        remaining_boreholes = [borehole for borehole in layer_predictions if borehole is not borehole_continuation]
+
+        # 3. Is the the current borehole likelly to be the continuation of the previous.
+        if not self._is_continuation(borehole_to_extend, borehole_continuation, current_page):
+            self.boreholes_layers_with_bb.extend(layer_predictions)
+            return
+
+        # 4. Combine the boreholes and deal with the remaining predictions
+        self._merge_boreholes(borehole_to_extend, borehole_continuation)
+        if remaining_boreholes:
+            self.boreholes_layers_with_bb.extend(remaining_boreholes)
+
+    def _identify_borehole_to_extend(self, current_page: int) -> ExtractedBorehole | None:
+        """Identify the borehole to potentially extend with the layers on this page.
+
+        If there is more than one previous borehole, we rank them to determine the most likely to be continued. The
+        score uses y1 (lower means more likely to continue on the next page) and also the width, so that
+        narrow parasite boreholes don't get too much weight.
+
+        Args:
+            current_page (int): The current page number.
+
+        Returns:
+            ExtractedBorehole | None: The borehole to extend, or None if no borehole is found on the previous page.
+        """
+        assert current_page > 1, "Can't be here on the first page"
+
+        boreholes_with_score = []
+        for borehole in self.boreholes_layers_with_bb:
+            prev_page_bbox = next((bbox for bbox in borehole.bounding_boxes if bbox.page == current_page - 1), None)
+            if not prev_page_bbox:
+                continue
+
+            outer_rect = prev_page_bbox.get_outer_rect()  # get the boreholes outer Rect
+            boreholes_with_score.append((borehole, outer_rect.y1 + outer_rect.width))
+
+        if not boreholes_with_score:
+            # no boreholes on the previous page, the ones detected here can't be the continuation of any
+            return None
+
+        boreholes_with_score.sort(key=lambda x: x[1], reverse=True)  # highest score first
+        return boreholes_with_score[0][0]
+
+    def _identify_borehole_continuation(self, layer_predictions: list[ExtractedBorehole]) -> ExtractedBorehole:
+        """Identify the borehole on the current page that is most likely to be the continuation of the previous.
+
+        Args:
+            layer_predictions (list[ExtractedBorehole]): List containing all detected boreholes on this page.
+
+        Returns:
+            ExtractedBorehole: The borehole that is most likely to be the continuation of the previous.
+        """
+        return min(
+            [(borehole, borehole.bounding_boxes[0].get_outer_rect().y0) for borehole in layer_predictions],
+            key=lambda x: x[1],  # sort by y0 value
+        )[0]  # grab the borehole with the smallest y0
+
+    def _is_continuation(
+        self, borehole_to_extend: ExtractedBorehole, borehole_continuation: ExtractedBorehole, current_page: int
+    ) -> bool:
+        """Determine if the borehole on the current page is the continuation of the previous borehole.
+
+        This method check if the depths are continuous, if the sidebar bounding boxes overlap or if the material
+        description bounding boxes significantly.
+
+        Args:
+            borehole_to_extend (ExtractedBorehole): The borehole from the previous page
+            borehole_continuation (ExtractedBorehole): The borehole from the current page
+            current_page (int): The current page number
+
+        Returns:
+            bool: True if the current borehole is the continuation of the previous borehole, False otherwise.
+        """
+        ok_prev_layers = [lay for lay in borehole_to_extend.predictions if lay.depths is not None]
+        prev_depths = [d.value for lay in ok_prev_layers for d in (lay.depths.start, lay.depths.end) if d is not None]
+
+        ok_layers = [lay for lay in borehole_continuation.predictions if lay.depths is not None]
+        depths = [d.value for lay in ok_layers for d in (lay.depths.start, lay.depths.end) if d is not None]
+        if (
+            depths
+            and prev_depths
+            and np.quantile(depths, DEPTHS_QUANTILE_SLACK) >= np.quantile(prev_depths, 1 - DEPTHS_QUANTILE_SLACK)
+        ):
+            # use quantile to allow some slack (e.g. few undetected duplicated layers)
+            return True  # if depths are continue, it is a continuation
+
+        prev_sidebar_bbox = next(
+            bbox.sidebar_bbox for bbox in borehole_to_extend.bounding_boxes if bbox.page == current_page - 1
+        )
+        current_sidebar_bbox = borehole_continuation.bounding_boxes[0].sidebar_bbox
+        if (
+            prev_sidebar_bbox is not None
+            and current_sidebar_bbox is not None
+            and x_overlap_significant_smallest(prev_sidebar_bbox.rect, current_sidebar_bbox.rect, SIDEBAR_BBOX_OVERLAP)
+        ):
+            return True  # if sidebars overlaps slighly, it is a continuation
+
+        prev_mat_bbox = next(
+            bbox.material_description_bbox
+            for bbox in borehole_to_extend.bounding_boxes
+            if bbox.page == current_page - 1
+        )
+        current_mat_bbox = borehole_continuation.bounding_boxes[0].material_description_bbox
+        return (
+            prev_mat_bbox is not None
+            and current_mat_bbox is not None
+            and x_overlap_significant_smallest(prev_mat_bbox.rect, current_mat_bbox.rect, MAT_DESCR_BBOX_OVERLAP)
+        )  # if material bounding box overlaps significantly, it is a continuation
+
+    def _merge_boreholes(self, borehole_to_extend: ExtractedBorehole, borehole_continuation: ExtractedBorehole):
+        """Merge the layers of the current borehole into the borehole to extend.
+
+        If the last layer of the previous borehole and the first layer of the current borehole appear to be the same
+        layer (based on depth continuity), they are merged into a single layer that spans both pages.
+
+        Args:
+            borehole_to_extend (ExtractedBorehole): The borehole from the previous page
+            borehole_continuation (ExtractedBorehole): The borehole from the current page
+
+        Note:
+            This method modifies the state of the borehole_to_extend object by updating its predictions and bounding
+        """
+        # Do the last layer of the previous borehole and the first of the current belong to the same layer.
+        last_prev_depths = borehole_to_extend.predictions[-1].depths if borehole_to_extend.predictions else None
+        first_depths = borehole_continuation.predictions[0].depths if borehole_continuation.predictions else None
+
+        if (
+            (last_prev_depths and last_prev_depths.start and last_prev_depths.end is None)
+            and (first_depths and first_depths.start is None and first_depths.end)
+            and (last_prev_depths.start.value < first_depths.end.value)
+        ):
+            # if the last interval of the previous page is open-ended, and the first of this page has no start
+            # value, it probably means that they refer to the same layer.
+            borehole_to_extend.predictions[-1] = self._build_spanning_layer(borehole_continuation.predictions[0])
+            borehole_continuation.predictions = borehole_continuation.predictions[1:]
+        borehole_to_extend.bounding_boxes.extend(borehole_continuation.bounding_boxes)
+        borehole_to_extend.predictions.extend(borehole_continuation.predictions)
 
     def _build_spanning_layer(self, first_next_layer: Layer) -> Layer:
+        """Build a new layer that spans the last layer of the previous borehole and the first of the current.
+
+        Args:
+            first_next_layer (Layer): The first layer of the current borehole.
+
+        Returns:
+            Layer: A new layer that contains the material description of both layers and spans their depths.
+        """
         last_prev_layer = self.boreholes_layers_with_bb[0].predictions[-1]
         return Layer(
             material_description=MaterialDescription(

--- a/src/extraction/features/stratigraphy/layer/layer.py
+++ b/src/extraction/features/stratigraphy/layer/layer.py
@@ -300,7 +300,7 @@ class LayersInDocument:
         borehole_continuation = self._identify_borehole_continuation(layer_predictions)
         remaining_boreholes = [borehole for borehole in layer_predictions if borehole is not borehole_continuation]
 
-        # 3. Is the the current borehole likelly to be the continuation of the previous.
+        # 3. Is the current borehole likely to be the continuation of the previous.
         if not self._is_continuation(borehole_to_extend, borehole_continuation, current_page):
             self.boreholes_layers_with_bb.extend(layer_predictions)
             return
@@ -393,7 +393,7 @@ class LayersInDocument:
             and current_sidebar_bbox is not None
             and x_overlap_significant_smallest(prev_sidebar_bbox.rect, current_sidebar_bbox.rect, SIDEBAR_BBOX_OVERLAP)
         ):
-            return True  # if sidebars overlaps slighly, it is a continuation
+            return True  # if sidebars overlaps slightly, it is a continuation
 
         prev_mat_bbox = next(
             bbox.material_description_bbox

--- a/src/extraction/features/stratigraphy/layer/layer.py
+++ b/src/extraction/features/stratigraphy/layer/layer.py
@@ -14,8 +14,6 @@ from ..interval.interval import Interval
 from .page_bounding_boxes import PageBoundingBoxes
 
 DEPTHS_QUANTILE_SLACK = 0.1
-SIDEBAR_BBOX_OVERLAP = 0.5
-MAT_DESCR_BBOX_OVERLAP = 0.9
 
 
 class LayerDepthsEntry(RectWithPageMixin):

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -281,6 +281,13 @@ def test_evaluate_single(value, ground_truth, expected):
 
 def test_assign_layers_to_boreholes():
     """Tests the merging of layer across two pages when both are open-ended."""
+
+    def get_mock_bb(page_number: int):
+        fake_bb = Mock()
+        fake_bb.page = page_number
+        fake_bb.get_outer_rect.return_value = pymupdf.Rect(0, 0, 100, 200)
+        return fake_bb
+
     existing_borehole = ExtractedBorehole(
         [
             Layer(
@@ -294,7 +301,7 @@ def test_assign_layers_to_boreholes():
                 depths=LayerDepths(LayerDepthsEntry(1, pymupdf.Rect(), 0), None),
             ),
         ],
-        [],
+        [get_mock_bb(1)],
     )
     next_page_borehole = ExtractedBorehole(
         [
@@ -305,7 +312,7 @@ def test_assign_layers_to_boreholes():
                 depths=LayerDepths(None, LayerDepthsEntry(2, pymupdf.Rect(), 1)),
             ),
         ],
-        [],
+        [get_mock_bb(2)],
     )
 
     layers_in_doc = LayersInDocument([existing_borehole], "test.pdf")


### PR DESCRIPTION
Resolves #279 

This PR implements functionality to handle borehole layers that span across multiple pages in PDF. Previously, the system made simplistic assumptions about single-page boreholes, but this change introduces logic to match and merge boreholes across pages based on positional and depth continuity.

Overall, the PR barely changes the metrics, since only a few documents are affected. The previous assumption was already good enough. The main difference is in zurich/684252058-bp.pdf, where the pipeline now correctly assigns the continuation layers to the second borehole (which should not be split, but it is unrelated to this issue), slightly improving the metrics.

In data/geoquat/validation/B366.pdf, the borehole detected on the second page is not actually the continuation of the one on the first page (in fact, it is not a borehole at all), but this does not impact the metrics.