### PR TITLE
Add deterministic dataset splitter

### DIFF
--- a/src/scripts/split_dataset.py
+++ b/src/scripts/split_dataset.py
@@ -27,8 +27,8 @@ def deterministic_hash_ratio(text: str) -> float:
 @click.command()
 @click.option("-i", "--input-directory", type=click.Path(exists=True, path_type=Path))
 @click.option("-o", "--output-directory", type=click.Path(path_type=Path))
-@click.option("-t", "--rtest", default=0.15, type=float)
-@click.option("-v", "--rvalid", default=0.15, type=float)
+@click.option("-rt", "--rtest", default=0.15, type=float)
+@click.option("-rv", "--rvalid", default=0.15, type=float)
 def split_data(input_directory: Path, output_directory: Path, rtest: float, rvalid: float) -> None:
     """Split input files and gt to train, valid and test.
 


### PR DESCRIPTION
Closes https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/363#

# Description
This PR introduces a script to deterministically split a directory of PDF files into train, validation, and test sets using a SHA-256 hash of filenames. The split is stable across runs so adding new files does not reshuffle existing ones.