### PR TITLE
use lower level of compression for PNG visualizations (faster)

### DIFF
--- a/src/extraction/annotations/plot_utils.py
+++ b/src/extraction/annotations/plot_utils.py
@@ -175,7 +175,7 @@ def save_visualization(
     if draw_directory:
         img_path = draw_directory / filename_visualization
         # CV2 expects the image to be in BGR colorspace
-        cv2.imwrite(str(img_path), cv2.cvtColor(img, cv2.COLOR_RGB2BGR), [cv2.IMWRITE_PNG_COMPRESSION, 9])
+        cv2.imwrite(str(img_path), cv2.cvtColor(img, cv2.COLOR_RGB2BGR), [cv2.IMWRITE_PNG_COMPRESSION, 3])
 
     if mlflow:
         mlflow.log_image(img, f"pages/{filename_visualization}")


### PR DESCRIPTION
When implementing https://github.com/swisstopo/swissgeol-boreholes-dataextraction/pull/397, I missed that the compression of the PNG images is very slow (almost doubling the overall runtime of the data extraction pipeline on my machine).

By reducing the compression level, I still obtain some reduction in file sizes, but now without any significant slowdown of the pipeline.