### PR TITLE
Fix multi page spanning line in visualization

### DIFF
--- a/src/extraction/annotations/draw.py
+++ b/src/extraction/annotations/draw.py
@@ -294,7 +294,7 @@ class PageDrawer:
                             pymupdf.Point(mat_descr_rect.x0, (mat_descr_rect.y0 + mat_descr_rect.y1) / 2)
                             * self.page.derotation_matrix,
                         )
-                    self.shape.finish(color=pymupdf.utils.getColor(color))
+                        self.shape.finish(color=pymupdf.utils.getColor(color))
 
                 # Get depth highlight rectangle
                 background_rect = layer.depths.get_background_rect(page_number, self.shape.page.rect.height)
@@ -306,13 +306,13 @@ class PageDrawer:
                     # Avoid full-page "pillars" for spanning layers:
                     # clip the vertical interval to the actual depth-entry extent visible on this page.
                     if depth_entry_rects:
-                        # Build one combined rectangle covering all detected depth entries on this page.
-                        page_depth_entries_rect = pymupdf.Rect(depth_entry_rects[0])
-                        for rect in depth_entry_rects[1:]:
-                            page_depth_entries_rect.include_rect(rect)
+                        clipped_background_rect.y0 = max(
+                            clipped_background_rect.y0, min(depth_entry_rects, key=lambda x: x.y0).y0
+                        )
 
-                        clipped_background_rect.y0 = max(clipped_background_rect.y0, page_depth_entries_rect.y0)
-                        clipped_background_rect.y1 = min(clipped_background_rect.y1, page_depth_entries_rect.y1)
+                        clipped_background_rect.y1 = min(
+                            clipped_background_rect.y1, max(depth_entry_rects, key=lambda x: x.y1).y1
+                        )
 
                     # Draw clipped depth highlight
                     if clipped_background_rect.y0 < clipped_background_rect.y1:

--- a/src/extraction/annotations/draw.py
+++ b/src/extraction/annotations/draw.py
@@ -120,9 +120,6 @@ class PageDrawer:
                     bboxes, start_is_continuation=start_is_continuation, end_has_continuation=end_has_continuation
                 )
 
