### PR TITLE
feat/issue-298/zeroing-starting-depth

### DIFF
--- a/src/app/api/v1/endpoints/extract_stratigraphy.py
+++ b/src/app/api/v1/endpoints/extract_stratigraphy.py
@@ -69,6 +69,7 @@ def extract_stratigraphy(filename: str) -> ExtractStratigraphyResponse:
         )
         layers_with_bb_in_document.assign_layers_to_boreholes(page_layers)
 
+    layers_with_bb_in_document.normalize_first_layer()
     extracted_stratigraphy = create_response_object(layers_with_bb_in_document, pdf_img_scalings)
 
     return extracted_stratigraphy

--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -552,7 +552,9 @@ class LayerDepthSchema(BaseModel):
                     x1=prediction.rect.x1,
                     y1=prediction.rect.y1,
                 ).rescale_factor(*page_scalings)
-            ],
+            ]
+            if prediction.rect
+            else [],
         )
 
 

--- a/src/classification/utils/data_loader.py
+++ b/src/classification/utils/data_loader.py
@@ -49,8 +49,6 @@ def is_valid_depth_interval(layer_depths, start: float, end: float) -> bool:
 
     layer_start = layer_depths["start"]
     layer_end = layer_depths["end"]
-    if layer_start is None:
-        return (start == 0) and (end == layer_end)
 
     if (layer_start is not None) and (layer_end is not None):
         return start == layer_start and end == layer_end

--- a/src/extraction/annotations/draw.py
+++ b/src/extraction/annotations/draw.py
@@ -227,7 +227,7 @@ class PageDrawer:
 
             if layer.depths:
                 depths_rect = pymupdf.Rect()
-                if layer.depths.start and layer.depths.start.page_number == page_number:
+                if layer.depths.start and layer.depths.start.rect and layer.depths.start.page_number == page_number:
                     depths_rect.include_rect(layer.depths.start.rect)
                 if layer.depths.end and layer.depths.end.page_number == page_number:
                     depths_rect.include_rect(layer.depths.end.rect)
@@ -266,13 +266,21 @@ class PageDrawer:
                         )
                 else:
                     # Depths are extracted from the material description: only draw bounding boxes
-                    if layer.depths.start and layer.depths.start.page_number == page_number:
+                    if (
+                        layer.depths.start
+                        and layer.depths.start.rect
+                        and layer.depths.start.page_number == page_number
+                    ):
                         self.shape.draw_rect(pymupdf.Rect(layer.depths.start.rect) * self.page.derotation_matrix)
                     if layer.depths.end and layer.depths.end.page_number == page_number:
                         self.shape.draw_rect(pymupdf.Rect(layer.depths.end.rect) * self.page.derotation_matrix)
                     self.shape.finish(color=pymupdf.utils.getColor("purple"))
 
-                    if layer.depths.start and layer.depths.start.page_number == page_number:
+                    if (
+                        layer.depths.start
+                        and layer.depths.start.rect
+                        and layer.depths.start.page_number == page_number
+                    ):
                         self._draw_correctness_line(
                             start=layer.depths.start.rect.bottom_left,
                             end=layer.depths.start.rect.bottom_right,

--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -424,7 +424,7 @@ def score_depths(layer: Layer, ground_truth: dict) -> float:
     ground_truth_end = ground_truth["depth_interval"]["end"]
 
     if layer.depths is not None:
-        if (layer.depths.start is None and (ground_truth_start == 0 or ground_truth_start is None)) or (
+        if (layer.depths.start is None and ground_truth_start is None) or (
             layer.depths.start is not None and layer.depths.start.value == ground_truth_start
         ):
             depth_score += 0.5

--- a/src/extraction/features/groundwater/groundwater_extraction.py
+++ b/src/extraction/features/groundwater/groundwater_extraction.py
@@ -155,7 +155,7 @@ class Groundwater(ExtractedFeature):
                     for layer in layers
                     if layer.depths is not None
                     for d in (layer.depths.start, layer.depths.end)
-                    if d is not None
+                    if d is not None and d.rect is not None
                 },
                 key=lambda d: d[0],
             )
@@ -419,7 +419,7 @@ class GroundwaterLevelExtractor(DataExtractor):
             areas_of_interest.append(get_text_lines_near_symbol(text_lines, upper_symbol_geom_line))
 
         seen_depths = [lay.depths for bh in extracted_boreholes for lay in bh.predictions if lay.depths]
-        seen_depth_entries = [d for depth in seen_depths for d in (depth.start, depth.end) if d]
+        seen_depth_entries = [d for depth in seen_depths for d in (depth.start, depth.end) if d and d.rect]
 
         found_groundwaters = []
         for text_lines in areas_of_interest:

--- a/src/extraction/features/predictions/predictions.py
+++ b/src/extraction/features/predictions/predictions.py
@@ -83,6 +83,9 @@ class BoreholeListBuilder:
         # only criterion for the number of boreholes in the document is the number of borehole layers identified.
         self._num_boreholes = len(self._layers_with_bb_in_document.boreholes_layers_with_bb)
 
+        # If the first layer of a borehole has no starting depth and meet some conditions, replace the None by 0.0
+        self._layers_with_bb_in_document.normalize_first_layer()
+
         # for each element, perform the perfect matching with the borehole layers, and retrieve the matching dict
         borehole_idx_to_elevation = self._one_to_one_match_element_to_borehole(self._elevations_list)
         borehole_idx_to_coordinate = self._one_to_one_match_element_to_borehole(self._coordinates_list)

--- a/src/extraction/features/utils/geometry/geometry_dataclasses.py
+++ b/src/extraction/features/utils/geometry/geometry_dataclasses.py
@@ -199,7 +199,7 @@ class BoundingBox:
 class RectWithPage:
     """Dataclass to store a rectangle and the page number it appears on."""
 
-    rect: pymupdf.Rect
+    rect: pymupdf.Rect | None
     page_number: int
 
 


### PR DESCRIPTION
Resolves #298 

This PR standardises layer depth handling by assigning a depth of 0.0 to the first layer when no start depth is found in the document, instead of using None. This removes the need for an extra check to verify whether start.depth is None and whether it belongs to the first layer.