### PR TITLE
Pytest changes example

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,3 +38,4 @@ jobs:
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
+          report-only-changed-files: true


### PR DESCRIPTION
Closes https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/356#

Errro was already there last year https://github.com/swisstopo/swissgeol-boreholes-dataextraction/actions/runs/19533281776/job/55921210979

> Run MishaKav/pytest-coverage-comment@main
> Uses Github URL: https://github.com/
> File read successfully "/home/runner/work/swissgeol-boreholes-dataextraction/swissgeol-boreholes-dataextraction/./pytest-coverage.txt"
> **Error: Coverage file "/home/runner/work/swissgeol-boreholes-dataextraction/swissgeol-boreholes-dataextraction/./pytest-coverage.txt" has bad format or wrong data**
> 


The test use the wrong coverage attribute
`pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=stratigraphy tests/ | tee pytest-coverage.txt`

The attribute `stratigraphy`  is not accessible as a package