-            self._depth_entry_rects = [
-                depth_entry.rect for bboxes in page_bboxes for depth_entry in bboxes.depth_column_entry_bboxes
-            ]
             layers = [layer for layer in bh_layers.layers if self.page_number in layer.material_description.pages]
             for index, layer in enumerate(layers):
                 self.draw_layer(
@@ -284,9 +281,7 @@ class PageDrawer:
                         self.shape.finish(color=pymupdf.utils.getColor(color))
 
                     # background color for depth interval
-                    background_rect = layer.depths.get_background_rect(
-                        page_number, self.shape.page.rect.height, self._depth_entry_rects
-                    )
+                    background_rect = layer.depths.get_background_rect(page_number)
                     if background_rect is not None:
                         self.shape.draw_rect(
                             background_rect * self.page.derotation_matrix,

--- a/src/extraction/annotations/draw.py
+++ b/src/extraction/annotations/draw.py
@@ -125,6 +125,9 @@ class PageDrawer:
                 self.draw_layer(
                     layer=layer,
                     sidebar_rects=[bboxes.sidebar_bbox.rect for bboxes in page_bboxes if bboxes.sidebar_bbox],
+                    depth_entry_rects=[
+                        depth_entry.rect for bboxes in page_bboxes for depth_entry in bboxes.depth_column_entry_bboxes
+                    ],
                     index=index,
                     page_number=self.page_number,
                 )
@@ -220,6 +223,7 @@ class PageDrawer:
         self,
         layer: Layer,
         sidebar_rects: list[pymupdf.Rect],
+        depth_entry_rects: list[pymupdf.Rect],
         index: int,
         page_number: int,
     ):
@@ -232,8 +236,9 @@ class PageDrawer:
         Args:
             layer (Layer): The layer (depth interval and material description).
             sidebar_rects (list[pymupdf.Rect]): The sidebar bounding boxes on the page.
+            depth_entry_rects (list[pymupdf.Rect]): Bounding boxes of all detected depth entries on the current page.
             index (int): Index of the layer.
-            page_number(int): the curent page number.
+            page_number(int): the current page number.
         """
         material_description = layer.material_description
         mat_descr_lines = [line for line in material_description.lines if line.page_number == page_number]
@@ -265,29 +270,54 @@ class PageDrawer:
 
             if layer.depths:
                 depths_rect = pymupdf.Rect()
+                # Collect depth rects on this page
                 if layer.depths.start and layer.depths.start.rect and layer.depths.start.page_number == page_number:
                     depths_rect.include_rect(layer.depths.start.rect)
                 if layer.depths.end and layer.depths.end.page_number == page_number:
                     depths_rect.include_rect(layer.depths.end.rect)
+                # For multi-page borehole layers, the borehole continuation is already shown
+                # separately, so drawing the usual connector line would be visually redundant.
+                # Check if layer spans multiple pages
+                is_cross_page_layer = (
+                    layer.depths.start is not None
+                    and layer.depths.end is not None
+                    and layer.depths.start.page_number != layer.depths.end.page_number
+                )
 
                 if any(sidebar_rect.contains(depths_rect) for sidebar_rect in sidebar_rects):
-                    # Depths are separate from the material description: draw a line connecting them
                     line_anchor = layer.depths.get_line_anchor(page_number)
-                    if line_anchor:
-                        rect = mat_descr_rect
+
+                    # Draw connector only for single-page layers
+                    if line_anchor and not is_cross_page_layer:
                         self.shape.draw_line(
                             line_anchor * self.page.derotation_matrix,
-                            pymupdf.Point(rect.x0, (rect.y0 + rect.y1) / 2) * self.page.derotation_matrix,
+                            pymupdf.Point(mat_descr_rect.x0, (mat_descr_rect.y0 + mat_descr_rect.y1) / 2)
+                            * self.page.derotation_matrix,
                         )
-                        self.shape.finish(
-                            color=pymupdf.utils.getColor(color),
-                        )
+                    self.shape.finish(color=pymupdf.utils.getColor(color))
 
-                    # background color for depth interval
-                    background_rect = layer.depths.get_background_rect(page_number, self.shape.page.rect.height)
-                    if background_rect is not None:
+                # Get depth highlight rectangle
+                background_rect = layer.depths.get_background_rect(page_number, self.shape.page.rect.height)
+
+                # Clip to visible depth entries to avoid full-page pillar
+                if background_rect is not None:
+                    clipped_background_rect = pymupdf.Rect(background_rect)
+
+                    # Avoid full-page "pillars" for spanning layers:
+                    # clip the vertical interval to the actual depth-entry extent visible on this page.
+                    if depth_entry_rects:
+                        # Build one combined rectangle covering all detected depth entries on this page.
+                        page_depth_entries_rect = pymupdf.Rect(depth_entry_rects[0])
+                        for rect in depth_entry_rects[1:]:
+                            page_depth_entries_rect.include_rect(rect)
+
+                        clipped_background_rect.y0 = max(clipped_background_rect.y0, page_depth_entries_rect.y0)
+                        clipped_background_rect.y1 = min(clipped_background_rect.y1, page_depth_entries_rect.y1)
+
+                    # Draw clipped depth highlight
+                    if clipped_background_rect.y0 < clipped_background_rect.y1:
                         self.shape.draw_rect(
-                            background_rect * self.page.derotation_matrix,
+                            clipped_background_rect * self.page.derotation_matrix,
                         )
                         self.shape.finish(
                             color=pymupdf.utils.getColor(color),
@@ -297,8 +327,8 @@ class PageDrawer:
                         )
 
                         self._draw_correctness_line(
-                            start=background_rect.top_left,
-                            end=background_rect.bottom_left,
+                            start=clipped_background_rect.top_left,
+                            end=clipped_background_rect.bottom_left,
                             is_correct=layer.depths.is_correct,
                             width=4,
                         )

--- a/src/extraction/annotations/draw.py
+++ b/src/extraction/annotations/draw.py
@@ -120,14 +120,14 @@ class PageDrawer:
                     bboxes, start_is_continuation=start_is_continuation, end_has_continuation=end_has_continuation
                 )
 
+            self._depth_entry_rects = [
+                depth_entry.rect for bboxes in page_bboxes for depth_entry in bboxes.depth_column_entry_bboxes
+            ]
             layers = [layer for layer in bh_layers.layers if self.page_number in layer.material_description.pages]
             for index, layer in enumerate(layers):
                 self.draw_layer(
                     layer=layer,
                     sidebar_rects=[bboxes.sidebar_bbox.rect for bboxes in page_bboxes if bboxes.sidebar_bbox],
-                    depth_entry_rects=[
-                        depth_entry.rect for bboxes in page_bboxes for depth_entry in bboxes.depth_column_entry_bboxes
-                    ],
                     index=index,
                     page_number=self.page_number,
                 )
@@ -223,7 +223,6 @@ class PageDrawer:
         self,
         layer: Layer,
         sidebar_rects: list[pymupdf.Rect],
-        depth_entry_rects: list[pymupdf.Rect],
         index: int,
         page_number: int,
     ):
@@ -236,7 +235,6 @@ class PageDrawer:
         Args:
             layer (Layer): The layer (depth interval and material description).
             sidebar_rects (list[pymupdf.Rect]): The sidebar bounding boxes on the page.
-            depth_entry_rects (list[pymupdf.Rect]): Bounding boxes of all detected depth entries on the current page.
             index (int): Index of the layer.
             page_number(int): the current page number.
         """
@@ -270,54 +268,28 @@ class PageDrawer:
 
             if layer.depths:
                 depths_rect = pymupdf.Rect()
-                # Collect depth rects on this page
                 if layer.depths.start and layer.depths.start.rect and layer.depths.start.page_number == page_number:
                     depths_rect.include_rect(layer.depths.start.rect)
                 if layer.depths.end and layer.depths.end.page_number == page_number:
                     depths_rect.include_rect(layer.depths.end.rect)
-                # For multi-page borehole layers, the borehole continuation is already shown
-                # separately, so drawing the usual connector line would be visually redundant.
-                # Check if layer spans multiple pages
-                is_cross_page_layer = (
-                    layer.depths.start is not None
-                    and layer.depths.end is not None
-                    and layer.depths.start.page_number != layer.depths.end.page_number
-                )
-
                 if any(sidebar_rect.contains(depths_rect) for sidebar_rect in sidebar_rects):
+                    # Depths are separate from the material description: draw a line connecting them
                     line_anchor = layer.depths.get_line_anchor(page_number)
-
-                    # Draw connector only for single-page layers
-                    if line_anchor and not is_cross_page_layer:
+                    if line_anchor:
+                        rect = mat_descr_rect
                         self.shape.draw_line(
                             line_anchor * self.page.derotation_matrix,
-                            pymupdf.Point(mat_descr_rect.x0, (mat_descr_rect.y0 + mat_descr_rect.y1) / 2)
-                            * self.page.derotation_matrix,
+                            pymupdf.Point(rect.x0, (rect.y0 + rect.y1) / 2) * self.page.derotation_matrix,
                         )
                         self.shape.finish(color=pymupdf.utils.getColor(color))
 
-                # Get depth highlight rectangle
-                background_rect = layer.depths.get_background_rect(page_number, self.shape.page.rect.height)
-
-                # Clip to visible depth entries to avoid full-page pillar
-                if background_rect is not None:
-                    clipped_background_rect = pymupdf.Rect(background_rect)
-
-                    # Avoid full-page "pillars" for spanning layers:
-                    # clip the vertical interval to the actual depth-entry extent visible on this page.
-                    if depth_entry_rects:
-                        clipped_background_rect.y0 = max(
-                            clipped_background_rect.y0, min(depth_entry_rects, key=lambda x: x.y0).y0
-                        )
-
-                        clipped_background_rect.y1 = min(
-                            clipped_background_rect.y1, max(depth_entry_rects, key=lambda x: x.y1).y1
-                        )
-
-                    # Draw clipped depth highlight
-                    if clipped_background_rect.y0 < clipped_background_rect.y1:
+                    # background color for depth interval
+                    background_rect = layer.depths.get_background_rect(
+                        page_number, self.shape.page.rect.height, self._depth_entry_rects
+                    )
+                    if background_rect is not None:
                         self.shape.draw_rect(
-                            clipped_background_rect * self.page.derotation_matrix,
+                            background_rect * self.page.derotation_matrix,
                         )
                         self.shape.finish(
                             color=pymupdf.utils.getColor(color),
@@ -327,8 +299,8 @@ class PageDrawer:
                         )
 
                         self._draw_correctness_line(
-                            start=clipped_background_rect.top_left,
-                            end=clipped_background_rect.bottom_left,
+                            start=background_rect.top_left,
+                            end=background_rect.bottom_left,
                             is_correct=layer.depths.is_correct,
                             width=4,
                         )

--- a/src/extraction/features/stratigraphy/layer/layer.py
+++ b/src/extraction/features/stratigraphy/layer/layer.py
@@ -77,24 +77,27 @@ class LayerDepths(ExtractedFeature):
                     max(self.start.rect.x1, self.end.rect.x1), (self.start.rect.y0 + self.end.rect.y1) / 2
                 )
             else:
