### PR TITLE
 Feat/issue-295/random-prediction-geoquat

### DIFF
--- a/src/utils/language_detection.py
+++ b/src/utils/language_detection.py
@@ -1,7 +1,7 @@
 """This module contains functionalities for language detection of a document."""
 
 import pymupdf
-from langdetect import detect
+from langdetect import DetectorFactory, detect
 from langdetect.lang_detect_exception import LangDetectException
 
 
@@ -38,17 +38,19 @@ def detect_language_of_document(doc: pymupdf.Document, default_language: str, su
     return detect_language_of_text(text, default_language, supported_languages)
 
 
-def detect_language_of_text(text: str, default_language: str, supported_languages: list) -> str:
+def detect_language_of_text(text: str, default_language: str, supported_languages: list, seed: int = 0) -> str:
     """Detects the language of a text.
 
     Args:
         text (str): The text to detect the language of.
         default_language (str): The default language to use if the language detection fails.
         supported_languages (list): A list of supported languages.
+        seed (int): Define seed for language detection.
 
     Returns:
         str: The detected language of the document. One of supported_languages.
     """
+    DetectorFactory.seed = seed
     try:
         language = detect(text)
     except LangDetectException:


### PR DESCRIPTION
PR closes https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/295

# Summary

The pipeline’s behavior for `B83.pdf` was erratic because langdetect is nondeterministic by default. Without a fixed seed, the same input text could yield different languages across runs. When the wrong language was predicted, downstream matching used the wrong keywords and the borehole creation failed due to missing matches.

# Root cause 

- `langdetect` relies on randomized initial state unless a global seed is set (DetectorFactory.seed).
- For the same input, different seeds produced conflicting results:

```python
# From B83.pdf
text = "B   Erde mit Steinen  Kies bis  cm DD        Sand mit Kies bis a cm fil FF  o  D o o     o    I o I I    I  "

DetectorFactory.seed = 0
detect_langs(text)  # -> [de:0.9999977789980602]

DetectorFactory.seed = 606
detect_langs(text)  # -> [en:0.5714274884515167, de:0.42856924905782434]
```
