### PR TITLE
adding all italian keyword support

### DIFF
--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -522,28 +522,24 @@ def start_pipeline(
         in_path = root / filename
         logger.info(f"Processing file: {in_path}")
 
-        try:
-            # Add file predictions
-            prediction = extract(
-                file=in_path,
-                filename=in_path.name,
-                out_directory=out_directory,
-                skip_draw_predictions=skip_draw_predictions,
-                draw_lines=draw_lines,
-                draw_tables=draw_tables,
-                draw_strip_logs=draw_strip_logs,
-                csv=csv,
-                part=part,
-                analytics=analytics,
-            )
-            predictions.add_file_predictions(prediction)
+        # Add file predictions
+        prediction = extract(
+            file=in_path,
+            filename=in_path.name,
+            out_directory=out_directory,
+            skip_draw_predictions=skip_draw_predictions,
+            draw_lines=draw_lines,
+            draw_tables=draw_tables,
+            draw_strip_logs=draw_strip_logs,
+            csv=csv,
+            part=part,
+            analytics=analytics,
+        )
+        predictions.add_file_predictions(prediction)
 
-            # Track progress in tmp file
-            logger.info(f"Writing predictions to tmp JSON file {predictions_path_tmp}")
-            write_json_predictions(filename=predictions_path_tmp, predictions=predictions)
-
-        except Exception as e:
-            logger.error(f"Unexpected error in file {filename}. Trace: {e}")
+        # Track progress in tmp file
+        logger.info(f"Writing predictions to tmp JSON file {predictions_path_tmp}")
+        write_json_predictions(filename=predictions_path_tmp, predictions=predictions)
 
     # Evaluate final predictions
     eval_summary = evaluate_all_predictions(

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -271,6 +271,8 @@ coordinate_keys:
   fr:
     - coordonnées
     - coordonn
+  it:
+    - coordinate
 
 groundwater_keys:
   de:
@@ -303,6 +305,9 @@ groundwater_keys:
     - groundwater
     - ground-water
     - ground-water level
+  it:
+    - Livello falda
+    - Pelo libero falda
 
 groundwater_fp_keys:
   de:
@@ -345,6 +350,10 @@ elevation_keys:
 
   en:
     - Surface level
+
+  it:
+    - Quota
+    - Altezza
 
 open_ended_depth_key:
   - ab


### PR DESCRIPTION
# Description

Hotfix for italian support in Boreholes. Adding basic keywords for coordinates, groundwater and elevation.

Also removing try/expect that silently failed during inference.

```yaml
coordinate_keys:
  it:
    - coordinate

groundwater_keys  
  it:
    - Livello falda
    - Pelo libero falda

elevation_keys  
  it:
    - Quota
    - Altezza
```