-                if self.start.page_number == page_number:
-                    return pymupdf.Point(self.start.rect.x1, self.start.rect.y1)
-                elif self.end.page_number == page_number:
-                    # anchor at the top of the page
-                    return pymupdf.Point(self.end.rect.x1, 0)
-                else:
-                    return None
+                # Cross-page layers: no connector line (the borehole span marker already shows continuity)
+                return None
         elif self.start and self.start.rect:
             return pymupdf.Point(self.start.rect.x1, self.start.rect.y1)
         elif self.end:
             return pymupdf.Point(self.end.rect.x1, self.end.rect.y0)
 
-    def get_background_rect(self, page_number: int, page_height: float) -> pymupdf.Rect | None:
+    def get_background_rect(
+        self,
+        page_number: int,
+        page_height: float,
+        depth_entry_rects: list[pymupdf.Rect] | None = None,
+    ) -> pymupdf.Rect | None:
         """Get the background rectangle for the layer depths.
 
         Args:
             page_number (int): The page number for which to get the background rectangle.
             page_height (float): The height of the page.
+            depth_entry_rects (list[pymupdf.Rect] | None): Bounding boxes of all detected depth entries on
+                the current page. When provided, the returned rect is clipped vertically to the extent of
+                these entries so that spanning layers do not produce full-page pillars.
 
         Returns:
             pymupdf.Rect | None: The background rectangle for the layer depths, or None if not applicable.
@@ -103,16 +106,25 @@ class LayerDepths(ExtractedFeature):
             return None
         if self.start.page_number != self.end.page_number:
             if page_number == self.start.page_number:
-                return pymupdf.Rect(self.start.rect.x0, self.start.rect.y1, self.start.rect.x1, page_height)
+                rect = pymupdf.Rect(self.start.rect.x0, self.start.rect.y1, self.start.rect.x1, page_height)
             elif page_number == self.end.page_number:
-                return pymupdf.Rect(self.end.rect.x0, 0, self.end.rect.x1, self.end.rect.y0)
+                rect = pymupdf.Rect(self.end.rect.x0, 0, self.end.rect.x1, self.end.rect.y0)
             else:
                 return None
-        if self.start.rect.y1 < self.end.rect.y0:
-            return pymupdf.Rect(
+        elif self.start.rect.y1 < self.end.rect.y0:
+            rect = pymupdf.Rect(
                 self.start.rect.x0, self.start.rect.y1, max(self.start.rect.x1, self.end.rect.x1), self.end.rect.y0
             )
-        return None
+        else:
+            return None
+
+        if depth_entry_rects:
+            rect.y0 = max(rect.y0, min(depth_entry_rects, key=lambda r: r.y0).y0)
+            rect.y1 = min(rect.y1, max(depth_entry_rects, key=lambda r: r.y1).y1)
+            if rect.y0 >= rect.y1:
+                return None
+
+        return rect
 
     def to_json(self):
         """Convert the LayerDepths object to a JSON serializable format."""

--- a/src/extraction/features/stratigraphy/layer/layer.py
+++ b/src/extraction/features/stratigraphy/layer/layer.py
@@ -84,20 +84,11 @@ class LayerDepths(ExtractedFeature):
         elif self.end:
             return pymupdf.Point(self.end.rect.x1, self.end.rect.y0)
 
-    def get_background_rect(
-        self,
-        page_number: int,
-        page_height: float,
-        depth_entry_rects: list[pymupdf.Rect] | None = None,
-    ) -> pymupdf.Rect | None:
+    def get_background_rect(self, page_number: int) -> pymupdf.Rect | None:
         """Get the background rectangle for the layer depths.
 
         Args:
             page_number (int): The page number for which to get the background rectangle.
