### PR TITLE
Feat/issue 282/optimize the extractpy script

### DIFF
--- a/src/app/api/v1/endpoints/extract_stratigraphy.py
+++ b/src/app/api/v1/endpoints/extract_stratigraphy.py
@@ -13,7 +13,6 @@ from extraction.features.stratigraphy.layer.layer import LayersInDocument
 from extraction.features.utils.geometry.line_detection import extract_lines
 from extraction.features.utils.strip_log_detection import detect_strip_logs
 from extraction.features.utils.table_detection import (
-    detect_structure_lines,
     detect_table_structures,
 )
 from extraction.features.utils.text.extract_text import extract_text_lines
@@ -57,8 +56,7 @@ def extract_stratigraphy(filename: str) -> ExtractStratigraphyResponse:
         geometric_lines = extract_lines(page, line_detection_params)
 
         # Detect table structures on the page
-        structure_lines = detect_structure_lines(geometric_lines)
-        table_structures = detect_table_structures(page_index, document, structure_lines, text_lines)
+        table_structures = detect_table_structures(page_index, document, geometric_lines, text_lines)
 
         # Detect strip logs on the page
         strip_logs = detect_strip_logs(page, geometric_lines, line_detection_params, text_lines)
@@ -67,7 +65,6 @@ def extract_stratigraphy(filename: str) -> ExtractStratigraphyResponse:
             extract_page(
                 text_lines,
                 geometric_lines,
-                structure_lines,
                 table_structures,
                 strip_logs,
                 language,

--- a/src/extraction/features/utils/table_detection.py
+++ b/src/extraction/features/utils/table_detection.py
@@ -47,7 +47,7 @@ def detect_structure_lines(geometric_lines: list[Line], filter_lines=True) -> li
 def detect_table_structures(
     page_index: int,
     document: pymupdf.Document,
-    structure_lines: list[StructureLine],
+    geometric_lines: list[Line],
     text_lines: list[TextLine],
 ) -> list[TableStructure]:
     """Detect multiple non-overlapping table structures on a page.
@@ -55,7 +55,7 @@ def detect_table_structures(
     Args:
         page_index (int): The page index (0-indexed).
         document (pymupdf.Document): the document.
-        structure_lines (list[StructureLine]): Vertical and horizonal structure lines.
+        geometric_lines (list[Line]): The geometric lines on the page.
         text_lines (list[TextLine]): All text lines on the page.
 
     Returns:
@@ -66,6 +66,7 @@ def detect_table_structures(
     page_width = page.rect.width
     page_height = page.rect.height
 
+    structure_lines = detect_structure_lines(geometric_lines)
     table_candidates = _find_table_structures(structure_lines, config, page_width, page_height, text_lines)
     table_candidates = [
         table

--- a/src/extraction/features/utils/text/textblock.py
+++ b/src/extraction/features/utils/text/textblock.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Self
 
-import numpy as np
 import pymupdf
 
 from extraction.features.utils.data_extractor import (
@@ -198,25 +197,3 @@ class TextBlock(RectWithPageMixin):
 
 def _is_close(a: float, b: list, tolerance: float) -> bool:
     return any(abs(a - c) < tolerance for c in b)
-
-
-def block_distance(block1: TextBlock, block2: TextBlock) -> float:
-    """Calculate the distance between two text blocks.
-
-    The distance is calculated as the difference between the y-coordinates of the bottom of the first block
-    and the top of the second block.
-
-    If a block is terminated by a line, the distance to the next block is set to infinity.
-    This ensures that the block is not merged with the next block.
-
-    Args:
-        block1 (TextBlock): The first text block.
-        block2 (TextBlock): The second text block.
-
-    Returns:
-        float: The distance between the two text blocks.
-    """
-    if block1.is_terminated_by_line:
-        return np.inf
-    else:
-        return block2.rect.y0 - block1.rect.y1

--- a/src/extraction/main.py
+++ b/src/extraction/main.py
@@ -29,7 +29,6 @@ from extraction.features.stratigraphy.layer.layer import LayersInDocument
 from extraction.features.utils.geometry.line_detection import extract_lines
 from extraction.features.utils.strip_log_detection import detect_strip_logs
 from extraction.features.utils.table_detection import (
-    detect_structure_lines,
     detect_table_structures,
 )
 from extraction.features.utils.text.extract_text import extract_text_lines
@@ -318,8 +317,7 @@ def start_pipeline(
                 geometric_lines = extract_lines(page, line_detection_params)
 
                 # Detect table structures on the page
-                structure_lines = detect_structure_lines(geometric_lines)
-                table_structures = detect_table_structures(page_index, doc, structure_lines, text_lines)
+                table_structures = detect_table_structures(page_index, doc, geometric_lines, text_lines)
 
                 # Detect strip logs on the page
                 strip_logs = detect_strip_logs(page, geometric_lines, line_detection_params, text_lines)
@@ -328,7 +326,6 @@ def start_pipeline(
                 page_layers = extract_page(
                     text_lines,
                     geometric_lines,
-                    structure_lines,
                     table_structures,
                     strip_logs,
                     file_metadata.language,

--- a/tests/test_textblock.py
+++ b/tests/test_textblock.py
@@ -2,7 +2,7 @@
 
 import pymupdf
 
-from extraction.features.utils.text.textblock import TextBlock, block_distance
+from extraction.features.utils.text.textblock import TextBlock
 from extraction.features.utils.text.textline import TextLine, TextWord
 
 
@@ -56,16 +56,3 @@ def test_post_init_longer_text():  # noqa: D103
     assert tb.line_count == 2, "The line count should be 2"
     assert tb.text == "Hello It's me", "Lines and words should be joined with a space"
     assert tb.rect == pymupdf.Rect(0, 0, 10, 2), "The block's rect should surround the rects of the individual words"
-
-
-def test_block_distance():  # noqa: D103
-    """Test the calculation of the distance between two TextBlocks."""
-    page_number = 1
-    block_1 = TextBlock([TextLine([TextWord(pymupdf.Rect(0, 0, 5, 1), "Hello", page_number)])])
-    block_2 = TextBlock([TextLine([TextWord(pymupdf.Rect(0, 2, 5, 3), "Hello", page_number)])])
-    assert block_distance(block_1, block_2) == 1, (
-        "The distance should be measured from the bottom of the first block to the top of the second block."
-    )
-    assert block_distance(block_2, block_1) == -3, (
-        "The distance should negative when the second block is above the first block."
-    )


### PR DESCRIPTION
Addresses https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/282 

This PR aims to refactor the `extract.py` script and particularly  `process_page()` method into a clear filter chain to eliminate redundant steps that do not boost accuracy (F1 score) of the current test sets.

The `process_page()` is simplified into four steps:

- Find all potential pairs (layer identifiers, depth sidebars, and no-sidebar cases)
- Sort by score (highest first)
- Apply filter chain
- Create boreholes

The main simplification come from removing table grouping logic that created `table_groups` which simplifies the filtering in the following way:

-  Material description pairs are sorted in descending order and filtered by `pair.score_match >= 0` condition
- Material description pairs are filtered by `table criteria` if they are within a table structure a specific width filter is applied. For tables outside the table structures no filtering is applied
- All remaining material descriptions pairs are filtered based on intersection criteria in order to leave only the highest value intersection pair based on `pair.score_match`. This method directly checks if pairs intersect and avoids building lists.
- No special method is applied to handle cases for pairs without sidebars, since applying the previous 3 methods results in approximately the same accuracy metrics (slight improvements around .1 - .2 % against the main branch).

https://github.com/swisstopo/swissgeol-boreholes-dataextraction/blob/80cdaabb4b9afd4f2f0b12f9dbab53a0337921a7/src/extraction/features/extract.py#L114-L128

The Proposed logic changes one of the goals of the issue 282: "aim of the table detection is to filter at most one borehole structure per table structure". With current filtering approach multiple boreholes can be extracted from the same table: the logic checks if each pair is contained in a table (getting the table_index), but it does not ensure only one pair per unique table. Description pairs are filtered based on specific width requirements and based on intersection. 

Currently we are still allowing for more lenient approach to description pairs that are not part of table structures. Removing this check reduces F1 scores significantly for the Geoquat dataset (~4%)

Additionally the deprecated `merge_blocks_by_vertical_spacing()` function is removed since it is not used in the extract.py script. 

Future improvements could also address simplification of `_find_all_material_description_candidates()` and `_match_sidebars_to_description_rects()` methods with aim to split them into modular components. This is avoided here to not go outside the scope of the issue.