-            page_height (float): The height of the page.
-            depth_entry_rects (list[pymupdf.Rect] | None): Bounding boxes of all detected depth entries on
-                the current page. When provided, the returned rect is clipped vertically to the extent of
-                these entries so that spanning layers do not produce full-page pillars.
 
         Returns:
             pymupdf.Rect | None: The background rectangle for the layer depths, or None if not applicable.
@@ -105,24 +96,13 @@ class LayerDepths(ExtractedFeature):
         if not (self.start and self.start.rect and self.end):
             return None
         if self.start.page_number != self.end.page_number:
-            if page_number == self.start.page_number:
-                rect = pymupdf.Rect(self.start.rect.x0, self.start.rect.y1, self.start.rect.x1, page_height)
-            elif page_number == self.end.page_number:
-                rect = pymupdf.Rect(self.end.rect.x0, 0, self.end.rect.x1, self.end.rect.y0)
-            else:
-                return None
+            return None
         elif self.start.rect.y1 < self.end.rect.y0:
             rect = pymupdf.Rect(
                 self.start.rect.x0, self.start.rect.y1, max(self.start.rect.x1, self.end.rect.x1), self.end.rect.y0
             )
         else:
             return None
-
-        if depth_entry_rects:
-            rect.y0 = max(rect.y0, min(depth_entry_rects, key=lambda r: r.y0).y0)
-            rect.y1 = min(rect.y1, max(depth_entry_rects, key=lambda r: r.y1).y1)
-            if rect.y0 >= rect.y1:
-                return None
 
         return rect
 

--- a/tests/test_layerdepths.py
+++ b/tests/test_layerdepths.py
@@ -29,12 +29,8 @@ def test_line_anchor():  # noqa: D103
         "right-most rect."
     )
     end_next_page = LayerDepthsEntry(10, pymupdf.Rect(0, 0, 1, 1), 1)
-    assert LayerDepths(start, end_next_page).get_line_anchor(0) == pymupdf.Point(1, 1), (
-        "When depths are across 2 pages, the anchor queried at the same page as the start is should point at the start"
-    )
-    assert LayerDepths(start, end_next_page).get_line_anchor(1) == pymupdf.Point(1, 0), (
-        "When depths are across 2 pages, the anchor queried at the same page as the end should be at the top "
-        "of the second page to signal that the description spans 2 pages"
+    assert LayerDepths(start, end_next_page).get_line_anchor(0) is None, (
+        "When depths span 2 pages, there is no line anchor (continuity is shown by the borehole span marker)."
     )
 
 
@@ -43,28 +39,21 @@ def test_background_rect():  # noqa: D103
     start = LayerDepthsEntry(5, pymupdf.Rect(0, 0, 1, 1), 0)
     end = LayerDepthsEntry(10, pymupdf.Rect(0, 2, 1, 3), 0)
     depths = LayerDepths(start, end)
-    page_height = 10000  # Simulating a large page height
-    assert depths.get_background_rect(0, page_height) == pymupdf.Rect(
-        start.rect.x0, start.rect.y1, start.rect.x1, end.rect.y0
+    assert depths.get_background_rect(0) == pymupdf.Rect(
+        start.rect.x0, start.rect.y1, max(start.rect.x1, end.rect.x1), end.rect.y0
     ), "The background rect should be (0, 1, 1, 2)"
-    assert depths.get_background_rect(0, page_height) == pymupdf.Rect(0, 1, 1, 2), (
-        "The background rect should be (0, 1, 1, 2)"
-    )
+    assert depths.get_background_rect(0) == pymupdf.Rect(0, 1, 1, 2), "The background rect should be (0, 1, 1, 2)"
 
     rect = pymupdf.Rect(0, 0, 1, 1)
     start = LayerDepthsEntry(5, rect, 0)
     end = LayerDepthsEntry(10, rect, 0)
-    assert LayerDepths(start, end).get_background_rect(0, page_height) is None, (
+    assert LayerDepths(start, end).get_background_rect(0) is None, (
         "When start and end depths are overlapping, there should be no background rect."
     )
 
-    # special case when depths are spanning 2 pages
+    # Cross-page depths: background rect is not rendered (borehole span marker covers continuity)
     start = LayerDepthsEntry(5, pymupdf.Rect(0, 1, 1, 2), 0)
     end = LayerDepthsEntry(10, pymupdf.Rect(0, 0.5, 1, 1), 1)
     depths = LayerDepths(start, end)
-    assert depths.get_background_rect(0, page_height) == pymupdf.Rect(0, 2, 1, page_height), (
-        "From the start to the bottom of the page"
-    )
-    assert depths.get_background_rect(1, page_height) == pymupdf.Rect(0, 0, 1, 0.5), (
-        "From the top of the page to the end"
-    )
+    assert depths.get_background_rect(0) is None, "Cross-page layers have no background rect."
+    assert depths.get_background_rect(1) is None, "Cross-page layers have no background rect."


### PR DESCRIPTION
## Before
The previous implementation drew the full background_rect for depth highlights without accounting for layers that span multiple pages. This caused visual highlight-"pillars" stretching the full page height for multi-page boreholes. 

<img width="340" height="450" alt="Image" src="https://github.com/user-attachments/assets/d2fb07c4-759d-40d2-b746-c4077b64cd4f" />

## Changes:

This PR fixes that by 
- clipping the highlight to only cover the depth entries actually visible on the current page. 
- It also removes the connector line between a depth entry and its material description in these cases, since the span marker arrow already makes the connection clear.
- To support this, draw_layer now receives the bounding boxes of the visible depth entries on the page, which are used to figure out how far the highlight should extend.

<img width="340" height="450" alt="Screenshot 2026-03-26 at 13 45 45" src="https://github.com/user-attachments/assets/482a0bed-a237-4a6c-b254-5b9817292462" />

