### PR TITLE
Refactoring of evaluation pipeline file by file

### DIFF
--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -32,7 +32,7 @@ predictions.json
     │       ├── page                      # Source page number
     │       └── rect                      # Bounding box of the measurement in the PDF
     │
-    └── metrics                           # Evaluation scores with tp, fp, fn,precision, recall, and f1
+    └── metrics                           # Evaluation scores with tp, fp, fn, precision, recall, and f1
         ├── language                      # Ground truth language for metric computation
         ├── layer_metrics                 # Layer detection
         ├── depth_interval_metrics        # Depth layer detection
@@ -119,6 +119,7 @@ All page numbers are counted starting at 1. All bounding boxes are measured with
               }
             }
           }
+          # ... (more layers)
         ],
         "bounding_boxes": [
           {
@@ -126,7 +127,13 @@ All page numbers are counted starting at 1. All bounding boxes are measured with
             "depth_column_entries": [
               [200.1201171875, 321.8956298828125, 208.59901428222656, 328.6802062988281],
               [200.63790893554688, 331.3035888671875, 207.83108520507812, 338.30450439453125],
-              [201.62551879882812, 374.30560302734375, 210.0361328125, 380.828857421875]
+              [201.62551879882812, 374.30560302734375, 210.0361328125, 380.828857421875],
+              [199.86251831054688, 434.51556396484375, 210.10894775390625, 441.4538879394531],
+              [198.11251831054688, 557.5472412109375, 210.35877990722656, 563.9244995117188],
+              [198.28451538085938, 582.0216674804688, 209.76953125, 588.7603759765625],
+              [198.7814178466797, 616.177001953125, 209.50042724609375, 622.502197265625],
+              [198.6378173828125, 663.2830810546875, 210.75906372070312, 669.5428466796875],
+              [198.26901245117188, 695.974609375, 209.12693786621094, 702.2628173828125]
             ],
             "material_description_rect": [256.777099609375, 345.9997253417969, 392.46051025390625, 728.2700805664062],
             "page": 1
@@ -148,6 +155,7 @@ All page numbers are counted starting at 1. All bounding boxes are measured with
           }
         ]
       }
+      # ... (more boreholes)
     ],
     "metrics": {
       "layer_metrics": {

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -17,7 +17,7 @@ predictions.json
     │   ├── metadata
     │   │   ├── elevation                 # Borehole surface elevation, if found
     │   │   └── coordinates               # Borehole coordinates, if found
-    │   ├── layers[]                      # Detected layers of the borehole profil
+    │   ├── layers[]                      # Detected layers of the borehole profile
     │   │   ├── material_description      # Material text description
     │   │   └── depth_interval            # Measured depth of the layer's upper and lower limits
     │   ├── bounding_boxes[]              # List of bounding boxes, one for each part of a borehole profile, that can be used for visualizations

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -54,7 +54,6 @@ All page numbers are counted starting at 1. All bounding boxes are measured with
 ## Example output
 ```yaml
 {
-# TODO Return metadata as before with page dimmension and language /GT vs predicted
   "B366.pdf": {  # file name
     "language": "de",
     "page_dimensions": [

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -5,7 +5,7 @@ The `predictions.json` file contains the results of a data extraction process in
 
 ## Schema Overview
 
-```yaml
+```text
 predictions.json
 └── "<filename>.pdf"                      # One entry per processed PDF file
     ├── file_metadata
@@ -20,7 +20,7 @@ predictions.json
     │   ├── layers[]                      # Detected layers of the borehole profil
     │   │   ├── material_description      # Material text description
     │   │   └── depth_interval            # Measured depth of the layer's upper and lower limits
-    │   ├── bounding_boxes[]
+    │   ├── bounding_boxes[]              # List of bounding boxes, one for each (part of a) borehole profile, that can be used for visualizations
     │   │   ├── page                      # Page number for this segment
     │   │   ├── sidebar_rect              # Area of the depth sidebar, if found
     │   │   ├── depth_column_entries[]    # Bounding boxes of depth entries

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -30,8 +30,9 @@ All bounding boxes are measured with PDF points as the unit, and with the top-le
 ## Example output
 ```yaml
 {
+# TODO Return metadata as before with page dimmension and language /GT vs predicted
   "B366.pdf": {  # file name
-    "language": "de", 
+    "language": "de",
     "page_dimensions": [
       {
         "width": 591.956787109375,

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -1,31 +1,56 @@
-# `predictions.json` output structure
+# `predictions.json` Output Structure
+
 The `predictions.json` file contains the results of a data extraction process in a machine-readable format. By default, the file is written to `data/output/predictions.json`.
 
-Each key in the JSON object is the name of a PDF file. The extracted data is listed as an object with the following keys:
-- `language`: language that was detected for the document.
-- `page_dimensions`: dimensions of each page in the PDF, measured in PDF points
-- `boreholes`: list of all boreholes identified on the documents. Each borehole object has the following keys.
-  - `borehole_index`: index to differenciate the extracted boreholes, starting at 0.
-  - `metadata`
-    - `elevation`: the detected elevation (if any) and the location in the PDF where they were extraction from.
-    - `coordinates`: the detected coordinates (if any) and the location in the PDF where they were extraction from.
-  - `layers`: a list of objects, where each object represents a layer of the borehole profile, using the following keys:
-    - `material_description`: the text of the material description, both as a single value as well as line-by-line, and the location in the PDF where the text resp. the lines where extracted from.
-    - `depth_interval`: the measured depth of the upper and lower limits of the layer, and the location in the PDF where they were extracted from.
-  - `bounding_boxes`: a list of objects, one for each (part of a) borehole profile in the PDF, that list some bounding boxes that can be used for visualizations. Each object has the following keys:
-    - `sidebar_rect`: the area of the page the contains a "sidebar" (if any), which contains depths or other data displayed to the side of material descriptions.
-    - `depth_column_entries`: list of locations of the entries in the depth column (if any).
-    - `material_description_rect`: the area of the page that contains all material descriptions.
-    - `page`: the number of the page of the PDF.
-  - `groundwater`: a list of objects, one for each groundwater measurement that was extracted from the PDF. Each object has the following keys.
-    - `date`: extracted date for the groundwater measurement (if any) as a string in YYYY-MM-DD format.
-    - `depth`: the measured depth (in m) of the groundwater measurement.
-    - `elevation`: the elevation (in m above sea level) of the groundwater measurement.
-    - `page` and `rect`: the location in the PDF where the groundwater measurement was extracted from.
 
-All page numbers are counted starting at 1.
+## Schema Overview
 
-All bounding boxes are measured with PDF points as the unit, and with the top-left of the page as the origin.
+```bash
+predictions.json
+└── "<filename>.pdf"                      # One entry per processed PDF file
+    ├── language                          # Ground truth language if externally provided
+    │
+    ├── file_metadata
+    │   ├── language                      # Detected language
+    │   └── page_dimensions[]             # Dimensions of each page, in PDF points
+    │
+    ├── boreholes[]                       # All boreholes identified in the document
+    │   ├── borehole_index                # Zero-based index to distinguish boreholes
+    │   ├── metadata
+    │   │   ├── elevation                 # Borehole surface elevation, if found
+    │   │   └── coordinates               # Borehole coordinates, if found
+    │   ├── layers[]                      # Ordered geological layers of the borehole profile
+    │   │   ├── material_description      # Soil/rock description for this layer
+    │   │   └── depth_interval            # Vertical extent of the layer
+    │   ├── bounding_boxes[]
+    │   │   ├── page                      # Page number for this segment
+    │   │   ├── sidebar_rect              # Area of the depth sidebar, if found
+    │   │   ├── depth_column_entries[]    # Bounding boxes of depth entries
+    │   │   └── material_description_rect # Bounding boxes of material descriptions
+    │   └── groundwater[]                 # Groundwater measurements extracted from the PDF
+    │       ├── date                      # Measurement date (YYYY-MM-DD), if found
+    │       ├── depth                     # Depth of the measurement (m), if found
+    │       ├── elevation                 # Elevation (m above sea level), if found
+    │       ├── page                      # Source page number
+    │       └── rect                      # Bounding box of the measurement in the PDF
+    │
+    └── metrics                           # Evaluation scores with tp, fp, fn,precision, recall, and f1
+        ├── layer_metrics                 # Layer detection
+        ├── depth_interval_metrics        # Depth layer detection
+        ├── material_description_metrics  # Meterial description detection
+        ├── gw_metrics
+        │   ├── metrics                   # Groundwater overall detection
+        │   ├── depth_metrics             # Groundwater depth detection
+        │   ├── elevation_metrics         # Groundwater elevation detection
+        │   └── date_metrics              # Groundwater date detection
+        └── metadata_metrics
+            ├── elevation                 # Borehole elevation detection
+            ├── coordinates               # Borehole coordinates detection
+            └── name                      # Borehole name detection
+```
+
+All page numbers are counted starting at 1. All bounding boxes are measured with PDF points as the unit, and with the top-left of the page as the origin.
+
 
 ## Example output
 ```yaml
@@ -57,7 +82,7 @@ All bounding boxes are measured with PDF points as the unit, and with the top-le
             "N": 257200.0,
             "rect": [28.263830184936523, 179.63882446289062, 150.3379364013672, 188.7487335205078],
             "page": 1
-          },
+          }
         },
         "layers": [
           {
@@ -93,8 +118,7 @@ All bounding boxes are measured with PDF points as the unit, and with the top-le
                 "rect": [201.62551879882812, 374.30560302734375, 210.0361328125, 380.828857421875]
               }
             }
-          },
-          # ... (more layers)
+          }
         ],
         "bounding_boxes": [
           {
@@ -102,13 +126,7 @@ All bounding boxes are measured with PDF points as the unit, and with the top-le
             "depth_column_entries": [
               [200.1201171875, 321.8956298828125, 208.59901428222656, 328.6802062988281],
               [200.63790893554688, 331.3035888671875, 207.83108520507812, 338.30450439453125],
-              [201.62551879882812, 374.30560302734375, 210.0361328125, 380.828857421875],
-              [199.86251831054688, 434.51556396484375, 210.10894775390625, 441.4538879394531],
-              [198.11251831054688, 557.5472412109375, 210.35877990722656, 563.9244995117188],
-              [198.28451538085938, 582.0216674804688, 209.76953125, 588.7603759765625],
-              [198.7814178466797, 616.177001953125, 209.50042724609375, 622.502197265625],
-              [198.6378173828125, 663.2830810546875, 210.75906372070312, 669.5428466796875],
-              [198.26901245117188, 695.974609375, 209.12693786621094, 702.2628173828125]
+              [201.62551879882812, 374.30560302734375, 210.0361328125, 380.828857421875]
             ],
             "material_description_rect": [256.777099609375, 345.9997253417969, 392.46051025390625, 728.2700805664062],
             "page": 1
@@ -129,9 +147,94 @@ All bounding boxes are measured with PDF points as the unit, and with the top-le
             "rect": [61.23963928222656, 489.3185119628906, 94.0096435546875, 513.6478881835938]
           }
         ]
+      }
+    ],
+    "metrics": {
+      "layer_metrics": {
+        "tp": 2,
+        "fp": 18,
+        "fn": 1,
+        "precision": 0.1,
+        "recall": 0.6666666666666666,
+        "f1": 0.1739130434782609
       },
-      # ... (more boreholes)
-    ]
+      "depth_interval_metrics": {
+        "tp": 2,
+        "fp": 18,
+        "fn": 1,
+        "precision": 0.1,
+        "recall": 0.6666666666666666,
+        "f1": 0.1739130434782609
+      },
+      "material_description_metrics": {
+        "tp": 2,
+        "fp": 18,
+        "fn": 1,
+        "precision": 0.1,
+        "recall": 0.6666666666666666,
+        "f1": 0.1739130434782609
+      },
+      "gw_metrics": {
+        "metrics": {
+          "tp": 0,
+          "fp": 1,
+          "fn": 0,
+          "precision": 0.0,
+          "recall": 0,
+          "f1": 0
+        },
+        "depth_metrics": {
+          "tp": 0,
+          "fp": 1,
+          "fn": 0,
+          "precision": 0.0,
+          "recall": 0,
+          "f1": 0
+        },
+        "elevation_metrics": {
+          "tp": 0,
+          "fp": 1,
+          "fn": 0,
+          "precision": 0.0,
+          "recall": 0,
+          "f1": 0
+        },
+        "date_metrics": {
+          "tp": 0,
+          "fp": 1,
+          "fn": 0,
+          "precision": 0.0,
+          "recall": 0,
+          "f1": 0
+        }
+      },
+      "metadata_metrics": {
+        "elevation": {
+          "tp": 0,
+          "fp": 1,
+          "fn": 1,
+          "precision": 0.0,
+          "recall": 0.0,
+          "f1": 0
+        },
+        "coordinates": {
+          "tp": 1,
+          "fp": 0,
+          "fn": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "f1": 1.0
+        },
+        "name": {
+          "tp": 1,
+          "fp": 0,
+          "fn": 0,
+          "precision": 1.0,
+          "recall": 1.0,
+          "f1": 1.0
+        }
+      }
+    }
   }
 }
 ```

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -36,7 +36,7 @@ predictions.json
         ├── language                      # Ground truth language for metric computation
         ├── layer_metrics                 # Layer detection
         ├── depth_interval_metrics        # Depth layer detection
-        ├── material_description_metrics  # Meterial description detection
+        ├── material_description_metrics  # Material description detection
         ├── gw_metrics
         │   ├── metrics                   # Groundwater overall detection
         │   ├── depth_metrics             # Groundwater depth detection
@@ -55,17 +55,19 @@ All page numbers are counted starting at 1. All bounding boxes are measured with
 ```yaml
 {
   "B366.pdf": {  # file name
-    "language": "de",
-    "page_dimensions": [
-      {
-        "width": 591.956787109375,
-        "height": 1030.426025390625
-      },
-      {
-        "width": 588.009521484375,
-        "height": 792.114990234375
-      }
-    ],
+    "file_metadata": {
+      "language": "de",
+      "page_dimensions": [
+        {
+          "width": 591.956787109375,
+          "height": 1030.426025390625
+        },
+        {
+          "width": 588.009521484375,
+          "height": 792.114990234375
+        }
+      ],
+    },
     "boreholes": [
       {
         "borehole_index": 0,

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -5,7 +5,7 @@ The `predictions.json` file contains the results of a data extraction process in
 
 ## Schema Overview
 
-```bash
+```yaml
 predictions.json
 └── "<filename>.pdf"                      # One entry per processed PDF file
     ├── file_metadata
@@ -52,9 +52,10 @@ All page numbers are counted starting at 1. All bounding boxes are measured with
 
 
 ## Example output
-```yaml
+```jsonc
 {
-  "B366.pdf": {  # file name
+  // filename
+  "B366.pdf": {
     "file_metadata": {
       "language": "de",
       "page_dimensions": [
@@ -119,7 +120,7 @@ All page numbers are counted starting at 1. All bounding boxes are measured with
               }
             }
           }
-          # ... (more layers)
+          // ... (more layers)
         ],
         "bounding_boxes": [
           {
@@ -155,7 +156,7 @@ All page numbers are counted starting at 1. All bounding boxes are measured with
           }
         ]
       }
-      # ... (more boreholes)
+      // ... (more boreholes)
     ],
     "metrics": {
       "layer_metrics": {

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -8,8 +8,6 @@ The `predictions.json` file contains the results of a data extraction process in
 ```bash
 predictions.json
 └── "<filename>.pdf"                      # One entry per processed PDF file
-    ├── language                          # Ground truth language if externally provided
-    │
     ├── file_metadata
     │   ├── language                      # Detected language
     │   └── page_dimensions[]             # Dimensions of each page, in PDF points
@@ -35,6 +33,7 @@ predictions.json
     │       └── rect                      # Bounding box of the measurement in the PDF
     │
     └── metrics                           # Evaluation scores with tp, fp, fn,precision, recall, and f1
+        ├── language                      # Ground truth language for metric computation
         ├── layer_metrics                 # Layer detection
         ├── depth_interval_metrics        # Depth layer detection
         ├── material_description_metrics  # Meterial description detection

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -20,7 +20,7 @@ predictions.json
     │   ├── layers[]                      # Detected layers of the borehole profil
     │   │   ├── material_description      # Material text description
     │   │   └── depth_interval            # Measured depth of the layer's upper and lower limits
-    │   ├── bounding_boxes[]              # List of bounding boxes, one for each (part of a) borehole profile, that can be used for visualizations
+    │   ├── bounding_boxes[]              # List of bounding boxes, one for each part of a borehole profile, that can be used for visualizations
     │   │   ├── page                      # Page number for this segment
     │   │   ├── sidebar_rect              # Area of the depth sidebar, if found
     │   │   ├── depth_column_entries[]    # Bounding boxes of depth entries

--- a/docs/predictions-json.md
+++ b/docs/predictions-json.md
@@ -13,13 +13,13 @@ predictions.json
     │   └── page_dimensions[]             # Dimensions of each page, in PDF points
     │
     ├── boreholes[]                       # All boreholes identified in the document
-    │   ├── borehole_index                # Zero-based index to distinguish boreholes
+    │   ├── borehole_index                # Zero-based index for extracted boreholes
     │   ├── metadata
     │   │   ├── elevation                 # Borehole surface elevation, if found
     │   │   └── coordinates               # Borehole coordinates, if found
-    │   ├── layers[]                      # Ordered geological layers of the borehole profile
-    │   │   ├── material_description      # Soil/rock description for this layer
-    │   │   └── depth_interval            # Vertical extent of the layer
+    │   ├── layers[]                      # Detected layers of the borehole profil
+    │   │   ├── material_description      # Material text description
+    │   │   └── depth_interval            # Measured depth of the layer's upper and lower limits
     │   ├── bounding_boxes[]
     │   │   ├── page                      # Page number for this segment
     │   │   ├── sidebar_rect              # Area of the depth sidebar, if found
@@ -29,8 +29,8 @@ predictions.json
     │       ├── date                      # Measurement date (YYYY-MM-DD), if found
     │       ├── depth                     # Depth of the measurement (m), if found
     │       ├── elevation                 # Elevation (m above sea level), if found
-    │       ├── page                      # Source page number
-    │       └── rect                      # Bounding box of the measurement in the PDF
+    │       ├── page                      # Page number of detected groundwater
+    │       └── rect                      # Bounding box of detected groundwater
     │
     └── metrics                           # Evaluation scores with tp, fp, fn, precision, recall, and f1
         ├── language                      # Ground truth language for metric computation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ source = "versioningit"
 default-version = "0.0.0"
 
 [tool.versioningit.tag2version]
-# Only match plain release tags (e.g. v1.0.162), ignore dev tags like v1.0.dev2
+# Only match plain release tags (e.g. v1.0.1), ignore dev tags like v1.0.1.dev2
 regex = "^v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$"
 
 [tool.versioningit.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "versioningit"]
 build-backend = "hatchling.build"
 
 [project]
@@ -68,7 +68,20 @@ all = ["swissgeol-boreholes-dataextraction[test, lint, experiment-tracking, visu
 
 # ---- Configuration for package building
 [tool.hatch.version]
-source = "vcs"
+source = "versioningit"
+
+[tool.versioningit]
+default-version = "0.0.0"
+
+[tool.versioningit.tag2version]
+# Only match plain release tags (e.g. v1.0.162), ignore dev tags like v1.0.dev2
+regex = "^v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$"
+
+[tool.versioningit.format]
+distance = "{next_version}.dev{distance}+{vcs}{rev}"
+dirty = "{version}+d{build_date:%Y%m%d}"
+distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
+
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs", "versioningit"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -68,20 +68,7 @@ all = ["swissgeol-boreholes-dataextraction[test, lint, experiment-tracking, visu
 
 # ---- Configuration for package building
 [tool.hatch.version]
-source = "versioningit"
-
-[tool.versioningit]
-default-version = "0.0.0"
-
-[tool.versioningit.tag2version]
-# Only match plain release tags (e.g. v1.0.1), ignore dev tags like v1.0.1.dev2
-regex = "^v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$"
-
-[tool.versioningit.format]
-distance = "{next_version}.dev{distance}+{vcs}{rev}"
-dirty = "{version}+d{build_date:%Y%m%d}"
-distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
-
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/src/core/benchmark_utils.py
+++ b/src/core/benchmark_utils.py
@@ -128,9 +128,6 @@ class Metrics:
     def to_json(self) -> dict[str, float]:
         """Converts the object to a dictionary.
 
-        Args:
-            feature_name (str): Name of the feature to append.
-
         Returns:
             dict[str, float]: The object as a dictionary.
         """
@@ -145,7 +142,14 @@ class Metrics:
 
     @classmethod
     def from_json(cls, json: dict) -> Metrics:
-        """TODO."""
+        """Construct a Metrics instance from a dictionary produced by `to_json`.
+
+        Args:
+            json (dict): Dictionary with keys tp, fp, and fn.
+
+        Returns:
+            Metrics: The reconstructed metrics object.
+        """
         return Metrics(
             tp=json["tp"],
             fp=json["fp"],
@@ -171,7 +175,14 @@ class Metrics:
         return cls(tp=tp, fp=fp, fn=fn)
 
     def to_dict(self, prefix: str) -> dict[str, float]:
-        """TODO."""
+        """Return f1, recall, and precision as a flat dictionary with prefixed keys.
+
+        Args:
+            prefix (str): String prepended to each key .
+
+        Returns:
+            dict[str, float]: Flat metrics dictionary with prefixed keys.
+        """
         return {
             f"{prefix}_f1": self.f1,
             f"{prefix}_recall": self.recall,

--- a/src/core/benchmark_utils.py
+++ b/src/core/benchmark_utils.py
@@ -92,9 +92,9 @@ class BenchmarkSummary(BaseModel, ABC):
 class Metrics:
     """Metrics for the evaluation of extracted features (e.g., Groundwater, Elevation, Coordinates)."""
 
-    tp: int
-    fp: int
-    fn: int
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
 
     @property
     def precision(self) -> float:

--- a/src/core/benchmark_utils.py
+++ b/src/core/benchmark_utils.py
@@ -178,7 +178,7 @@ class Metrics:
         """Return f1, recall, and precision as a flat dictionary with prefixed keys.
 
         Args:
-            prefix (str): String prepended to each key .
+            prefix (str): String prepended to each key.
 
         Returns:
             dict[str, float]: Flat metrics dictionary with prefixed keys.

--- a/src/core/benchmark_utils.py
+++ b/src/core/benchmark_utils.py
@@ -125,7 +125,7 @@ class Metrics:
         recall = self.recall
         return 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0
 
-    def to_json(self, feature_name: str) -> dict[str, float]:
+    def to_json(self) -> dict[str, float]:
         """Converts the object to a dictionary.
 
         Args:
@@ -135,10 +135,22 @@ class Metrics:
             dict[str, float]: The object as a dictionary.
         """
         return {
-            f"{feature_name}_precision": self.precision,
-            f"{feature_name}_recall": self.recall,
-            f"{feature_name}_f1": self.f1,
+            "tp": self.tp,
+            "fp": self.fp,
+            "fn": self.fn,
+            "precision": self.precision,
+            "recall": self.recall,
+            "f1": self.f1,
         }
+
+    @classmethod
+    def from_json(cls, json: dict) -> Metrics:
+        """TODO."""
+        return Metrics(
+            tp=json["tp"],
+            fp=json["fp"],
+            fn=json["fn"],
+        )
 
     # TODO: Currently, some other methods for averaging metrics are in the OverallMetrics class.
     # On the long run, we should refactor this to have a single place where these averaging computations are

--- a/src/core/benchmark_utils.py
+++ b/src/core/benchmark_utils.py
@@ -170,6 +170,14 @@ class Metrics:
         fn = sum(metric.fn for metric in metric_list)
         return cls(tp=tp, fp=fp, fn=fn)
 
+    def to_dict(self, prefix: str) -> dict[str, float]:
+        """TODO."""
+        return {
+            f"{prefix}_f1": self.f1,
+            f"{prefix}_recall": self.recall,
+            f"{prefix}_precision": self.precision,
+        }
+
 
 def relative_after_common_root(paths: Sequence[Path]) -> list[str]:
     """Return relative paths after the longest common path prefix.

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -16,6 +16,12 @@ class OverallMetrics:
     # this to have a single place where these averaging computations are implemented.
 
     def __init__(self, metrics: dict[str, Metrics] | None = None):
+        """Initialise class with an optional pre-populated metrics dictionary.
+
+        Args:
+            metrics (dict[str, Metrics] | None): Mapping of document filename to per-document
+                Metrics. Defaults to an empty dict when None.
+        """
         self.metrics: dict[str, Metrics] = metrics if metrics is not None else {}
 
     def macro_f1(self) -> float:

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 from collections.abc import Callable
+from functools import reduce
 
 import pandas as pd
 
@@ -45,15 +46,6 @@ class OverallMetrics:
         else:
             return 0
 
-    def to_dataframe(self, name: str, fn: Callable[[Metrics], float]) -> pd.DataFrame:
-        """Convert the metrics to a DataFrame."""
-        series = pd.Series({filename: fn(metric) for filename, metric in self.metrics.items()})
-        return series.to_frame(name=name)
-
-    def get_metrics_list(self) -> list[Metrics]:
-        """Return a list of all metrics."""
-        return list(self.metrics.values())
-
     def get_language_subset(self, fp_languages: dict[str, str], language: str) -> "OverallMetrics":
         """Filter per-file metrics to only those whose file language matches the given language code.
 
@@ -67,6 +59,41 @@ class OverallMetrics:
         return OverallMetrics(
             {filename: metric for filename, metric in self.metrics.items() if fp_languages.get(filename) == language}
         )
+
+    def to_macro_dict(self, prefix: str) -> dict[str, float]:
+        """TODO."""
+        return {
+            f"{prefix}_f1": self.macro_f1(),
+            f"{prefix}_recall": self.macro_recall(),
+            f"{prefix}_precision": self.macro_precision(),
+        }
+
+    def to_micro_dict(self, prefix: str) -> dict[str, float]:
+        """TODO."""
+        micro_avg = Metrics.micro_average(self.metrics.values())
+        return {
+            f"{prefix}_f1": micro_avg.f1,
+            f"{prefix}_recall": micro_avg.recall,
+            f"{prefix}_precision": micro_avg.precision,
+        }
+
+    def to_df(
+        self,
+        prefix: str,
+        extra_metrics: dict[str, Callable[[Metrics], float]] | None = None,
+    ) -> pd.DataFrame:
+        """TODO."""
+        metrics = {"f1": lambda m: m.f1, "recall": lambda m: m.recall, "precision": lambda m: m.precision}
+        if extra_metrics:
+            metrics = metrics | extra_metrics
+
+        return pd.DataFrame(
+            {
+                "filename": filename,
+                **{f"{prefix}_{name}": fn(metric) for name, fn in metrics.items()},
+            }
+            for filename, metric in self.metrics.items()
+        ).set_index("filename")
 
 
 class OverallMetricsCatalog:
@@ -106,35 +133,49 @@ class OverallMetricsCatalog:
         self.coordinates_metrics.metrics[filename] = coordinates_metric
         self.name_metrics.metrics[filename] = name_metric
 
-    def document_level_metrics_df(self) -> pd.DataFrame:
-        """Return a DataFrame with all the document level metrics."""
-        all_series = [
-            self.layer_metrics.to_dataframe("F1", lambda metric: metric.f1),
-            self.layer_metrics.to_dataframe("precision", lambda metric: metric.precision),
-            self.layer_metrics.to_dataframe("recall", lambda metric: metric.recall),
-            self.depth_interval_metrics.to_dataframe("Depth_interval_f1", lambda metric: metric.f1),
-            self.depth_interval_metrics.to_dataframe("Depth_interval_recall", lambda metric: metric.recall),
-            self.depth_interval_metrics.to_dataframe("Depth_interval_precision", lambda metric: metric.precision),
-            self.material_description_metrics.to_dataframe("material_description_f1", lambda metric: metric.f1),
-            self.material_description_metrics.to_dataframe(
-                "material_description_recall", lambda metric: metric.recall
-            ),
-            self.material_description_metrics.to_dataframe(
-                "material_description_precision", lambda metric: metric.precision
-            ),
-            self.layer_metrics.to_dataframe("Number Elements", lambda metric: metric.tp + metric.fn),
-            self.layer_metrics.to_dataframe("Number wrong elements", lambda metric: metric.fp + metric.fn),
-            self.groundwater_metrics.to_dataframe("groundwater", lambda metric: metric.f1),
-            self.groundwater_depth_metrics.to_dataframe("groundwater_depth", lambda metric: metric.f1),
-            self.groundwater_depth_metrics.to_dataframe("Number of GW detected", lambda metric: metric.tp + metric.fp),
-        ]
-        document_level_metrics = pd.DataFrame()
-        for series in all_series:
-            document_level_metrics = document_level_metrics.join(series, how="outer")
-        return document_level_metrics
+    def to_dfs(self) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """TODO."""
+        return self.to_metadata_df(), self.to_geology_df()
 
-    def metrics_dict(self) -> dict[str, float]:
-        """Return a dictionary with the overall metrics."""
+    def to_metadata_df(self) -> pd.DataFrame:
+        """TODO."""
+        dfs = [
+            self.name_metrics.to_df("name"),
+            self.coordinates_metrics.to_df("coordinate"),
+            self.elevation_metrics.to_df("elevation"),
+        ]
+
+        df_final = reduce(lambda left, right: left.merge(right, on="filename"), dfs)
+        return df_final.sort_index(ascending=True)
+
+    def to_geology_df(self) -> pd.DataFrame:
+        """TODO."""
+        dfs = [
+            self.layer_metrics.to_df(
+                "layer",
+                extra_metrics={
+                    "num_total": lambda metric: metric.tp + metric.fn,
+                    "num_wrong": lambda metric: metric.fp + metric.fn,
+                },
+            ),
+            self.material_description_metrics.to_df("material_description"),
+            self.depth_interval_metrics.to_df("depth_interval"),
+            self.groundwater_metrics.to_df("groundwater"),
+            self.groundwater_depth_metrics.to_df(
+                "groundwater_depth",
+                extra_metrics={"num_detected": lambda metric: metric.tp + metric.fp},
+            ),
+        ]
+
+        df_final = reduce(lambda left, right: left.merge(right, on="filename"), dfs)
+        return df_final.sort_index(ascending=True)
+
+    def to_dicts(self) -> tuple[dict[str, float], dict[str, float]]:
+        """TODO."""
+        return self.to_metadata_dict(), self.to_geology_dict()
+
+    def to_geology_dict(self) -> dict[str, float]:
+        """TODO."""
         # Initialize a defaultdict to automatically return 0.0 for missing keys
         result = defaultdict(lambda: None)
 
@@ -143,34 +184,27 @@ class OverallMetricsCatalog:
         groundwater_depth_metrics = Metrics.micro_average(self.groundwater_depth_metrics.metrics.values())
 
         # Populate the basic metrics
-        result.update(
-            {
-                "layer_f1": self.layer_metrics.macro_f1() if self.layer_metrics else None,
-                "layer_recall": self.layer_metrics.macro_recall() if self.layer_metrics else None,
-                "layer_precision": self.layer_metrics.macro_precision() if self.layer_metrics else None,
-                "depth_interval_f1": self.depth_interval_metrics.macro_f1(),
-                "depth_interval_recall": self.depth_interval_metrics.macro_recall(),
-                "depth_interval_precision": self.depth_interval_metrics.macro_precision(),
-                "material_description_f1": self.material_description_metrics.macro_f1(),
-                "material_description_recall": self.material_description_metrics.macro_recall(),
-                "material_description_precision": self.material_description_metrics.macro_precision(),
-                "groundwater_f1": groundwater_metrics.f1,
-                "groundwater_recall": groundwater_metrics.recall,
-                "groundwater_precision": groundwater_metrics.precision,
-                "groundwater_depth_f1": groundwater_depth_metrics.f1,
-                "groundwater_depth_recall": groundwater_depth_metrics.recall,
-                "groundwater_depth_precision": groundwater_depth_metrics.precision,
-            }
-        )
+        result.update(self.layer_metrics.to_macro_dict("layer"))
+        result.update(self.depth_interval_metrics.to_macro_dict("depth_interval"))
+        result.update(self.material_description_metrics.to_macro_dict("material_description"))
+        result.update(groundwater_metrics.to_dict("groundwater"))
+        result.update(groundwater_depth_metrics.to_dict("groundwater_depth"))
 
         # Add dynamic language-specific metrics only if they exist
         for lang in self.languages:
             for metric_topic in ["layer", "depth_interval", "material_description"]:
-                key = f"{lang}_{metric_topic}_metrics"
+                key_prefix = f"{lang}_{metric_topic}"
+                key = f"{key_prefix}_metrics"
 
                 if getattr(self, key) and getattr(self, key).metrics:
-                    result[f"{lang}_{metric_topic}_f1"] = getattr(self, key).macro_f1()
-                    result[f"{lang}_{metric_topic}_recall"] = getattr(self, key).macro_recall()
-                    result[f"{lang}_{metric_topic}_precision"] = getattr(self, key).macro_precision()
+                    result.update(getattr(self, key).to_macro_dict(key_prefix))
 
         return dict(result)  # Convert defaultdict back to a regular dict
+
+    def to_metadata_dict(self) -> dict[str, float]:
+        """TODO."""
+        return (
+            self.name_metrics.to_micro_dict("name")
+            | self.elevation_metrics.to_micro_dict("elevation")
+            | self.coordinates_metrics.to_micro_dict("coordinates")
+        )

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -15,8 +15,8 @@ class OverallMetrics:
     # (see micro_average(metric_list: list["Metrics"]). On the long run, we should refactor
     # this to have a single place where these averaging computations are implemented.
 
-    def __init__(self):
-        self.metrics: dict[str, Metrics] = {}
+    def __init__(self, metrics: dict[str, Metrics] | None = None):
+        self.metrics: dict[str, Metrics] = metrics if metrics is not None else {}
 
     def macro_f1(self) -> float:
         """Compute the macro F1 score."""

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -73,11 +73,14 @@ class OverallMetricsCatalog:
     """Keeps track of all different relevant metrics that are computed for a dataset."""
 
     def __init__(self, languages: set[str]):
-        self.material_description_metrics = OverallMetrics()
         self.layer_metrics = OverallMetrics()
+        self.material_description_metrics = OverallMetrics()
         self.depth_interval_metrics = OverallMetrics()
         self.groundwater_metrics = OverallMetrics()
         self.groundwater_depth_metrics = OverallMetrics()
+        self.elevation_metrics = OverallMetrics()
+        self.coordinates_metrics = OverallMetrics()
+        self.name_metrics = OverallMetrics()
         self.languages = languages
 
         # Initialize language-specific metrics
@@ -85,6 +88,23 @@ class OverallMetricsCatalog:
             setattr(self, f"{lang}_layer_metrics", OverallMetrics())
             setattr(self, f"{lang}_depth_interval_metrics", OverallMetrics())
             setattr(self, f"{lang}_material_description_metrics", OverallMetrics())
+
+    def add_datapoint(
+        self,
+        filename: str,
+        material_description_metric: Metrics,
+        layer_metrics: Metrics,
+        depth_interval_metric: Metrics,
+        elevation_metric: Metrics,
+        coordinates_metric: Metrics,
+        name_metric: Metrics,
+    ):
+        self.layer_metrics.metrics[filename] = layer_metrics
+        self.material_description_metrics.metrics[filename] = material_description_metric
+        self.depth_interval_metrics.metrics[filename] = depth_interval_metric
+        self.elevation_metrics.metrics[filename] = elevation_metric
+        self.coordinates_metrics.metrics[filename] = coordinates_metric
+        self.name_metrics.metrics[filename] = name_metric
 
     def document_level_metrics_df(self) -> pd.DataFrame:
         """Return a DataFrame with all the document level metrics."""

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -185,7 +185,7 @@ class OverallMetricsCatalog:
         """
         dfs = [
             self.name_metrics.to_df("name"),
-            self.coordinates_metrics.to_df("coordinate"),
+            self.coordinates_metrics.to_df("coordinates"),
             self.elevation_metrics.to_df("elevation"),
         ]
 
@@ -234,7 +234,7 @@ class OverallMetricsCatalog:
         """Return overall geology metrics as a dictionary.
 
         Includes macro-averaged layer (and language-specific), depth interval, and material
-        description metrics, annd micro-averaged groundwater metrics.
+        description metrics, and micro-averaged groundwater metrics.
 
         Returns:
             dict[str, float]: Dictionary of overall geology metrics with prefixed keys.
@@ -270,7 +270,7 @@ class OverallMetricsCatalog:
         Computes micro-averages across all files for name, elevation, and coordinate metrics.
 
         Returns:
-            dict[str, float]:  Dictionary with prefixed keys.
+            dict[str, float]: Dictionary with prefixed keys.
         """
         return (
             self.name_metrics.to_micro_dict("name")

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -54,6 +54,21 @@ class OverallMetrics:
         """Return a list of all metrics."""
         return list(self.metrics.values())
 
+    # Set metrics for language
+    def get_language_subset(self, fp_languages: dict[str, str], language: str) -> "OverallMetrics":
+        """Filter per-file metrics to only those whose file language matches the given language code.
+
+        Args:
+            fp_languages (dict[str, str]): Dictionary with filenames as key and language as value.
+            language (str): Language code to filter by (e.g. "de", "fr").
+
+        Returns:
+            OverallMetrics: Metrics for files matching the specified language.
+        """
+        return OverallMetrics(
+            {filename: metric for filename, metric in self.metrics.items() if fp_languages.get(filename) == language}
+        )
+
 
 class OverallMetricsCatalog:
     """Keeps track of all different relevant metrics that are computed for a dataset."""

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -57,7 +57,9 @@ class OverallMetrics:
             OverallMetrics: Metrics for files matching the specified language.
         """
         return OverallMetrics(
-            {filename: metric for filename, metric in self.metrics.items() if fp_languages.get(filename) == language}
+            metrics={
+                filename: metric for filename, metric in self.metrics.items() if fp_languages.get(filename) == language
+            }
         )
 
     def to_macro_dict(self, prefix: str) -> dict[str, float]:

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -61,7 +61,14 @@ class OverallMetrics:
         )
 
     def to_macro_dict(self, prefix: str) -> dict[str, float]:
-        """TODO."""
+        """Return macro-averaged f1, recall, and precision as a dictionary with prefixed keys.
+
+        Args:
+            prefix (str): String prepended to each key.
+
+        Returns:
+            dict[str, float]: Flat macro-averaged metrics dictionary with prefixed keys.
+        """
         return {
             f"{prefix}_f1": self.macro_f1(),
             f"{prefix}_recall": self.macro_recall(),
@@ -69,7 +76,14 @@ class OverallMetrics:
         }
 
     def to_micro_dict(self, prefix: str) -> dict[str, float]:
-        """TODO."""
+        """Return micro-averaged f1, recall, and precision as a dictionary with prefixed keys.
+
+        Args:
+            prefix (str): String prepended to each key.
+
+        Returns:
+            dict[str, float]: Flat micro-averaged metrics dictionary with prefixed keys.
+        """
         micro_avg = Metrics.micro_average(self.metrics.values())
         return {
             f"{prefix}_f1": micro_avg.f1,
@@ -82,7 +96,16 @@ class OverallMetrics:
         prefix: str,
         extra_metrics: dict[str, Callable[[Metrics], float]] | None = None,
     ) -> pd.DataFrame:
-        """TODO."""
+        """Build a per-file DataFrame with f1, recall, and precision columns.
+
+        Args:
+            prefix (str): String prepended to each metric column name.
+            extra_metrics (dict[str, Callable[[Metrics], float]] | None): Dictionary of optional
+                metrics as a callable function. Defaults to None.
+
+        Returns:
+            pd.DataFrame: DataFrame indexed by filename with one prefixed column per metric.
+        """
         metrics = {"f1": lambda m: m.f1, "recall": lambda m: m.recall, "precision": lambda m: m.precision}
         if extra_metrics:
             metrics = metrics | extra_metrics
@@ -125,7 +148,18 @@ class OverallMetricsCatalog:
         elevation_metric: Metrics,
         coordinates_metric: Metrics,
         name_metric: Metrics,
-    ):
+    ) -> None:
+        """Register per-file metrics for all extraction categories.
+
+        Args:
+            filename (str): The file name used as key.
+            material_description_metric (Metrics): Material description metrics.
+            layer_metrics (Metrics): Layer detection metrics.
+            depth_interval_metric (Metrics): Depth interval metrics.
+            elevation_metric (Metrics): Elevation metrics.
+            coordinates_metric (Metrics): Coordinate metrics.
+            name_metric (Metrics): Borehole name metrics.
+        """
         self.layer_metrics.metrics[filename] = layer_metrics
         self.material_description_metrics.metrics[filename] = material_description_metric
         self.depth_interval_metrics.metrics[filename] = depth_interval_metric
@@ -134,11 +168,21 @@ class OverallMetricsCatalog:
         self.name_metrics.metrics[filename] = name_metric
 
     def to_dfs(self) -> tuple[pd.DataFrame, pd.DataFrame]:
-        """TODO."""
+        """Return document-level metrics as two DataFrames, one for metadata and one for geology.
+
+        Returns:
+            tuple[pd.DataFrame, pd.DataFrame]: A pair (metadata_df, geology_df), both indexed
+                by filename.
+        """
         return self.to_metadata_df(), self.to_geology_df()
 
     def to_metadata_df(self) -> pd.DataFrame:
-        """TODO."""
+        """Build a per-file DataFrame with name, coordinate, and elevation metrics.
+
+        Returns:
+            pd.DataFrame: DataFrame indexed by filename with columns for name, coordinate, and
+                elevation f1/recall/precision.
+        """
         dfs = [
             self.name_metrics.to_df("name"),
             self.coordinates_metrics.to_df("coordinate"),
@@ -149,7 +193,15 @@ class OverallMetricsCatalog:
         return df_final.sort_index(ascending=True)
 
     def to_geology_df(self) -> pd.DataFrame:
-        """TODO."""
+        """Build a per-file DataFrame with layer, depth interval, material description, and groundwater metrics.
+
+        Layer columns also include layer_num_total: (tp + fn) and layer_num_wrong: (fp + fn).
+        Groundwater depth columns also include groundwater_depth_num_detected: (tp + fp).
+
+        Returns:
+            pd.DataFrame: DataFrame indexed by filename with all geology metric columns,
+                sorted alphabetically by filename.
+        """
         dfs = [
             self.layer_metrics.to_df(
                 "layer",
@@ -171,11 +223,22 @@ class OverallMetricsCatalog:
         return df_final.sort_index(ascending=True)
 
     def to_dicts(self) -> tuple[dict[str, float], dict[str, float]]:
-        """TODO."""
+        """Return overall metrics as two flat dictionaries, one for metadata and one for geology.
+
+        Returns:
+            tuple[dict[str, float], dict[str, float]]: A pair (metadata_dict, geology_dict).
+        """
         return self.to_metadata_dict(), self.to_geology_dict()
 
     def to_geology_dict(self) -> dict[str, float]:
-        """TODO."""
+        """Return overall geology metrics as a dictionary.
+
+        Includes macro-averaged layer (and language-specific), depth interval, and material
+        description metrics, annd micro-averaged groundwater metrics.
+
+        Returns:
+            dict[str, float]: Dictionary of overall geology metrics with prefixed keys.
+        """
         # Initialize a defaultdict to automatically return 0.0 for missing keys
         result = defaultdict(lambda: None)
 
@@ -202,7 +265,13 @@ class OverallMetricsCatalog:
         return dict(result)  # Convert defaultdict back to a regular dict
 
     def to_metadata_dict(self) -> dict[str, float]:
-        """TODO."""
+        """Return overall metadata metrics as a dictionary.
+
+        Computes micro-averages across all files for name, elevation, and coordinate metrics.
+
+        Returns:
+            dict[str, float]:  Dictionary with prefixed keys.
+        """
         return (
             self.name_metrics.to_micro_dict("name")
             | self.elevation_metrics.to_micro_dict("elevation")

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -150,6 +150,8 @@ class OverallMetricsCatalog:
         elevation_metric: Metrics,
         coordinates_metric: Metrics,
         name_metric: Metrics,
+        groundwater_metrics: Metrics,
+        groundwater_depth_metrics: Metrics,
     ) -> None:
         """Register per-file metrics for all extraction categories.
 
@@ -161,6 +163,8 @@ class OverallMetricsCatalog:
             elevation_metric (Metrics): Elevation metrics.
             coordinates_metric (Metrics): Coordinate metrics.
             name_metric (Metrics): Borehole name metrics.
+            groundwater_metrics (Metrics): Groundwater metrics.
+            groundwater_depth_metrics (Metrics): Groundwater depth metrics.
         """
         self.layer_metrics.metrics[filename] = layer_metrics
         self.material_description_metrics.metrics[filename] = material_description_metric
@@ -168,6 +172,8 @@ class OverallMetricsCatalog:
         self.elevation_metrics.metrics[filename] = elevation_metric
         self.coordinates_metrics.metrics[filename] = coordinates_metric
         self.name_metrics.metrics[filename] = name_metric
+        self.groundwater_metrics.metrics[filename] = groundwater_metrics
+        self.groundwater_depth_metrics.metrics[filename] = groundwater_depth_metrics
 
     def to_dfs(self) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Return document-level metrics as two DataFrames, one for metadata and one for geology.

--- a/src/extraction/evaluation/benchmark/metrics.py
+++ b/src/extraction/evaluation/benchmark/metrics.py
@@ -54,7 +54,6 @@ class OverallMetrics:
         """Return a list of all metrics."""
         return list(self.metrics.values())
 
-    # Set metrics for language
     def get_language_subset(self, fp_languages: dict[str, str], language: str) -> "OverallMetrics":
         """Filter per-file metrics to only those whose file language matches the given language code.
 

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -88,9 +88,7 @@ def evaluate_all_predictions(
 
     matched_list_with_gt = Evaluator.match_overall_with_ground_truth(predictions, ground_truth)
 
-    #############################
-    # Evaluate the layer extraction
-    #############################
+    # Evaluate overall extraction
     geology_metrics, metadata_metrics_list = Evaluator.evaluate_overall(matched_list_with_gt)
 
     logger.info("Macro avg:")
@@ -101,30 +99,18 @@ def evaluate_all_predictions(
         geology_metrics.material_description_metrics.macro_f1() * 100,
     )
 
-    #############################
-    # Evaluate the borehole extraction
-    #############################
-
+    # Log detailed geology metrics
     geology_metrics_dict = geology_metrics.metrics_dict()
-
-    # Format the metrics dictionary to limit to three digits
     formatted_metrics = {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()}
     logger.info("Performance metrics: %s", formatted_metrics)
 
-    #############################
-    # Evaluate the borehole extraction metadata
-    #############################
+    # Log detailed metadata metrics
     metadata_metrics = metadata_metrics_list.get_cumulated_metrics()
     document_level_metadata_metrics: pd.DataFrame = metadata_metrics_list.get_document_level_metrics()
-
-    # print the metrics
     logger.info("Metadata Performance metrics:")
     logger.info(metadata_metrics.to_json())
 
-    #############################
     # Log results
-    #############################
-
     if mlflow:
         mlflow.log_metrics(geology_metrics_dict)
         mlflow.log_metrics(metadata_metrics.to_json())

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 from core.benchmark_utils import BenchmarkSummary
 from core.mlflow_tracking import mlflow
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
+from extraction.evaluation.evaluator import Evaluator
 from extraction.features.predictions.file_predictions import FilePredictions
 from extraction.features.predictions.overall_file_predictions import OverallFilePredictions
 from swissgeol_doc_processing.utils.file_utils import get_data_path
@@ -40,7 +41,7 @@ class ExtractionBenchmarkSummary(BenchmarkSummary):
         return geology_dict | metadata_dict
 
 
-def evaluate_single_prediction(
+def evaluate_prediction(
     prediction: FilePredictions,
     ground_truth: GroundTruth | None = None,
 ) -> FilePredictions:
@@ -59,17 +60,14 @@ def evaluate_single_prediction(
     if ground_truth is None:
         return prediction
 
-    # Create dummy overall file prediction and append prediction
-    # --- 1 Create prediction with GT
-    # matched_with_ground_truth = Evaluator.match_with_ground_truth(prediction, ground_truth)
+    # Create prediction with GT
+    matched_with_gt = Evaluator.match_with_ground_truth(prediction, ground_truth)
 
     # Run evaluation for file (! mutates prediction !)
-    # TODO: hello
-    # metadata_metrics = Evaluator.evaluate_metadata_extraction(matched_with_ground_truth)
-    # geology_metrics = Evaluator.evaluate_geology(matched_with_ground_truth)
+    Evaluator.evaluate_metadata(matched_with_gt)
+    Evaluator.evaluate_geology(matched_with_gt)
 
     # matched_with_ground_truth.evaluate_geology(verbose=False)
-    # matched_with_ground_truth.evaluate_metadata_extraction()
 
     return prediction
 
@@ -91,22 +89,25 @@ def evaluate_all_predictions(
     if ground_truth is None:
         return None
 
+    matched_list_with_gt = Evaluator.match_overall_with_ground_truth(predictions, ground_truth)
+
     #############################
     # Evaluate the borehole extraction
     #############################
-    matched_with_ground_truth = predictions.match_with_ground_truth(ground_truth)
-    metrics = matched_with_ground_truth.evaluate_geology()
-    metrics_dict = metrics.metrics_dict()
+
+    # matched_with_ground_truth = predictions.match_with_ground_truth(ground_truth)
+    geology_metrics_list = Evaluator.evaluate_overall_geology(matched_list_with_gt)
+    geology_metrics_dict = geology_metrics_list.metrics_dict()
 
     # Format the metrics dictionary to limit to three digits
-    formatted_metrics = {k: f"{v:.3f}" for k, v in metrics_dict.items()}
+    formatted_metrics = {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()}
     logger.info("Performance metrics: %s", formatted_metrics)
 
     #############################
     # Evaluate the borehole extraction metadata
     #############################
 
-    metadata_metrics_list = matched_with_ground_truth.evaluate_metadata_extraction()
+    metadata_metrics_list = Evaluator.evaluate_overall_metadata(matched_list_with_gt)
     metadata_metrics = metadata_metrics_list.get_cumulated_metrics()
     document_level_metadata_metrics: pd.DataFrame = metadata_metrics_list.get_document_level_metrics()
 
@@ -114,25 +115,31 @@ def evaluate_all_predictions(
     logger.info("Metadata Performance metrics:")
     logger.info(metadata_metrics.to_json())
 
+    #############################
+    # Log results
+    #############################
+
     if mlflow:
-        mlflow.log_metrics(metrics_dict)
+        mlflow.log_metrics(geology_metrics_dict)
         mlflow.log_metrics(metadata_metrics.to_json())
 
-        # # Create temporary folder to dump csv file and track them using MLFlow
+        # Create temporary folder to dump csv file and track them using MLFlow
         with tempfile.TemporaryDirectory() as temp_directory:
+            # Metadata
             document_level_metadata_metrics.to_csv(
                 Path(temp_directory) / "document_level_metadata_metrics.csv", index_label="document_name"
             )  # mlflow.log_artifact expects a file
-            metrics.document_level_metrics_df().to_csv(
+            mlflow.log_artifact(Path(temp_directory) / "document_level_metadata_metrics.csv")
+            # Geology
+            geology_metrics_list.document_level_metrics_df().to_csv(
                 Path(temp_directory) / "document_level_metrics.csv", index_label="document_name"
             )  # mlflow.log_artifact expects a file
             mlflow.log_artifact(Path(temp_directory) / "document_level_metrics.csv")
-            mlflow.log_artifact(Path(temp_directory) / "document_level_metadata_metrics.csv")
 
     return ExtractionBenchmarkSummary(
         ground_truth_path=str(ground_truth.path),
         n_documents=len(predictions.file_predictions_list),
-        geology=metrics_dict,
+        geology=geology_metrics_dict,
         metadata=metadata_metrics.to_json(),
     )
 

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import tempfile
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -101,50 +102,36 @@ def evaluate_all_predictions(
     # Evaluate overall extraction
     overall_metrics = Evaluator.aggregate(predictions)
 
-    logger.info("Macro avg:")
-    logger.info(
-        "layer f1: %.1f%%, depth interval f1: %.1f%%, material description f1: %.1f%%",
-        overall_metrics.layer_metrics.macro_f1() * 100,
-        overall_metrics.depth_interval_metrics.macro_f1() * 100,
-        overall_metrics.material_description_metrics.macro_f1() * 100,
-    )
-
     # Log detailed geology metrics
-    # geology_metrics_dict = geology_metrics.metrics_dict()
-    # logger.info("Performance metrics: %s", {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()})
+    metadata_metrics_dict, geology_metrics_dict = overall_metrics.to_dicts()
+    logger.info("Metadata metrics: %s", {k: f"{v:.3f}" for k, v in metadata_metrics_dict.items()})
+    logger.info("Geology metrics: %s", {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()})
 
-    # # Log detailed metadata metrics
-    # metadata_metrics = metadata_metrics_list.get_cumulated_metrics()
-    # metadata_metrics_dict = flatten(metadata_metrics.to_json(), separator="_")
-    # # document_level_metadata_metrics: pd.DataFrame = metadata_metrics_list.get_document_level_metrics()
-    # logger.info("Metadata Performance metrics: %s", metadata_metrics_dict)
+    if mlflow:
+        # Log results
+        document_level_metadata_metrics, document_level_meology_metrics = overall_metrics.to_dfs()
 
-    # Log results
-    # TODO
-    # if mlflow:
-    #     mlflow.log_metrics(geology_metrics_dict)
-    #     mlflow.log_metrics(metadata_metrics_dict)
+        mlflow.log_metrics(geology_metrics_dict)
+        mlflow.log_metrics(metadata_metrics_dict)
 
-    #     # Create temporary folder to dump csv file and track them using MLFlow
-    #     with tempfile.TemporaryDirectory() as temp_directory:
-    #         # Metadata
-    #         document_level_metadata_metrics.to_csv(
-    #             Path(temp_directory) / "document_level_metadata_metrics.csv", index_label="document_name"
-    #         )  # mlflow.log_artifact expects a file
-    #         mlflow.log_artifact(Path(temp_directory) / "document_level_metadata_metrics.csv")
-    #         # Geology
-    #         geology_metrics.document_level_metrics_df().to_csv(
-    #             Path(temp_directory) / "document_level_metrics.csv", index_label="document_name"
-    #         )  # mlflow.log_artifact expects a file
-    #         mlflow.log_artifact(Path(temp_directory) / "document_level_metrics.csv")
+        # Create temporary folder to dump csv file and track them using MLFlow
+        with tempfile.TemporaryDirectory() as temp_directory:
+            # Metadata
+            document_level_metadata_metrics.to_csv(
+                Path(temp_directory) / "document_level_metadata_metrics.csv", index_label="filename"
+            )  # mlflow.log_artifact expects a file
+            mlflow.log_artifact(Path(temp_directory) / "document_level_metadata_metrics.csv")
+            # Geology
+            document_level_meology_metrics.to_csv(
+                Path(temp_directory) / "document_level_geology_metrics.csv", index_label="filename"
+            )  # mlflow.log_artifact expects a file
+            mlflow.log_artifact(Path(temp_directory) / "document_level_geology_metrics.csv")
 
     return ExtractionBenchmarkSummary(
         ground_truth_path=str(ground_truth.path),
         n_documents=len(predictions.file_predictions_list),
-        geology={},
-        metadata={},
-        # geology=geology_metrics_dict,
-        # metadata=metadata_metrics_dict,
+        geology=geology_metrics_dict,
+        metadata=metadata_metrics_dict,
     )
 
 

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -101,14 +101,12 @@ def evaluate_all_predictions(
 
     # Log detailed geology metrics
     geology_metrics_dict = geology_metrics.metrics_dict()
-    formatted_metrics = {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()}
-    logger.info("Performance metrics: %s", formatted_metrics)
+    logger.info("Performance metrics: %s", {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()})
 
     # Log detailed metadata metrics
     metadata_metrics = metadata_metrics_list.get_cumulated_metrics()
     document_level_metadata_metrics: pd.DataFrame = metadata_metrics_list.get_document_level_metrics()
-    logger.info("Metadata Performance metrics:")
-    logger.info(metadata_metrics.to_json())
+    logger.info("Metadata Performance metrics: %s", metadata_metrics.to_json())
 
     # Log results
     if mlflow:

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -126,7 +126,7 @@ def evaluate_all_predictions(
     #############################
 
     if mlflow:
-        # mlflow.log_metrics(geology_metrics_dict)
+        mlflow.log_metrics(geology_metrics_dict)
         mlflow.log_metrics(metadata_metrics.to_json())
 
         # Create temporary folder to dump csv file and track them using MLFlow

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -60,25 +60,28 @@ def evaluate_prediction(
     Returns:
         FilePredictionsWithMetrics: The prediction, with evaluation flags set when ground truth is provided.
     """
-    if ground_truth is None:
-        return FilePredictionsWithMetrics(
-            filename=prediction.file_name,
-            boreholes=prediction.borehole_predictions_list,
-            language=None,
-            metrics=None,
+    language: str | None = None
+    metrics: FilePredictionsMetrics | None = None
+
+    if ground_truth is not None:
+        # Create prediction with GT
+        matched_with_gt = Evaluator.match_with_ground_truth(prediction, ground_truth)
+
+        # Run evaluation for file (! mutates prediction !)
+        layer_metrics, depth_metrics, material_metrics, gw_metrics, metadata_metrics = Evaluator.evaluate(
+            matched_with_gt
         )
 
-    # Create prediction with GT
-    matched_with_gt = Evaluator.match_with_ground_truth(prediction, ground_truth)
-
-    # Run evaluation for file (! mutates prediction !)
-    layer_metrics, depth_metrics, material_metrics, gw_metrics, metadata_metrics = Evaluator.evaluate(matched_with_gt)
+        # Set GT language and aggregate metrics into a single entity
+        language = matched_with_gt.language
+        metrics = FilePredictionsMetrics(layer_metrics, depth_metrics, material_metrics, gw_metrics, metadata_metrics)
 
     return FilePredictionsWithMetrics(
         filename=prediction.file_name,
+        file_metadata=prediction.file_metadata,
         boreholes=prediction.borehole_predictions_list,
-        language=matched_with_gt.language,
-        metrics=FilePredictionsMetrics(layer_metrics, depth_metrics, material_metrics, gw_metrics, metadata_metrics),
+        language=language,
+        metrics=metrics,
     )
 
 

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -47,15 +47,15 @@ def evaluate_prediction(
 ) -> FilePredictions:
     """Computes metrics for a given file.
 
-    Note that the implementation of `evaluate_geology` and `evaluate_metadata_extraction` mutates
-    the attributes of `prediction`.
+    Note that evaluation mutates the `is_correct` flags on layers, metadata,
+    and groundwater entries inside `prediction`.
 
     Args:
         prediction (FilePredictions): The predictions object.
-        ground_truth (GroundTruth | None): The ground truth object.
+        ground_truth (GroundTruth | None): The ground truth object. If None, no evaluation is performed.
 
     Returns:
-        FilePredictions: Evaluated prediction.
+        FilePredictions: The prediction, with evaluation flags set when ground truth is provided.
     """
     if ground_truth is None:
         return prediction

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -60,7 +60,6 @@ def evaluate_prediction(
     Returns:
         FilePredictionsWithMetrics: The prediction, with evaluation flags set when ground truth is provided.
     """
-    language: str | None = None
     metrics: FilePredictionsMetrics | None = None
 
     if ground_truth is not None:
@@ -73,14 +72,14 @@ def evaluate_prediction(
         )
 
         # Set GT language and aggregate metrics into a single entity
-        language = matched_with_gt.language
-        metrics = FilePredictionsMetrics(layer_metrics, depth_metrics, material_metrics, gw_metrics, metadata_metrics)
+        metrics = FilePredictionsMetrics(
+            matched_with_gt.language, layer_metrics, depth_metrics, material_metrics, gw_metrics, metadata_metrics
+        )
 
     return FilePredictionsWithMetrics(
         filename=prediction.file_name,
         file_metadata=prediction.file_metadata,
         boreholes=prediction.borehole_predictions_list,
-        language=language,
         metrics=metrics,
     )
 

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -64,7 +64,7 @@ def evaluate_prediction(
     matched_with_gt = Evaluator.match_with_ground_truth(prediction, ground_truth)
 
     # Run evaluation for file (! mutates prediction !)
-    Evaluator.evaluate_metadata(matched_with_gt)
+    Evaluator.evaluate(matched_with_gt)
 
     return prediction
 
@@ -89,21 +89,24 @@ def evaluate_all_predictions(
     matched_list_with_gt = Evaluator.match_overall_with_ground_truth(predictions, ground_truth)
 
     #############################
+    # Evaluate the layer extraction
+    #############################
+    metadata_metrics_list = Evaluator.evaluate_overall(matched_list_with_gt)
+
+    #############################
     # Evaluate the borehole extraction
     #############################
 
-    geology_metrics_list = Evaluator.evaluate_overall_geology(matched_list_with_gt)
-    geology_metrics_dict = geology_metrics_list.metrics_dict()
+    # geology_metrics_list = Evaluator.evaluate_overall_geology(matched_list_with_gt)
+    # geology_metrics_dict = geology_metrics_list.metrics_dict()
 
-    # Format the metrics dictionary to limit to three digits
-    formatted_metrics = {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()}
-    logger.info("Performance metrics: %s", formatted_metrics)
+    # # Format the metrics dictionary to limit to three digits
+    # formatted_metrics = {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()}
+    # logger.info("Performance metrics: %s", formatted_metrics)
 
     #############################
     # Evaluate the borehole extraction metadata
     #############################
-
-    metadata_metrics_list = Evaluator.evaluate_overall_metadata(matched_list_with_gt)
     metadata_metrics = metadata_metrics_list.get_cumulated_metrics()
     document_level_metadata_metrics: pd.DataFrame = metadata_metrics_list.get_document_level_metrics()
 
@@ -116,7 +119,7 @@ def evaluate_all_predictions(
     #############################
 
     if mlflow:
-        mlflow.log_metrics(geology_metrics_dict)
+        # mlflow.log_metrics(geology_metrics_dict)
         mlflow.log_metrics(metadata_metrics.to_json())
 
         # Create temporary folder to dump csv file and track them using MLFlow
@@ -127,15 +130,16 @@ def evaluate_all_predictions(
             )  # mlflow.log_artifact expects a file
             mlflow.log_artifact(Path(temp_directory) / "document_level_metadata_metrics.csv")
             # Geology
-            geology_metrics_list.document_level_metrics_df().to_csv(
-                Path(temp_directory) / "document_level_metrics.csv", index_label="document_name"
-            )  # mlflow.log_artifact expects a file
-            mlflow.log_artifact(Path(temp_directory) / "document_level_metrics.csv")
+            # geology_metrics_list.document_level_metrics_df().to_csv(
+            #     Path(temp_directory) / "document_level_metrics.csv", index_label="document_name"
+            # )  # mlflow.log_artifact expects a file
+            # mlflow.log_artifact(Path(temp_directory) / "document_level_metrics.csv")
 
     return ExtractionBenchmarkSummary(
         ground_truth_path=str(ground_truth.path),
         n_documents=len(predictions.file_predictions_list),
-        geology=geology_metrics_dict,
+        # geology=geology_metrics_dict,
+        geology={},
         metadata=metadata_metrics.to_json(),
     )
 

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -109,7 +109,7 @@ def evaluate_all_predictions(
 
     if mlflow:
         # Log results
-        document_level_metadata_metrics, document_level_meology_metrics = overall_metrics.to_dfs()
+        document_level_metadata_metrics, document_level_geology_metrics = overall_metrics.to_dfs()
 
         mlflow.log_metrics(geology_metrics_dict)
         mlflow.log_metrics(metadata_metrics_dict)
@@ -122,7 +122,7 @@ def evaluate_all_predictions(
             )  # mlflow.log_artifact expects a file
             mlflow.log_artifact(Path(temp_directory) / "document_level_metadata_metrics.csv")
             # Geology
-            document_level_meology_metrics.to_csv(
+            document_level_geology_metrics.to_csv(
                 Path(temp_directory) / "document_level_geology_metrics.csv", index_label="filename"
             )  # mlflow.log_artifact expects a file
             mlflow.log_artifact(Path(temp_directory) / "document_level_geology_metrics.csv")

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -5,17 +5,19 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import tempfile
 from pathlib import Path
 
-import pandas as pd
 from dotenv import load_dotenv
 
 from core.benchmark_utils import BenchmarkSummary
 from core.mlflow_tracking import mlflow
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
 from extraction.evaluation.evaluator import Evaluator
-from extraction.features.predictions.file_predictions import FilePredictions
+from extraction.features.predictions.file_predictions import (
+    FilePredictions,
+    FilePredictionsMetrics,
+    FilePredictionsWithMetrics,
+)
 from extraction.features.predictions.overall_file_predictions import OverallFilePredictions
 from swissgeol_doc_processing.utils.file_utils import get_data_path
 
@@ -44,7 +46,7 @@ class ExtractionBenchmarkSummary(BenchmarkSummary):
 def evaluate_prediction(
     prediction: FilePredictions,
     ground_truth: GroundTruth | None = None,
-) -> FilePredictions:
+) -> FilePredictionsWithMetrics:
     """Computes metrics for a given file.
 
     Note that evaluation mutates the `is_correct` flags on layers, metadata,
@@ -55,18 +57,28 @@ def evaluate_prediction(
         ground_truth (GroundTruth | None): The ground truth object. If None, no evaluation is performed.
 
     Returns:
-        FilePredictions: The prediction, with evaluation flags set when ground truth is provided.
+        FilePredictionsWithMetrics: The prediction, with evaluation flags set when ground truth is provided.
     """
     if ground_truth is None:
-        return prediction
+        return FilePredictionsWithMetrics(
+            filename=prediction.file_name,
+            boreholes=prediction.borehole_predictions_list,
+            language=None,
+            metrics=None,
+        )
 
     # Create prediction with GT
     matched_with_gt = Evaluator.match_with_ground_truth(prediction, ground_truth)
 
     # Run evaluation for file (! mutates prediction !)
-    Evaluator.evaluate(matched_with_gt)
+    layer_metrics, depth_metrics, material_metrics, gw_metrics, metadata_metrics = Evaluator.evaluate(matched_with_gt)
 
-    return prediction
+    return FilePredictionsWithMetrics(
+        filename=prediction.file_name,
+        boreholes=prediction.borehole_predictions_list,
+        language=matched_with_gt.language,
+        metrics=FilePredictionsMetrics(layer_metrics, depth_metrics, material_metrics, gw_metrics, metadata_metrics),
+    )
 
 
 def evaluate_all_predictions(
@@ -86,51 +98,53 @@ def evaluate_all_predictions(
     if ground_truth is None:
         return None
 
-    matched_list_with_gt = Evaluator.match_overall_with_ground_truth(predictions, ground_truth)
-
     # Evaluate overall extraction
-    geology_metrics, metadata_metrics_list = Evaluator.evaluate_overall(matched_list_with_gt)
+    overall_metrics = Evaluator.aggregate(predictions)
 
     logger.info("Macro avg:")
     logger.info(
         "layer f1: %.1f%%, depth interval f1: %.1f%%, material description f1: %.1f%%",
-        geology_metrics.layer_metrics.macro_f1() * 100,
-        geology_metrics.depth_interval_metrics.macro_f1() * 100,
-        geology_metrics.material_description_metrics.macro_f1() * 100,
+        overall_metrics.layer_metrics.macro_f1() * 100,
+        overall_metrics.depth_interval_metrics.macro_f1() * 100,
+        overall_metrics.material_description_metrics.macro_f1() * 100,
     )
 
     # Log detailed geology metrics
-    geology_metrics_dict = geology_metrics.metrics_dict()
-    logger.info("Performance metrics: %s", {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()})
+    # geology_metrics_dict = geology_metrics.metrics_dict()
+    # logger.info("Performance metrics: %s", {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()})
 
-    # Log detailed metadata metrics
-    metadata_metrics = metadata_metrics_list.get_cumulated_metrics()
-    document_level_metadata_metrics: pd.DataFrame = metadata_metrics_list.get_document_level_metrics()
-    logger.info("Metadata Performance metrics: %s", metadata_metrics.to_json())
+    # # Log detailed metadata metrics
+    # metadata_metrics = metadata_metrics_list.get_cumulated_metrics()
+    # metadata_metrics_dict = flatten(metadata_metrics.to_json(), separator="_")
+    # # document_level_metadata_metrics: pd.DataFrame = metadata_metrics_list.get_document_level_metrics()
+    # logger.info("Metadata Performance metrics: %s", metadata_metrics_dict)
 
     # Log results
-    if mlflow:
-        mlflow.log_metrics(geology_metrics_dict)
-        mlflow.log_metrics(metadata_metrics.to_json())
+    # TODO
+    # if mlflow:
+    #     mlflow.log_metrics(geology_metrics_dict)
+    #     mlflow.log_metrics(metadata_metrics_dict)
 
-        # Create temporary folder to dump csv file and track them using MLFlow
-        with tempfile.TemporaryDirectory() as temp_directory:
-            # Metadata
-            document_level_metadata_metrics.to_csv(
-                Path(temp_directory) / "document_level_metadata_metrics.csv", index_label="document_name"
-            )  # mlflow.log_artifact expects a file
-            mlflow.log_artifact(Path(temp_directory) / "document_level_metadata_metrics.csv")
-            # Geology
-            geology_metrics.document_level_metrics_df().to_csv(
-                Path(temp_directory) / "document_level_metrics.csv", index_label="document_name"
-            )  # mlflow.log_artifact expects a file
-            mlflow.log_artifact(Path(temp_directory) / "document_level_metrics.csv")
+    #     # Create temporary folder to dump csv file and track them using MLFlow
+    #     with tempfile.TemporaryDirectory() as temp_directory:
+    #         # Metadata
+    #         document_level_metadata_metrics.to_csv(
+    #             Path(temp_directory) / "document_level_metadata_metrics.csv", index_label="document_name"
+    #         )  # mlflow.log_artifact expects a file
+    #         mlflow.log_artifact(Path(temp_directory) / "document_level_metadata_metrics.csv")
+    #         # Geology
+    #         geology_metrics.document_level_metrics_df().to_csv(
+    #             Path(temp_directory) / "document_level_metrics.csv", index_label="document_name"
+    #         )  # mlflow.log_artifact expects a file
+    #         mlflow.log_artifact(Path(temp_directory) / "document_level_metrics.csv")
 
     return ExtractionBenchmarkSummary(
         ground_truth_path=str(ground_truth.path),
         n_documents=len(predictions.file_predictions_list),
-        geology=geology_metrics_dict,
-        metadata=metadata_metrics.to_json(),
+        geology={},
+        metadata={},
+        # geology=geology_metrics_dict,
+        # metadata=metadata_metrics_dict,
     )
 
 

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -91,18 +91,25 @@ def evaluate_all_predictions(
     #############################
     # Evaluate the layer extraction
     #############################
-    metadata_metrics_list = Evaluator.evaluate_overall(matched_list_with_gt)
+    geology_metrics, metadata_metrics_list = Evaluator.evaluate_overall(matched_list_with_gt)
+
+    logger.info("Macro avg:")
+    logger.info(
+        "layer f1: %.1f%%, depth interval f1: %.1f%%, material description f1: %.1f%%",
+        geology_metrics.layer_metrics.macro_f1() * 100,
+        geology_metrics.depth_interval_metrics.macro_f1() * 100,
+        geology_metrics.material_description_metrics.macro_f1() * 100,
+    )
 
     #############################
     # Evaluate the borehole extraction
     #############################
 
-    # geology_metrics_list = Evaluator.evaluate_overall_geology(matched_list_with_gt)
-    # geology_metrics_dict = geology_metrics_list.metrics_dict()
+    geology_metrics_dict = geology_metrics.metrics_dict()
 
-    # # Format the metrics dictionary to limit to three digits
-    # formatted_metrics = {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()}
-    # logger.info("Performance metrics: %s", formatted_metrics)
+    # Format the metrics dictionary to limit to three digits
+    formatted_metrics = {k: f"{v:.3f}" for k, v in geology_metrics_dict.items()}
+    logger.info("Performance metrics: %s", formatted_metrics)
 
     #############################
     # Evaluate the borehole extraction metadata
@@ -130,16 +137,15 @@ def evaluate_all_predictions(
             )  # mlflow.log_artifact expects a file
             mlflow.log_artifact(Path(temp_directory) / "document_level_metadata_metrics.csv")
             # Geology
-            # geology_metrics_list.document_level_metrics_df().to_csv(
-            #     Path(temp_directory) / "document_level_metrics.csv", index_label="document_name"
-            # )  # mlflow.log_artifact expects a file
-            # mlflow.log_artifact(Path(temp_directory) / "document_level_metrics.csv")
+            geology_metrics.document_level_metrics_df().to_csv(
+                Path(temp_directory) / "document_level_metrics.csv", index_label="document_name"
+            )  # mlflow.log_artifact expects a file
+            mlflow.log_artifact(Path(temp_directory) / "document_level_metrics.csv")
 
     return ExtractionBenchmarkSummary(
         ground_truth_path=str(ground_truth.path),
         n_documents=len(predictions.file_predictions_list),
-        # geology=geology_metrics_dict,
-        geology={},
+        geology=geology_metrics_dict,
         metadata=metadata_metrics.to_json(),
     )
 

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -65,9 +65,6 @@ def evaluate_prediction(
 
     # Run evaluation for file (! mutates prediction !)
     Evaluator.evaluate_metadata(matched_with_gt)
-    Evaluator.evaluate_geology(matched_with_gt)
-
-    # matched_with_ground_truth.evaluate_geology(verbose=False)
 
     return prediction
 
@@ -95,7 +92,6 @@ def evaluate_all_predictions(
     # Evaluate the borehole extraction
     #############################
 
-    # matched_with_ground_truth = predictions.match_with_ground_truth(ground_truth)
     geology_metrics_list = Evaluator.evaluate_overall_geology(matched_list_with_gt)
     geology_metrics_dict = geology_metrics_list.metrics_dict()
 

--- a/src/extraction/evaluation/benchmark/score.py
+++ b/src/extraction/evaluation/benchmark/score.py
@@ -60,11 +60,16 @@ def evaluate_single_prediction(
         return prediction
 
     # Create dummy overall file prediction and append prediction
-    matched_with_ground_truth = OverallFilePredictions([prediction]).match_with_ground_truth(ground_truth)
+    # --- 1 Create prediction with GT
+    # matched_with_ground_truth = Evaluator.match_with_ground_truth(prediction, ground_truth)
 
     # Run evaluation for file (! mutates prediction !)
-    matched_with_ground_truth.evaluate_geology(verbose=False)
-    matched_with_ground_truth.evaluate_metadata_extraction()
+    # TODO: hello
+    # metadata_metrics = Evaluator.evaluate_metadata_extraction(matched_with_ground_truth)
+    # geology_metrics = Evaluator.evaluate_geology(matched_with_ground_truth)
+
+    # matched_with_ground_truth.evaluate_geology(verbose=False)
+    # matched_with_ground_truth.evaluate_metadata_extraction()
 
     return prediction
 

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -26,8 +26,15 @@ class BoreholeMetadataMetrics:
         }
 
     @classmethod
-    def from_json(cls, json: dict) -> Metrics:
-        """TODO."""
+    def from_json(cls, json: dict) -> "BoreholeMetadataMetrics":
+        """Construct a BoreholeMetadataMetrics instance from a dictionary produced by `to_json`.
+
+        Args:
+            json (dict): Dictionary with elevation, coordinates, and name metrics.
+
+        Returns:
+            BoreholeMetadataMetrics: The reconstructed metadata metrics object.
+        """
         return BoreholeMetadataMetrics(
             elevation_metrics=Metrics.from_json(json["elevation"]),
             coordinates_metrics=Metrics.from_json(json["coordinates"]),

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -62,7 +62,12 @@ class OverallBoreholeMetadataMetrics:
         self.borehole_metadata_metrics.append(borehole_metadata_metrics)
 
     def get_cumulated_metrics(self) -> BoreholeMetadataMetrics:
-        """Evaluate the metadata metrics."""
+        """Compute metadata metrics across all collected files.
+
+        Returns:
+            BoreholeMetadataMetrics: Micro-average of elevation, coordinate, and name metrics
+                across all files in the collection.
+        """
         elevation_metrics = Metrics.micro_average(
             [metadata.elevation_metrics for metadata in self.borehole_metadata_metrics]
         )
@@ -81,11 +86,12 @@ class OverallBoreholeMetadataMetrics:
             pd.DataFrame: A DataFrame indexed by document names with columns:
                 - elevation: F1 score for elevation predictions
                 - coordinate: F1 score for coordinate predictions
+                - borehole_name: F1 score for borehole name predictions
 
         Example:
-                         elevation  coordinate
-            doc1.pdf     1.00      1.00
-            doc2.pdf     1.00      0.00
+                         elevation  coordinate  borehole_name
+            doc1.pdf     1.00       1.00        0.00
+            doc2.pdf     1.00       0.00        1.00
         """
         # Get a dataframe per document, concatenate, and sort by index (document name)
         return pd.concat(

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -1,6 +1,6 @@
 """Evaluation utilities."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from core.benchmark_utils import Metrics
 
@@ -40,18 +40,3 @@ class BoreholeMetadataMetrics:
             coordinates_metrics=Metrics.from_json(json["coordinates"]),
             name_metrics=Metrics.from_json(json["name"]),
         )
-
-
-@dataclass
-class OverallBoreholeMetadataMetrics:
-    """Metrics for borehole metadata."""
-
-    borehole_metadata_metrics: list[BoreholeMetadataMetrics] = field(default_factory=list)
-
-    def add_metadata_metrics(self, borehole_metadata_metrics: BoreholeMetadataMetrics) -> None:
-        """Append per-file metadata metrics to the collection.
-
-        Args:
-            borehole_metadata_metrics (BoreholeMetadataMetrics): The metrics for a single file to add.
-        """
-        self.borehole_metadata_metrics.append(borehole_metadata_metrics)

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -1,7 +1,7 @@
 """Evaluation utilities."""
 
 import abc
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pandas as pd
 
@@ -48,10 +48,10 @@ class FileBoreholeMetadataMetrics(BoreholeMetadataMetrics):
 
 
 @dataclass
-class OverallBoreholeMetadataMetrics(metaclass=abc.ABCMeta):
+class OverallBoreholeMetadataMetrics:
     """Metrics for borehole metadata."""
 
-    borehole_metadata_metrics: list[BoreholeMetadataMetrics]
+    borehole_metadata_metrics: list[BoreholeMetadataMetrics] = field(default_factory=list)
 
     def add_metadata_metrics(self, borehole_metadata_metrics: BoreholeMetadataMetrics):
         self.borehole_metadata_metrics.append(borehole_metadata_metrics)

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -2,8 +2,6 @@
 
 from dataclasses import dataclass, field
 
-import pandas as pd
-
 from core.benchmark_utils import Metrics
 
 
@@ -14,17 +12,6 @@ class BoreholeMetadataMetrics:
     elevation_metrics: Metrics
     coordinates_metrics: Metrics
     name_metrics: Metrics
-
-    # def get_document_level_metrics(self) -> pd.DataFrame:
-    #     """Get the document level metrics."""
-    #     return pd.DataFrame(
-    #         data={
-    #             "elevation": [self.elevation_metrics.f1],
-    #             "coordinate": [self.coordinates_metrics.f1],
-    #             "borehole_name": [self.name_metrics.f1],
-    #         },
-    #         index=[self.filename],
-    #     )
 
     def to_json(self) -> dict[str, float]:
         """Converts the object to a dictionary.
@@ -61,42 +48,3 @@ class OverallBoreholeMetadataMetrics:
             borehole_metadata_metrics (BoreholeMetadataMetrics): The metrics for a single file to add.
         """
         self.borehole_metadata_metrics.append(borehole_metadata_metrics)
-
-    def get_cumulated_metrics(self) -> BoreholeMetadataMetrics:
-        """Compute metadata metrics across all collected files.
-
-        Returns:
-            BoreholeMetadataMetrics: Micro-average of elevation, coordinate, and name metrics
-                across all files in the collection.
-        """
-        elevation_metrics = Metrics.micro_average(
-            [metadata.elevation_metrics for metadata in self.borehole_metadata_metrics]
-        )
-        coordinates_metrics = Metrics.micro_average(
-            [metadata.coordinates_metrics for metadata in self.borehole_metadata_metrics]
-        )
-        name_metrics = Metrics.micro_average([metadata.name_metrics for metadata in self.borehole_metadata_metrics])
-        return BoreholeMetadataMetrics(
-            elevation_metrics=elevation_metrics,
-            coordinates_metrics=coordinates_metrics,
-            name_metrics=name_metrics,
-        )
-
-    def get_document_level_metrics(self) -> pd.DataFrame:
-        """Get metrics aggregated at the document level.
-
-        Returns:
-            pd.DataFrame: A DataFrame indexed by document names with columns:
-                - elevation: F1 score for elevation predictions
-                - coordinate: F1 score for coordinate predictions
-                - borehole_name: F1 score for borehole name predictions
-
-        Example:
-                         elevation  coordinate  borehole_name
-            doc1.pdf     1.00       1.00        0.00
-            doc2.pdf     1.00       0.00        1.00
-        """
-        # Get a dataframe per document, concatenate, and sort by index (document name)
-        return pd.concat(
-            [metadata.get_document_level_metrics() for metadata in self.borehole_metadata_metrics]
-        ).sort_index()

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -54,6 +54,11 @@ class OverallBoreholeMetadataMetrics:
     borehole_metadata_metrics: list[BoreholeMetadataMetrics] = field(default_factory=list)
 
     def add_metadata_metrics(self, borehole_metadata_metrics: BoreholeMetadataMetrics):
+        """Append per-file metadata metrics to the collection.
+
+        Args:
+            borehole_metadata_metrics (BoreholeMetadataMetrics): The metrics for a single file to add.
+        """
         self.borehole_metadata_metrics.append(borehole_metadata_metrics)
 
     def get_cumulated_metrics(self) -> BoreholeMetadataMetrics:

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -53,10 +53,6 @@ class OverallBoreholeMetadataMetrics(metaclass=abc.ABCMeta):
 
     borehole_metadata_metrics: list[BoreholeMetadataMetrics]
 
-    def __init__(self):
-        """Initializes the OverallBoreholeMetadataMetrics object."""
-        self.borehole_metadata_metrics = []
-
     def get_cumulated_metrics(self) -> BoreholeMetadataMetrics:
         """Evaluate the metadata metrics."""
         elevation_metrics = Metrics.micro_average(

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -53,7 +53,7 @@ class OverallBoreholeMetadataMetrics:
 
     borehole_metadata_metrics: list[BoreholeMetadataMetrics] = field(default_factory=list)
 
-    def add_metadata_metrics(self, borehole_metadata_metrics: BoreholeMetadataMetrics):
+    def add_metadata_metrics(self, borehole_metadata_metrics: BoreholeMetadataMetrics) -> None:
         """Append per-file metadata metrics to the collection.
 
         Args:

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -13,11 +13,11 @@ class BoreholeMetadataMetrics:
     coordinates_metrics: Metrics
     name_metrics: Metrics
 
-    def to_json(self) -> dict[str, float]:
+    def to_json(self) -> dict[str, dict]:
         """Converts the object to a dictionary.
 
         Returns:
-            dict[str, float]: The object as a dictionary.
+            dict[str, dict]: The object as a dictionary.
         """
         return {
             "elevation": self.elevation_metrics.to_json(),

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -53,6 +53,9 @@ class OverallBoreholeMetadataMetrics(metaclass=abc.ABCMeta):
 
     borehole_metadata_metrics: list[BoreholeMetadataMetrics]
 
+    def add_metadata_metrics(self, borehole_metadata_metrics: BoreholeMetadataMetrics):
+        self.borehole_metadata_metrics.append(borehole_metadata_metrics)
+
     def get_cumulated_metrics(self) -> BoreholeMetadataMetrics:
         """Evaluate the metadata metrics."""
         elevation_metrics = Metrics.micro_average(

--- a/src/extraction/evaluation/evaluation_dataclasses.py
+++ b/src/extraction/evaluation/evaluation_dataclasses.py
@@ -1,6 +1,5 @@
 """Evaluation utilities."""
 
-import abc
 from dataclasses import dataclass, field
 
 import pandas as pd
@@ -9,12 +8,23 @@ from core.benchmark_utils import Metrics
 
 
 @dataclass
-class BoreholeMetadataMetrics(metaclass=abc.ABCMeta):
+class BoreholeMetadataMetrics:
     """Metrics for metadata."""
 
     elevation_metrics: Metrics
     coordinates_metrics: Metrics
     name_metrics: Metrics
+
+    # def get_document_level_metrics(self) -> pd.DataFrame:
+    #     """Get the document level metrics."""
+    #     return pd.DataFrame(
+    #         data={
+    #             "elevation": [self.elevation_metrics.f1],
+    #             "coordinate": [self.coordinates_metrics.f1],
+    #             "borehole_name": [self.name_metrics.f1],
+    #         },
+    #         index=[self.filename],
+    #     )
 
     def to_json(self) -> dict[str, float]:
         """Converts the object to a dictionary.
@@ -23,27 +33,18 @@ class BoreholeMetadataMetrics(metaclass=abc.ABCMeta):
             dict[str, float]: The object as a dictionary.
         """
         return {
-            **self.elevation_metrics.to_json("elevation"),
-            **self.coordinates_metrics.to_json("coordinate"),
-            **self.name_metrics.to_json("borehole_name"),
+            "elevation": self.elevation_metrics.to_json(),
+            "coordinates": self.coordinates_metrics.to_json(),
+            "name": self.name_metrics.to_json(),
         }
 
-
-@dataclass
-class FileBoreholeMetadataMetrics(BoreholeMetadataMetrics):
-    """Single file Metrics for borehole metadata."""
-
-    filename: str
-
-    def get_document_level_metrics(self) -> pd.DataFrame:
-        """Get the document level metrics."""
-        return pd.DataFrame(
-            data={
-                "elevation": [self.elevation_metrics.f1],
-                "coordinate": [self.coordinates_metrics.f1],
-                "borehole_name": [self.name_metrics.f1],
-            },
-            index=[self.filename],
+    @classmethod
+    def from_json(cls, json: dict) -> Metrics:
+        """TODO."""
+        return BoreholeMetadataMetrics(
+            elevation_metrics=Metrics.from_json(json["elevation"]),
+            coordinates_metrics=Metrics.from_json(json["coordinates"]),
+            name_metrics=Metrics.from_json(json["name"]),
         )
 
 
@@ -76,7 +77,9 @@ class OverallBoreholeMetadataMetrics:
         )
         name_metrics = Metrics.micro_average([metadata.name_metrics for metadata in self.borehole_metadata_metrics])
         return BoreholeMetadataMetrics(
-            elevation_metrics=elevation_metrics, coordinates_metrics=coordinates_metrics, name_metrics=name_metrics
+            elevation_metrics=elevation_metrics,
+            coordinates_metrics=coordinates_metrics,
+            name_metrics=name_metrics,
         )
 
     def get_document_level_metrics(self) -> pd.DataFrame:

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -1,17 +1,27 @@
 """Evaluator for borehole predictions against ground truth data."""
 
+import logging
+
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
+from extraction.evaluation.benchmark.metrics import OverallMetricsCatalog
 from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics, OverallBoreholeMetadataMetrics
+from extraction.evaluation.groundwater_evaluator import GroundwaterEvaluator
 from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.evaluation.metadata_evaluator import MetadataEvaluator
 from extraction.features.predictions.borehole_predictions import (
+    BoreholeGroundwaterWithGroundTruth,
+    BoreholeLayersWithGroundTruth,
     BoreholeMetadataWithGroundTruth,
+    FileGroundwaterWithGroundTruth,
+    FileLayersWithGroundTruth,
     FileMetadataWithGroundTruth,
     FilePredictionsWithGroundTruth,
 )
 from extraction.features.predictions.file_predictions import FilePredictions
 from extraction.features.predictions.overall_file_predictions import OverallFilePredictions
 from extraction.features.predictions.predictions import AllBoreholePredictionsWithGroundTruth
+
+logger = logging.getLogger(__name__)
 
 
 class Evaluator:
@@ -72,7 +82,86 @@ class Evaluator:
         return AllBoreholePredictionsWithGroundTruth(files)
 
     @staticmethod
-    def evaluate_metadata_extraction(
+    def evaluate_geology(file_predictions: FilePredictionsWithGroundTruth):
+        pass
+
+    @staticmethod
+    def evaluate_overall_geology(overall_predictions: AllBoreholePredictionsWithGroundTruth) -> OverallMetricsCatalog:
+        """Evaluate the borehole extraction predictions.
+
+        Args:
+            overall_predictions (AllBoreholePredictionsWithGroundTruth): metrics for the current evaluation.
+
+        Returns:
+            OverallMetricsCatalog: A OverallMetricsCatalog that maps a metrics name to the corresponding
+            OverallMetrics object. If no ground truth is available, None is returned.
+        """
+        languages = set(fp.language for fp in overall_predictions.predictions_list)
+        all_metrics = OverallMetricsCatalog(languages=languages)
+
+        layers_list = [
+            FileLayersWithGroundTruth(
+                file.filename,
+                file.language,
+                [
+                    BoreholeLayersWithGroundTruth(
+                        predictions.predictions.layers_in_borehole if predictions.predictions else None,
+                        predictions.ground_truth.get("layers", []),
+                    )
+                    for predictions in file.boreholes
+                ],
+            )
+            for file in overall_predictions.predictions_list
+        ]
+        evaluator = LayerEvaluator(layers_list)
+        all_metrics.material_description_metrics = evaluator.get_material_description_metrics()
+        all_metrics.depth_interval_metrics = evaluator.get_depth_interval_metrics()
+        all_metrics.layer_metrics = evaluator.get_layer_metrics()
+
+        predictions_by_language = {language: [] for language in languages}
+        for borehole_data in layers_list:
+            # even if metadata can be different for boreholes in the same document, langage is the same (take index 0)
+            predictions_by_language[borehole_data.language].append(borehole_data)
+
+        for language, language_predictions_list in predictions_by_language.items():
+            evaluator = LayerEvaluator(language_predictions_list)
+            setattr(all_metrics, f"{language}_layer_metrics", evaluator.get_layer_metrics())
+            setattr(all_metrics, f"{language}_depth_interval_metrics", evaluator.get_depth_interval_metrics())
+            setattr(
+                all_metrics, f"{language}_material_description_metrics", evaluator.get_material_description_metrics()
+            )
+
+        logger.info("Macro avg:")
+        logger.info(
+            "layer f1: %.1f%%, depth interval f1: %.1f%%, material description f1: %.1f%%",
+            all_metrics.layer_metrics.macro_f1() * 100,
+            all_metrics.depth_interval_metrics.macro_f1() * 100,
+            all_metrics.material_description_metrics.macro_f1() * 100,
+        )
+
+        # TODO groundwater should not be in evaluate_geology(), it should be handle by a higher-level function call
+        groundwater_list = [
+            FileGroundwaterWithGroundTruth(
+                file.filename,
+                [
+                    BoreholeGroundwaterWithGroundTruth(
+                        predictions.predictions.groundwater_in_borehole if predictions.predictions else None,
+                        predictions.ground_truth.get("groundwater", []) or [],  # value can be `None`
+                    )
+                    for predictions in file.boreholes
+                ],
+            )
+            for file in overall_predictions.predictions_list
+        ]
+        overall_groundwater_metrics = GroundwaterEvaluator(groundwater_list).evaluate()
+        all_metrics.groundwater_metrics = overall_groundwater_metrics.groundwater_metrics_to_overall_metrics()
+        all_metrics.groundwater_depth_metrics = (
+            overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
+        )
+        return all_metrics
+
+    @staticmethod
+    def evaluate_metadata(
         file_predictions: FilePredictionsWithGroundTruth,
     ) -> BoreholeMetadataMetrics:
         """Evaluate the metadata extraction of the predictions against the ground truth.
@@ -98,7 +187,7 @@ class Evaluator:
         return MetadataEvaluator.evaluate(file_metadata_gt)
 
     @staticmethod
-    def evaluate_overall_metadata_extraction(
+    def evaluate_overall_metadata(
         overall_predictions: AllBoreholePredictionsWithGroundTruth,
     ) -> OverallBoreholeMetadataMetrics:
         """Evaluate metadata extraction for all files in the overall predictions.
@@ -114,7 +203,7 @@ class Evaluator:
         """
         return OverallBoreholeMetadataMetrics(
             [
-                Evaluator.evaluate_metadata_extraction(file_metadata_gt)
+                Evaluator.evaluate_metadata(file_metadata_gt)
                 for file_metadata_gt in overall_predictions.predictions_list
             ]
         )

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -45,7 +45,7 @@ class Evaluator:
             ground_truth (GroundTruth): The ground truth.
 
         Returns:
-            FilePredictionsWithGroundTruth: all predictions per borehole with associated ground truth data.
+            FilePredictionsWithGroundTruth: All predictions per borehole with associated ground truth data.
         """
         boreholes = []
         ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
@@ -121,7 +121,7 @@ class Evaluator:
                 paired with their ground truth data.
 
         Returns:
-            BoreholeMetadataMetrics: the computed metrics for the metadata.
+            BoreholeMetadataMetrics: The computed metrics for the metadata.
         """
         return MetadataEvaluator.evaluate(
             file_predictions=FileMetadataWithGroundTruth(
@@ -212,7 +212,7 @@ class Evaluator:
         overall_depth_interval_metrics = OverallMetrics()
         overall_material_description_metrics = OverallMetrics()
 
-        # Iterate over all the file
+        # Iterate over all the files
         for file_predictions in overall_predictions.predictions_list:
             # Evaluate file
             layer_metrics, depth_interval_metrics, material_description_metrics, gw_metrics, metadata_metrics = (

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -56,16 +56,34 @@ class Evaluator:
         )
 
     @staticmethod
-    def evaluate(file_predictions: FilePredictionsWithGroundTruth) -> tuple[BoreholeMetadataMetrics]:
-        """Evaluate layers, metadata, and groundwater for a single file prediction (mutates prediction flags).
+    def evaluate(
+        file_predictions: FilePredictionsWithGroundTruth,
+    ) -> tuple[Metrics, Metrics, Metrics, GroundwaterMetrics, BoreholeMetadataMetrics]:
+        """Evaluate layers, metadata, and groundwater for a single file prediction.
+
+        Sets the `is_correct` flags on layers, depth intervals, material descriptions, groundwater entries,
+        and metadata fields inside `file_predictions`.
 
         Args:
             file_predictions (FilePredictionsWithGroundTruth): Per-file borehole predictions
                 paired with their ground truth data.
+
+        Returns:
+            tuple[Metrics, Metrics, Metrics, GroundwaterMetrics, BoreholeMetadataMetrics]:
+                A 5-tuple of:
+                - layer_metrics (Metrics): Metrics for layer detection.
+                - depth_interval_metrics (Metrics): Metrics for depth intervals.
+                - material_description_metrics (Metrics): Metrics for material descriptions.
+                - groundwater_metrics (GroundwaterMetrics): Metrics for Groundwater detection.
+                - metadata_metrics (BoreholeMetadataMetrics): Metrics for elevation, coordinate, and name.
         """
-        Evaluator.evaluate_layers(file_predictions)
-        Evaluator.evaluate_metadata(file_predictions)
-        Evaluator.evaluate_gw(file_predictions)
+        layer_metrics, depth_interval_metrics, material_description_metrics = Evaluator.evaluate_layers(
+            file_predictions
+        )
+        gw_metrics = Evaluator.evaluate_gw(file_predictions)
+        metadata_metrics = Evaluator.evaluate_metadata(file_predictions)
+
+        return layer_metrics, depth_interval_metrics, material_description_metrics, gw_metrics, metadata_metrics
 
     @staticmethod
     def evaluate_layers(file_predictions: FilePredictionsWithGroundTruth) -> tuple[Metrics, Metrics, Metrics]:
@@ -196,14 +214,15 @@ class Evaluator:
 
         # iteration over all the file
         for file_predictions in overall_predictions.predictions_list:
-            (
-                overall_layer_metrics.metrics[file_predictions.filename],
-                overall_depth_interval_metrics.metrics[file_predictions.filename],
-                overall_material_description_metrics.metrics[file_predictions.filename],
-            ) = Evaluator.evaluate_layers(file_predictions)
-            gw_metrics = Evaluator.evaluate_gw(file_predictions)
-            metadata_metrics = Evaluator.evaluate_metadata(file_predictions)
+            # Evaluate file
+            layer_metrics, depth_interval_metrics, material_description_metrics, gw_metrics, metadata_metrics = (
+                Evaluator.evaluate(file_predictions)
+            )
 
+            # Affect values to overall predictions
+            overall_layer_metrics.metrics[file_predictions.filename] = layer_metrics
+            overall_depth_interval_metrics.metrics[file_predictions.filename] = depth_interval_metrics
+            overall_material_description_metrics.metrics[file_predictions.filename] = material_description_metrics
             overall_groundwater_metrics.add_groundwater_metrics(gw_metrics)
             overall_metadata_metrics.add_metadata_metrics(metadata_metrics)
 

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -77,16 +77,16 @@ class Evaluator:
                 - groundwater_metrics (GroundwaterMetrics): Metrics for Groundwater detection.
                 - metadata_metrics (BoreholeMetadataMetrics): Metrics for elevation, coordinate, and name.
         """
-        layer_metrics, depth_interval_metrics, material_description_metrics = Evaluator.evaluate_layers(
+        layer_metrics, depth_interval_metrics, material_description_metrics = Evaluator._evaluate_layers(
             file_predictions
         )
-        gw_metrics = Evaluator.evaluate_gw(file_predictions)
-        metadata_metrics = Evaluator.evaluate_metadata(file_predictions)
+        gw_metrics = Evaluator._evaluate_gw(file_predictions)
+        metadata_metrics = Evaluator._evaluate_metadata(file_predictions)
 
         return layer_metrics, depth_interval_metrics, material_description_metrics, gw_metrics, metadata_metrics
 
     @staticmethod
-    def evaluate_layers(file_predictions: FilePredictionsWithGroundTruth) -> tuple[Metrics, Metrics, Metrics]:
+    def _evaluate_layers(file_predictions: FilePredictionsWithGroundTruth) -> tuple[Metrics, Metrics, Metrics]:
         """Evaluate layer, depth-interval, and material-description metrics for a single file.
 
         Args:
@@ -111,7 +111,7 @@ class Evaluator:
         )
 
     @staticmethod
-    def evaluate_metadata(
+    def _evaluate_metadata(
         file_predictions: FilePredictionsWithGroundTruth,
     ) -> BoreholeMetadataMetrics:
         """Evaluate the metadata extraction of the predictions against the ground truth.
@@ -137,7 +137,7 @@ class Evaluator:
         )
 
     @staticmethod
-    def evaluate_gw(file_predictions: FilePredictionsWithGroundTruth) -> GroundwaterMetrics:
+    def _evaluate_gw(file_predictions: FilePredictionsWithGroundTruth) -> GroundwaterMetrics:
         """Evaluate groundwater metrics for a single file prediction.
 
         Args:

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -2,15 +2,19 @@
 
 import logging
 
+from core.benchmark_utils import Metrics
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
+from extraction.evaluation.benchmark.metrics import OverallMetrics, OverallMetricsCatalog
 from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics, OverallBoreholeMetadataMetrics
 from extraction.evaluation.groundwater_evaluator import GroundwaterEvaluator, OverallGroundwaterMetrics
 from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.evaluation.metadata_evaluator import MetadataEvaluator
 from extraction.features.predictions.borehole_predictions import (
     BoreholeGroundwaterWithGroundTruth,
+    BoreholeLayersWithGroundTruth,
     BoreholeMetadataWithGroundTruth,
     FileGroundwaterWithGroundTruth,
+    FileLayersWithGroundTruth,
     FileMetadataWithGroundTruth,
     FilePredictionsWithGroundTruth,
 )
@@ -55,7 +59,19 @@ class Evaluator:
 
     @staticmethod
     def evaluate_layers(file_predictions: FilePredictionsWithGroundTruth) -> None:
-        LayerEvaluator.evaluate(file_predictions)
+        return LayerEvaluator.evaluate(
+            file_predictions=FileLayersWithGroundTruth(
+                file_predictions.filename,
+                file_predictions.language,
+                [
+                    BoreholeLayersWithGroundTruth(
+                        predictions.predictions.layers_in_borehole if predictions.predictions else None,
+                        predictions.ground_truth.get("layers", []),
+                    )
+                    for predictions in file_predictions.boreholes
+                ],
+            )
+        )
 
     @staticmethod
     def evaluate_metadata(
@@ -70,33 +86,33 @@ class Evaluator:
         Returns:
             BoreholeMetadataMetrics: the computed metrics for the metadata.
         """
-        file_metadata_gt = FileMetadataWithGroundTruth(
-            file_predictions.filename,
-            [
-                BoreholeMetadataWithGroundTruth(
-                    predictions.predictions.metadata if predictions.predictions else None,
-                    predictions.ground_truth.get("metadata", {}),
-                )
-                for predictions in file_predictions.boreholes
-            ],
+        return MetadataEvaluator.evaluate(
+            file_predictions=FileMetadataWithGroundTruth(
+                file_predictions.filename,
+                [
+                    BoreholeMetadataWithGroundTruth(
+                        predictions.predictions.metadata if predictions.predictions else None,
+                        predictions.ground_truth.get("metadata", {}),
+                    )
+                    for predictions in file_predictions.boreholes
+                ],
+            )
         )
-
-        return MetadataEvaluator.evaluate(file_metadata_gt)
 
     @staticmethod
     def evaluate_gw(file_predictions: FilePredictionsWithGroundTruth) -> OverallGroundwaterMetrics:
-        groundwater = FileGroundwaterWithGroundTruth(
-            file_predictions.filename,
-            [
-                BoreholeGroundwaterWithGroundTruth(
-                    predictions.predictions.groundwater_in_borehole if predictions.predictions else None,
-                    predictions.ground_truth.get("groundwater", []) or [],  # value can be `None`
-                )
-                for predictions in file_predictions.boreholes
-            ],
+        return GroundwaterEvaluator.evaluate(
+            file_predictions=FileGroundwaterWithGroundTruth(
+                file_predictions.filename,
+                [
+                    BoreholeGroundwaterWithGroundTruth(
+                        predictions.predictions.groundwater_in_borehole if predictions.predictions else None,
+                        predictions.ground_truth.get("groundwater", []) or [],  # value can be `None`
+                    )
+                    for predictions in file_predictions.boreholes
+                ],
+            )
         )
-
-        return GroundwaterEvaluator.evaluate(groundwater)
 
     @staticmethod
     def match_overall_with_ground_truth(
@@ -124,117 +140,67 @@ class Evaluator:
         )
 
     @staticmethod
-    def evaluate_overall(overall_predictions: AllBoreholePredictionsWithGroundTruth) -> tuple[BoreholeMetadataMetrics]:
-        Evaluator.evaluate_overall_layer(overall_predictions)
-        metadata_metrics_list = Evaluator.evaluate_overall_metadata(overall_predictions)
-        Evaluator.evaluate_overall_gw(overall_predictions)
-        return metadata_metrics_list
-
-    @staticmethod
-    def evaluate_overall_layer(overall_predictions: AllBoreholePredictionsWithGroundTruth):
-        for file_predictions in overall_predictions.predictions_list:
-            LayerEvaluator.evaluate(file_predictions)
-
-    # @staticmethod
-    # def evaluate_overall_geology(overall_predictions: AllBoreholePredictionsWithGroundTruth) ->OverallMetricsCatalog:
-    #     """Evaluate the borehole extraction predictions.
-
-    #     Args:
-    #         overall_predictions (AllBoreholePredictionsWithGroundTruth): metrics for the current evaluation.
-
-    #     Returns:
-    #         OverallMetricsCatalog: A OverallMetricsCatalog that maps a metrics name to the corresponding
-    #         OverallMetrics object. If no ground truth is available, None is returned.
-    #     """
-    #     languages = set(fp.language for fp in overall_predictions.predictions_list)
-    #     all_metrics = OverallMetricsCatalog(languages=languages)
-
-    #     layers_list = [
-    #         FileLayersWithGroundTruth(
-    #             file.filename,
-    #             file.language,
-    #             [
-    #                 BoreholeLayersWithGroundTruth(
-    #                     predictions.predictions.layers_in_borehole if predictions.predictions else None,
-    #                     predictions.ground_truth.get("layers", []),
-    #                 )
-    #                 for predictions in file.boreholes
-    #             ],
-    #         )
-    #         for file in overall_predictions.predictions_list
-    #     ]
-    #     evaluator = LayerEvaluator(layers_list)
-    #     all_metrics.material_description_metrics = evaluator.get_material_description_metrics()
-    #     all_metrics.depth_interval_metrics = evaluator.get_depth_interval_metrics()
-    #     all_metrics.layer_metrics = evaluator.get_layer_metrics()
-
-    #     predictions_by_language = {language: [] for language in languages}
-    #     for borehole_data in layers_list:
-    #         # even if metadata can be different for boreholes in the same document,
-    #         # langage is the same (take index 0)
-    #         predictions_by_language[borehole_data.language].append(borehole_data)
-
-    #     for language, language_predictions_list in predictions_by_language.items():
-    #         evaluator = LayerEvaluator(language_predictions_list)
-    #         setattr(all_metrics, f"{language}_layer_metrics", evaluator.get_layer_metrics())
-    #         setattr(all_metrics, f"{language}_depth_interval_metrics", evaluator.get_depth_interval_metrics())
-    #         setattr(
-    #             all_metrics, f"{language}_material_description_metrics", evaluator.get_material_description_metrics()
-    #         )
-
-    #     logger.info("Macro avg:")
-    #     logger.info(
-    #         "layer f1: %.1f%%, depth interval f1: %.1f%%, material description f1: %.1f%%",
-    #         all_metrics.layer_metrics.macro_f1() * 100,
-    #         all_metrics.depth_interval_metrics.macro_f1() * 100,
-    #         all_metrics.material_description_metrics.macro_f1() * 100,
-    #     )
-
-    #     # TODO groundwater should not be in evaluate_geology(), it should be handle by a higher-level function call
-    #     groundwater_list = [
-    #         FileGroundwaterWithGroundTruth(
-    #             file.filename,
-    #             [
-    #                 BoreholeGroundwaterWithGroundTruth(
-    #                     predictions.predictions.groundwater_in_borehole if predictions.predictions else None,
-    #                     predictions.ground_truth.get("groundwater", []) or [],  # value can be `None`
-    #                 )
-    #                 for predictions in file.boreholes
-    #             ],
-    #         )
-    #         for file in overall_predictions.predictions_list
-    #     ]
-    #     overall_groundwater_metrics = GroundwaterEvaluator(groundwater_list).evaluate()
-    #     all_metrics.groundwater_metrics = overall_groundwater_metrics.groundwater_metrics_to_overall_metrics()
-    #     all_metrics.groundwater_depth_metrics = (
-    #         overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
-    #     )
-    #     return all_metrics
-
-    @staticmethod
-    def evaluate_overall_metadata(
+    def evaluate_overall(
         overall_predictions: AllBoreholePredictionsWithGroundTruth,
-    ) -> OverallBoreholeMetadataMetrics:
-        """Evaluate metadata extraction for all files in the overall predictions.
+    ) -> tuple[OverallMetricsCatalog, OverallBoreholeMetadataMetrics]:
+        fp_languages = {fp.filename: fp.language for fp in overall_predictions.predictions_list}
+        languages = set(fp_languages.values())
 
-        Delegates per-file evaluation to evaluate_metadata_extraction and collects the results.
+        overall_groundwater_metrics = OverallGroundwaterMetrics([])
+        overall_metadata_metrics = OverallBoreholeMetadataMetrics([])
 
-        Args:
-            overall_predictions (AllBoreholePredictionsWithGroundTruth): All per-file borehole
-                predictions paired with their ground truth data.
+        overall_geology_metrics = OverallMetricsCatalog(languages=languages)
+        overall_layer_metrics = OverallMetrics()
+        overall_depth_interval_metrics = OverallMetrics()
+        overall_material_description_metrics = OverallMetrics()
 
-        Returns:
-            OverallBoreholeMetadataMetrics: Aggregated metadata metrics across all files.
-        """
-        return OverallBoreholeMetadataMetrics(
-            [
-                Evaluator.evaluate_metadata(file_metadata_gt)
-                for file_metadata_gt in overall_predictions.predictions_list
-            ]
+        # iteration over all the file
+        for file_predictions in overall_predictions.predictions_list:
+            (
+                overall_layer_metrics.metrics[file_predictions.filename],
+                overall_depth_interval_metrics.metrics[file_predictions.filename],
+                overall_material_description_metrics.metrics[file_predictions.filename],
+            ) = Evaluator.evaluate_layers(file_predictions)
+            gw_metrics = Evaluator.evaluate_gw(file_predictions)
+            metadata_metrics = Evaluator.evaluate_metadata(file_predictions)
+
+            overall_groundwater_metrics.add_groundwater_metrics(gw_metrics)
+            overall_metadata_metrics.add_metadata_metrics(metadata_metrics)
+
+        # Set metrics for geology
+        overall_geology_metrics.layer_metrics = overall_layer_metrics
+        overall_geology_metrics.depth_interval_metrics = overall_depth_interval_metrics
+        overall_geology_metrics.material_description_metrics = overall_material_description_metrics
+        overall_geology_metrics.groundwater_metrics = (
+            overall_groundwater_metrics.groundwater_metrics_to_overall_metrics()
+        )
+        overall_geology_metrics.groundwater_depth_metrics = (
+            overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
         )
 
-    @staticmethod
-    def evaluate_overall_gw(overall_predictions: AllBoreholePredictionsWithGroundTruth) -> OverallGroundwaterMetrics:
-        return OverallGroundwaterMetrics(
-            [Evaluator.evaluate_gw(file_predictions) for file_predictions in overall_predictions.predictions_list]
-        )
+        # Set metrics for language
+        def get_language_metric(fp: dict[str, Metrics], language: str) -> OverallMetrics:
+            return OverallMetrics(
+                {filename: metric for filename, metric in fp.items() if fp_languages.get(filename) == language}
+            )
+
+        for language in languages:
+            setattr(
+                overall_geology_metrics,
+                f"{language}_layer_metrics",
+                get_language_metric(overall_layer_metrics.metrics, language),
+            )
+
+            setattr(
+                overall_geology_metrics,
+                f"{language}_depth_interval_metrics",
+                get_language_metric(overall_depth_interval_metrics.metrics, language),
+            )
+
+            setattr(
+                overall_geology_metrics,
+                f"{language}_material_description_metrics",
+                get_language_metric(overall_material_description_metrics.metrics, language),
+            )
+
+        return overall_geology_metrics, overall_metadata_metrics

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -146,8 +146,8 @@ class Evaluator:
         fp_languages = {fp.filename: fp.language for fp in overall_predictions.predictions_list}
         languages = set(fp_languages.values())
 
-        overall_groundwater_metrics = OverallGroundwaterMetrics([])
-        overall_metadata_metrics = OverallBoreholeMetadataMetrics([])
+        overall_groundwater_metrics = OverallGroundwaterMetrics()
+        overall_metadata_metrics = OverallBoreholeMetadataMetrics()
 
         overall_geology_metrics = OverallMetricsCatalog(languages=languages)
         overall_layer_metrics = OverallMetrics()

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -1,16 +1,23 @@
-"""TODO."""
+"""Evaluator for borehole predictions against ground truth data."""
 
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
+from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics, OverallBoreholeMetadataMetrics
 from extraction.evaluation.layer_evaluator import LayerEvaluator
+from extraction.evaluation.metadata_evaluator import MetadataEvaluator
 from extraction.features.predictions.borehole_predictions import (
+    BoreholeMetadataWithGroundTruth,
+    FileMetadataWithGroundTruth,
     FilePredictionsWithGroundTruth,
 )
 from extraction.features.predictions.file_predictions import FilePredictions
+from extraction.features.predictions.overall_file_predictions import OverallFilePredictions
+from extraction.features.predictions.predictions import AllBoreholePredictionsWithGroundTruth
 
 
 class Evaluator:
-    """TODO."""
+    """Static utility class for matching borehole predictions with ground truth and computing evaluation metrics."""
 
+    @staticmethod
     def match_with_ground_truth(
         file_predictions: FilePredictions, ground_truth: GroundTruth
     ) -> FilePredictionsWithGroundTruth:
@@ -19,6 +26,7 @@ class Evaluator:
         This is done by comparing the layers of the extracted boreholes with those in the groundtruth.
 
         Args:
+            file_predictions (FilePredictions): File predictions.
             ground_truth (GroundTruth): The ground truth.
 
         Returns:
@@ -32,25 +40,81 @@ class Evaluator:
             file_predictions.file_name, file_predictions.file_metadata.language, boreholes
         )
 
-    # TODO: hello
-    # def evaluate_metadata_extraction(self) -> OverallBoreholeMetadataMetrics:
-    #     """Evaluate the metadata extraction of the predictions against the ground truth.
+    @staticmethod
+    def match_overall_with_ground_truth(
+        overall_predictions: OverallFilePredictions, ground_truth: GroundTruth
+    ) -> AllBoreholePredictionsWithGroundTruth:
+        """Match all file predictions across multiple files with their corresponding ground truth data.
 
-    #     Returns:
-    #         OverallBoreholeMetadataMetrics: the computed metrics for the metadata.
-    #     """
-    #     metadata_list = [
-    #         FileMetadataWithGroundTruth(
-    #             file.filename,
-    #             [
-    #                 BoreholeMetadataWithGroundTruth(
-    #                     predictions.predictions.metadata if predictions.predictions else None,
-    #                     predictions.ground_truth.get("metadata", {}),
-    #                 )
-    #                 for predictions in file.boreholes
-    #             ],
-    #         )
-    #         for file in self.predictions_list
-    #     ]
+        Iterates over each file in overall_predictions and delegates per-file matching to
+        LayerEvaluator. Files with no matching ground truth entry are included with an empty
+        borehole list.
 
-    #     return MetadataEvaluator(metadata_list).evaluate()
+        Args:
+            overall_predictions (OverallFilePredictions): Predictions for all processed files.
+            ground_truth (GroundTruth): The ground truth dataset to match against.
+
+        Returns:
+            AllBoreholePredictionsWithGroundTruth: Predictions for every file, each paired with
+                its corresponding ground truth boreholes.
+        """
+        files = []
+        for file_predictions in overall_predictions.file_predictions_list:
+            boreholes = []
+            ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
+            if ground_truth_for_file:
+                boreholes = LayerEvaluator.match_predictions_with_ground_truth(file_predictions, ground_truth_for_file)
+            files.append(
+                FilePredictionsWithGroundTruth(
+                    file_predictions.file_name, file_predictions.file_metadata.language, boreholes
+                )
+            )
+        return AllBoreholePredictionsWithGroundTruth(files)
+
+    @staticmethod
+    def evaluate_metadata_extraction(
+        file_predictions: FilePredictionsWithGroundTruth,
+    ) -> BoreholeMetadataMetrics:
+        """Evaluate the metadata extraction of the predictions against the ground truth.
+
+        Args:
+            file_predictions (FilePredictionsWithGroundTruth): Per-file borehole predictions
+                paired with their ground truth data.
+
+        Returns:
+            BoreholeMetadataMetrics: the computed metrics for the metadata.
+        """
+        file_metadata_gt = FileMetadataWithGroundTruth(
+            file_predictions.filename,
+            [
+                BoreholeMetadataWithGroundTruth(
+                    predictions.predictions.metadata if predictions.predictions else None,
+                    predictions.ground_truth.get("metadata", {}),
+                )
+                for predictions in file_predictions.boreholes
+            ],
+        )
+
+        return MetadataEvaluator.evaluate(file_metadata_gt)
+
+    @staticmethod
+    def evaluate_overall_metadata_extraction(
+        overall_predictions: AllBoreholePredictionsWithGroundTruth,
+    ) -> OverallBoreholeMetadataMetrics:
+        """Evaluate metadata extraction for all files in the overall predictions.
+
+        Delegates per-file evaluation to evaluate_metadata_extraction and collects the results.
+
+        Args:
+            overall_predictions (AllBoreholePredictionsWithGroundTruth): All per-file borehole
+                predictions paired with their ground truth data.
+
+        Returns:
+            OverallBoreholeMetadataMetrics: Aggregated metadata metrics across all files.
+        """
+        return OverallBoreholeMetadataMetrics(
+            [
+                Evaluator.evaluate_metadata_extraction(file_metadata_gt)
+                for file_metadata_gt in overall_predictions.predictions_list
+            ]
+        )

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -237,29 +237,23 @@ class Evaluator:
             overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
         )
 
-        # Set metrics for language
-        def get_language_metric(fp: dict[str, Metrics], language: str) -> OverallMetrics:
-            return OverallMetrics(
-                {filename: metric for filename, metric in fp.items() if fp_languages.get(filename) == language}
-            )
-
         for language in languages:
             setattr(
                 overall_geology_metrics,
                 f"{language}_layer_metrics",
-                get_language_metric(overall_layer_metrics.metrics, language),
+                overall_layer_metrics.get_language_subset(fp_languages, language),
             )
 
             setattr(
                 overall_geology_metrics,
                 f"{language}_depth_interval_metrics",
-                get_language_metric(overall_depth_interval_metrics.metrics, language),
+                overall_depth_interval_metrics.get_language_subset(fp_languages, language),
             )
 
             setattr(
                 overall_geology_metrics,
                 f"{language}_material_description_metrics",
-                get_language_metric(overall_material_description_metrics.metrics, language),
+                overall_material_description_metrics.get_language_subset(fp_languages, language),
             )
 
         return overall_geology_metrics, overall_metadata_metrics

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -1,0 +1,56 @@
+"""TODO."""
+
+from extraction.evaluation.benchmark.ground_truth import GroundTruth
+from extraction.evaluation.layer_evaluator import LayerEvaluator
+from extraction.features.predictions.borehole_predictions import (
+    FilePredictionsWithGroundTruth,
+)
+from extraction.features.predictions.file_predictions import FilePredictions
+
+
+class Evaluator:
+    """TODO."""
+
+    def match_with_ground_truth(
+        file_predictions: FilePredictions, ground_truth: GroundTruth
+    ) -> FilePredictionsWithGroundTruth:
+        """Match the extracted boreholes with corresponding boreholes in the ground truth data.
+
+        This is done by comparing the layers of the extracted boreholes with those in the groundtruth.
+
+        Args:
+            ground_truth (GroundTruth): The ground truth.
+
+        Returns:
+            AllBoreholePredictionsWithGroundTruth: all predictions per borehole with associated ground truth data.
+        """
+        boreholes = []
+        ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
+        if ground_truth_for_file:
+            boreholes = LayerEvaluator.match_predictions_with_ground_truth(file_predictions, ground_truth_for_file)
+        return FilePredictionsWithGroundTruth(
+            file_predictions.file_name, file_predictions.file_metadata.language, boreholes
+        )
+
+    # TODO: hello
+    # def evaluate_metadata_extraction(self) -> OverallBoreholeMetadataMetrics:
+    #     """Evaluate the metadata extraction of the predictions against the ground truth.
+
+    #     Returns:
+    #         OverallBoreholeMetadataMetrics: the computed metrics for the metadata.
+    #     """
+    #     metadata_list = [
+    #         FileMetadataWithGroundTruth(
+    #             file.filename,
+    #             [
+    #                 BoreholeMetadataWithGroundTruth(
+    #                     predictions.predictions.metadata if predictions.predictions else None,
+    #                     predictions.ground_truth.get("metadata", {}),
+    #                 )
+    #                 for predictions in file.boreholes
+    #             ],
+    #         )
+    #         for file in self.predictions_list
+    #     ]
+
+    #     return MetadataEvaluator(metadata_list).evaluate()

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -9,7 +9,6 @@ from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics
 from extraction.evaluation.groundwater_evaluator import (
     GroundwaterEvaluator,
     GroundwaterMetrics,
-    OverallGroundwaterMetrics,
 )
 from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.evaluation.metadata_evaluator import MetadataEvaluator
@@ -73,7 +72,7 @@ class Evaluator:
                 - layer_metrics (Metrics): Metrics for layer detection.
                 - depth_interval_metrics (Metrics): Metrics for depth intervals.
                 - material_description_metrics (Metrics): Metrics for material descriptions.
-                - groundwater_metrics (GroundwaterMetrics): Metrics for Groundwater detection.
+                - gw_metrics (GroundwaterMetrics): Metrics for Groundwater detection.
                 - metadata_metrics (BoreholeMetadataMetrics): Metrics for elevation, coordinate, and name.
         """
         layer_metrics, depth_interval_metrics, material_description_metrics = Evaluator._evaluate_layers(
@@ -177,7 +176,6 @@ class Evaluator:
         languages = set(fp_languages.values())
 
         overall_metrics_catalog = OverallMetricsCatalog(languages=languages)
-        overall_groundwater_metrics = OverallGroundwaterMetrics()
 
         # Iterate over all the files
         for predictions in overall_predictions.file_predictions_list:
@@ -189,18 +187,9 @@ class Evaluator:
                 elevation_metric=predictions.metrics.metadata_metrics.elevation_metrics,
                 coordinates_metric=predictions.metrics.metadata_metrics.coordinates_metrics,
                 name_metric=predictions.metrics.metadata_metrics.name_metrics,
+                groundwater_metrics=predictions.metrics.gw_metrics.groundwater_metrics,
+                groundwater_depth_metrics=predictions.metrics.gw_metrics.groundwater_depth_metrics,
             )
-
-            # Assign values to overall predictions
-            overall_groundwater_metrics.add_groundwater_metrics(predictions.metrics.gw_metrics)
-
-        # Set metrics for geology
-        overall_metrics_catalog.groundwater_metrics = (
-            overall_groundwater_metrics.groundwater_metrics_to_overall_metrics()
-        )
-        overall_metrics_catalog.groundwater_depth_metrics = (
-            overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
-        )
 
         # Language subsets for geology
         for language in languages:

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -102,10 +102,10 @@ class Evaluator:
                 file_predictions.language,
                 [
                     BoreholeLayersWithGroundTruth(
-                        predictions.predictions.layers_in_borehole if predictions.predictions else None,
-                        predictions.ground_truth.get("layers", []),
+                        borehole.predictions.layers_in_borehole if borehole.predictions else None,
+                        borehole.ground_truth.get("layers", []),
                     )
-                    for predictions in file_predictions.boreholes
+                    for borehole in file_predictions.boreholes
                 ],
             )
         )

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -163,7 +163,7 @@ class Evaluator:
     def aggregate(
         overall_predictions: OverallFilePredictions,
     ) -> OverallMetricsCatalog:
-        """Aggregate all files prediction for geology and metadata metrics.
+        """Aggregate all files predictions for geology and metadata metrics.
 
         Args:
             overall_predictions (OverallFilePredictions): All per-file predictions

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -173,7 +173,7 @@ class Evaluator:
             OverallMetricsCatalog: Aggregated geology and metadata metrics (layers, depth intervals,
                 material descriptions, groundwater) globally and per language.
         """
-        fp_languages = {fp.filename: fp.language for fp in overall_predictions.file_predictions_list}
+        fp_languages = {fp.filename: fp.metrics.language for fp in overall_predictions.file_predictions_list}
         languages = set(fp_languages.values())
 
         overall_metrics_catalog = OverallMetricsCatalog(languages=languages)

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -4,7 +4,7 @@ import logging
 
 from core.benchmark_utils import Metrics
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
-from extraction.evaluation.benchmark.metrics import OverallMetrics, OverallMetricsCatalog
+from extraction.evaluation.benchmark.metrics import OverallMetricsCatalog
 from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics, OverallBoreholeMetadataMetrics
 from extraction.evaluation.groundwater_evaluator import (
     GroundwaterEvaluator,
@@ -204,13 +204,9 @@ class Evaluator:
         fp_languages = {fp.filename: fp.language for fp in overall_predictions.predictions_list}
         languages = set(fp_languages.values())
 
-        overall_groundwater_metrics = OverallGroundwaterMetrics()
         overall_metadata_metrics = OverallBoreholeMetadataMetrics()
-
         overall_geology_metrics = OverallMetricsCatalog(languages=languages)
-        overall_layer_metrics = OverallMetrics()
-        overall_depth_interval_metrics = OverallMetrics()
-        overall_material_description_metrics = OverallMetrics()
+        overall_groundwater_metrics = OverallGroundwaterMetrics()
 
         # Iterate over all the files
         for file_predictions in overall_predictions.predictions_list:
@@ -219,17 +215,18 @@ class Evaluator:
                 Evaluator.evaluate(file_predictions)
             )
 
+            # Assigne geology metric for layer, depth and material
+            overall_geology_metrics.layer_metrics.metrics[file_predictions.filename] = layer_metrics
+            overall_geology_metrics.depth_interval_metrics[file_predictions.filename] = depth_interval_metrics
+            overall_geology_metrics.material_description_metrics[file_predictions.filename] = (
+                material_description_metrics
+            )
+
             # Assign values to overall predictions
-            overall_layer_metrics.metrics[file_predictions.filename] = layer_metrics
-            overall_depth_interval_metrics.metrics[file_predictions.filename] = depth_interval_metrics
-            overall_material_description_metrics.metrics[file_predictions.filename] = material_description_metrics
             overall_groundwater_metrics.add_groundwater_metrics(gw_metrics)
             overall_metadata_metrics.add_metadata_metrics(metadata_metrics)
 
         # Set metrics for geology
-        overall_geology_metrics.layer_metrics = overall_layer_metrics
-        overall_geology_metrics.depth_interval_metrics = overall_depth_interval_metrics
-        overall_geology_metrics.material_description_metrics = overall_material_description_metrics
         overall_geology_metrics.groundwater_metrics = (
             overall_groundwater_metrics.groundwater_metrics_to_overall_metrics()
         )
@@ -237,23 +234,24 @@ class Evaluator:
             overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
         )
 
+        # Set metrics for each language
         for language in languages:
             setattr(
                 overall_geology_metrics,
                 f"{language}_layer_metrics",
-                overall_layer_metrics.get_language_subset(fp_languages, language),
+                overall_geology_metrics.layer_metrics.get_language_subset(fp_languages, language),
             )
 
             setattr(
                 overall_geology_metrics,
                 f"{language}_depth_interval_metrics",
-                overall_depth_interval_metrics.get_language_subset(fp_languages, language),
+                overall_geology_metrics.depth_interval_metrics.get_language_subset(fp_languages, language),
             )
 
             setattr(
                 overall_geology_metrics,
                 f"{language}_material_description_metrics",
-                overall_material_description_metrics.get_language_subset(fp_languages, language),
+                overall_geology_metrics.material_description_metrics.get_language_subset(fp_languages, language),
             )
 
         return overall_geology_metrics, overall_metadata_metrics

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -3,17 +3,14 @@
 import logging
 
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
-from extraction.evaluation.benchmark.metrics import OverallMetricsCatalog
 from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics, OverallBoreholeMetadataMetrics
-from extraction.evaluation.groundwater_evaluator import GroundwaterEvaluator
+from extraction.evaluation.groundwater_evaluator import GroundwaterEvaluator, OverallGroundwaterMetrics
 from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.evaluation.metadata_evaluator import MetadataEvaluator
 from extraction.features.predictions.borehole_predictions import (
     BoreholeGroundwaterWithGroundTruth,
-    BoreholeLayersWithGroundTruth,
     BoreholeMetadataWithGroundTruth,
     FileGroundwaterWithGroundTruth,
-    FileLayersWithGroundTruth,
     FileMetadataWithGroundTruth,
     FilePredictionsWithGroundTruth,
 )
@@ -45,120 +42,20 @@ class Evaluator:
         boreholes = []
         ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
         if ground_truth_for_file:
-            boreholes = LayerEvaluator.match_predictions_with_ground_truth(file_predictions, ground_truth_for_file)
+            boreholes = LayerEvaluator.match_boreholes_to_ground_truth(file_predictions, ground_truth_for_file)
         return FilePredictionsWithGroundTruth(
             file_predictions.file_name, file_predictions.file_metadata.language, boreholes
         )
 
     @staticmethod
-    def match_overall_with_ground_truth(
-        overall_predictions: OverallFilePredictions, ground_truth: GroundTruth
-    ) -> AllBoreholePredictionsWithGroundTruth:
-        """Match all file predictions across multiple files with their corresponding ground truth data.
-
-        Iterates over each file in overall_predictions and delegates per-file matching to
-        LayerEvaluator. Files with no matching ground truth entry are included with an empty
-        borehole list.
-
-        Args:
-            overall_predictions (OverallFilePredictions): Predictions for all processed files.
-            ground_truth (GroundTruth): The ground truth dataset to match against.
-
-        Returns:
-            AllBoreholePredictionsWithGroundTruth: Predictions for every file, each paired with
-                its corresponding ground truth boreholes.
-        """
-        files = []
-        for file_predictions in overall_predictions.file_predictions_list:
-            boreholes = []
-            ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
-            if ground_truth_for_file:
-                boreholes = LayerEvaluator.match_predictions_with_ground_truth(file_predictions, ground_truth_for_file)
-            files.append(
-                FilePredictionsWithGroundTruth(
-                    file_predictions.file_name, file_predictions.file_metadata.language, boreholes
-                )
-            )
-        return AllBoreholePredictionsWithGroundTruth(files)
+    def evaluate(file_predictions: FilePredictionsWithGroundTruth) -> tuple[BoreholeMetadataMetrics]:
+        Evaluator.evaluate_layers(file_predictions)
+        Evaluator.evaluate_metadata(file_predictions)
+        Evaluator.evaluate_gw(file_predictions)
 
     @staticmethod
-    def evaluate_geology(file_predictions: FilePredictionsWithGroundTruth):
-        pass
-
-    @staticmethod
-    def evaluate_overall_geology(overall_predictions: AllBoreholePredictionsWithGroundTruth) -> OverallMetricsCatalog:
-        """Evaluate the borehole extraction predictions.
-
-        Args:
-            overall_predictions (AllBoreholePredictionsWithGroundTruth): metrics for the current evaluation.
-
-        Returns:
-            OverallMetricsCatalog: A OverallMetricsCatalog that maps a metrics name to the corresponding
-            OverallMetrics object. If no ground truth is available, None is returned.
-        """
-        languages = set(fp.language for fp in overall_predictions.predictions_list)
-        all_metrics = OverallMetricsCatalog(languages=languages)
-
-        layers_list = [
-            FileLayersWithGroundTruth(
-                file.filename,
-                file.language,
-                [
-                    BoreholeLayersWithGroundTruth(
-                        predictions.predictions.layers_in_borehole if predictions.predictions else None,
-                        predictions.ground_truth.get("layers", []),
-                    )
-                    for predictions in file.boreholes
-                ],
-            )
-            for file in overall_predictions.predictions_list
-        ]
-        evaluator = LayerEvaluator(layers_list)
-        all_metrics.material_description_metrics = evaluator.get_material_description_metrics()
-        all_metrics.depth_interval_metrics = evaluator.get_depth_interval_metrics()
-        all_metrics.layer_metrics = evaluator.get_layer_metrics()
-
-        predictions_by_language = {language: [] for language in languages}
-        for borehole_data in layers_list:
-            # even if metadata can be different for boreholes in the same document, langage is the same (take index 0)
-            predictions_by_language[borehole_data.language].append(borehole_data)
-
-        for language, language_predictions_list in predictions_by_language.items():
-            evaluator = LayerEvaluator(language_predictions_list)
-            setattr(all_metrics, f"{language}_layer_metrics", evaluator.get_layer_metrics())
-            setattr(all_metrics, f"{language}_depth_interval_metrics", evaluator.get_depth_interval_metrics())
-            setattr(
-                all_metrics, f"{language}_material_description_metrics", evaluator.get_material_description_metrics()
-            )
-
-        logger.info("Macro avg:")
-        logger.info(
-            "layer f1: %.1f%%, depth interval f1: %.1f%%, material description f1: %.1f%%",
-            all_metrics.layer_metrics.macro_f1() * 100,
-            all_metrics.depth_interval_metrics.macro_f1() * 100,
-            all_metrics.material_description_metrics.macro_f1() * 100,
-        )
-
-        # TODO groundwater should not be in evaluate_geology(), it should be handle by a higher-level function call
-        groundwater_list = [
-            FileGroundwaterWithGroundTruth(
-                file.filename,
-                [
-                    BoreholeGroundwaterWithGroundTruth(
-                        predictions.predictions.groundwater_in_borehole if predictions.predictions else None,
-                        predictions.ground_truth.get("groundwater", []) or [],  # value can be `None`
-                    )
-                    for predictions in file.boreholes
-                ],
-            )
-            for file in overall_predictions.predictions_list
-        ]
-        overall_groundwater_metrics = GroundwaterEvaluator(groundwater_list).evaluate()
-        all_metrics.groundwater_metrics = overall_groundwater_metrics.groundwater_metrics_to_overall_metrics()
-        all_metrics.groundwater_depth_metrics = (
-            overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
-        )
-        return all_metrics
+    def evaluate_layers(file_predictions: FilePredictionsWithGroundTruth) -> None:
+        LayerEvaluator.evaluate(file_predictions)
 
     @staticmethod
     def evaluate_metadata(
@@ -187,6 +84,134 @@ class Evaluator:
         return MetadataEvaluator.evaluate(file_metadata_gt)
 
     @staticmethod
+    def evaluate_gw(file_predictions: FilePredictionsWithGroundTruth) -> OverallGroundwaterMetrics:
+        groundwater = FileGroundwaterWithGroundTruth(
+            file_predictions.filename,
+            [
+                BoreholeGroundwaterWithGroundTruth(
+                    predictions.predictions.groundwater_in_borehole if predictions.predictions else None,
+                    predictions.ground_truth.get("groundwater", []) or [],  # value can be `None`
+                )
+                for predictions in file_predictions.boreholes
+            ],
+        )
+
+        return GroundwaterEvaluator.evaluate(groundwater)
+
+    @staticmethod
+    def match_overall_with_ground_truth(
+        overall_predictions: OverallFilePredictions, ground_truth: GroundTruth
+    ) -> AllBoreholePredictionsWithGroundTruth:
+        """Match all file predictions across multiple files with their corresponding ground truth data.
+
+        Iterates over each file in overall_predictions and delegates per-file matching to
+        LayerEvaluator. Files with no matching ground truth entry are included with an empty
+        borehole list.
+
+        Args:
+            overall_predictions (OverallFilePredictions): Predictions for all processed files.
+            ground_truth (GroundTruth): The ground truth dataset to match against.
+
+        Returns:
+            AllBoreholePredictionsWithGroundTruth: Predictions for every file, each paired with
+                its corresponding ground truth boreholes.
+        """
+        return AllBoreholePredictionsWithGroundTruth(
+            [
+                Evaluator.match_with_ground_truth(file_predictions=file, ground_truth=ground_truth)
+                for file in overall_predictions.file_predictions_list
+            ]
+        )
+
+    @staticmethod
+    def evaluate_overall(overall_predictions: AllBoreholePredictionsWithGroundTruth) -> tuple[BoreholeMetadataMetrics]:
+        Evaluator.evaluate_overall_layer(overall_predictions)
+        metadata_metrics_list = Evaluator.evaluate_overall_metadata(overall_predictions)
+        Evaluator.evaluate_overall_gw(overall_predictions)
+        return metadata_metrics_list
+
+    @staticmethod
+    def evaluate_overall_layer(overall_predictions: AllBoreholePredictionsWithGroundTruth):
+        for file_predictions in overall_predictions.predictions_list:
+            LayerEvaluator.evaluate(file_predictions)
+
+    # @staticmethod
+    # def evaluate_overall_geology(overall_predictions: AllBoreholePredictionsWithGroundTruth) ->OverallMetricsCatalog:
+    #     """Evaluate the borehole extraction predictions.
+
+    #     Args:
+    #         overall_predictions (AllBoreholePredictionsWithGroundTruth): metrics for the current evaluation.
+
+    #     Returns:
+    #         OverallMetricsCatalog: A OverallMetricsCatalog that maps a metrics name to the corresponding
+    #         OverallMetrics object. If no ground truth is available, None is returned.
+    #     """
+    #     languages = set(fp.language for fp in overall_predictions.predictions_list)
+    #     all_metrics = OverallMetricsCatalog(languages=languages)
+
+    #     layers_list = [
+    #         FileLayersWithGroundTruth(
+    #             file.filename,
+    #             file.language,
+    #             [
+    #                 BoreholeLayersWithGroundTruth(
+    #                     predictions.predictions.layers_in_borehole if predictions.predictions else None,
+    #                     predictions.ground_truth.get("layers", []),
+    #                 )
+    #                 for predictions in file.boreholes
+    #             ],
+    #         )
+    #         for file in overall_predictions.predictions_list
+    #     ]
+    #     evaluator = LayerEvaluator(layers_list)
+    #     all_metrics.material_description_metrics = evaluator.get_material_description_metrics()
+    #     all_metrics.depth_interval_metrics = evaluator.get_depth_interval_metrics()
+    #     all_metrics.layer_metrics = evaluator.get_layer_metrics()
+
+    #     predictions_by_language = {language: [] for language in languages}
+    #     for borehole_data in layers_list:
+    #         # even if metadata can be different for boreholes in the same document,
+    #         # langage is the same (take index 0)
+    #         predictions_by_language[borehole_data.language].append(borehole_data)
+
+    #     for language, language_predictions_list in predictions_by_language.items():
+    #         evaluator = LayerEvaluator(language_predictions_list)
+    #         setattr(all_metrics, f"{language}_layer_metrics", evaluator.get_layer_metrics())
+    #         setattr(all_metrics, f"{language}_depth_interval_metrics", evaluator.get_depth_interval_metrics())
+    #         setattr(
+    #             all_metrics, f"{language}_material_description_metrics", evaluator.get_material_description_metrics()
+    #         )
+
+    #     logger.info("Macro avg:")
+    #     logger.info(
+    #         "layer f1: %.1f%%, depth interval f1: %.1f%%, material description f1: %.1f%%",
+    #         all_metrics.layer_metrics.macro_f1() * 100,
+    #         all_metrics.depth_interval_metrics.macro_f1() * 100,
+    #         all_metrics.material_description_metrics.macro_f1() * 100,
+    #     )
+
+    #     # TODO groundwater should not be in evaluate_geology(), it should be handle by a higher-level function call
+    #     groundwater_list = [
+    #         FileGroundwaterWithGroundTruth(
+    #             file.filename,
+    #             [
+    #                 BoreholeGroundwaterWithGroundTruth(
+    #                     predictions.predictions.groundwater_in_borehole if predictions.predictions else None,
+    #                     predictions.ground_truth.get("groundwater", []) or [],  # value can be `None`
+    #                 )
+    #                 for predictions in file.boreholes
+    #             ],
+    #         )
+    #         for file in overall_predictions.predictions_list
+    #     ]
+    #     overall_groundwater_metrics = GroundwaterEvaluator(groundwater_list).evaluate()
+    #     all_metrics.groundwater_metrics = overall_groundwater_metrics.groundwater_metrics_to_overall_metrics()
+    #     all_metrics.groundwater_depth_metrics = (
+    #         overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
+    #     )
+    #     return all_metrics
+
+    @staticmethod
     def evaluate_overall_metadata(
         overall_predictions: AllBoreholePredictionsWithGroundTruth,
     ) -> OverallBoreholeMetadataMetrics:
@@ -206,4 +231,10 @@ class Evaluator:
                 Evaluator.evaluate_metadata(file_metadata_gt)
                 for file_metadata_gt in overall_predictions.predictions_list
             ]
+        )
+
+    @staticmethod
+    def evaluate_overall_gw(overall_predictions: AllBoreholePredictionsWithGroundTruth) -> OverallGroundwaterMetrics:
+        return OverallGroundwaterMetrics(
+            [Evaluator.evaluate_gw(file_predictions) for file_predictions in overall_predictions.predictions_list]
         )

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -217,8 +217,8 @@ class Evaluator:
 
             # Assigne geology metric for layer, depth and material
             overall_geology_metrics.layer_metrics.metrics[file_predictions.filename] = layer_metrics
-            overall_geology_metrics.depth_interval_metrics[file_predictions.filename] = depth_interval_metrics
-            overall_geology_metrics.material_description_metrics[file_predictions.filename] = (
+            overall_geology_metrics.depth_interval_metrics.metrics[file_predictions.filename] = depth_interval_metrics
+            overall_geology_metrics.material_description_metrics.metrics[file_predictions.filename] = (
                 material_description_metrics
             )
 

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -170,10 +170,8 @@ class Evaluator:
                 paired with their ground truth boreholes.
 
         Returns:
-            tuple[OverallMetricsCatalog]:
-                - OverallMetricsCatalog: aggregated geology metrics (layers, depth intervals,
-                  material descriptions, groundwater) globally and per language.
-                - OverallBoreholeMetadataMetrics: aggregated metadata metrics across all files.
+            OverallMetricsCatalog: Aggregated geology and metadata metrics (layers, depth intervals,
+                material descriptions, groundwater) globally and per language.
         """
         fp_languages = {fp.filename: fp.language for fp in overall_predictions.file_predictions_list}
         languages = set(fp_languages.values())

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -6,7 +6,11 @@ from core.benchmark_utils import Metrics
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
 from extraction.evaluation.benchmark.metrics import OverallMetrics, OverallMetricsCatalog
 from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics, OverallBoreholeMetadataMetrics
-from extraction.evaluation.groundwater_evaluator import GroundwaterEvaluator, OverallGroundwaterMetrics
+from extraction.evaluation.groundwater_evaluator import (
+    GroundwaterEvaluator,
+    GroundwaterMetrics,
+    OverallGroundwaterMetrics,
+)
 from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.evaluation.metadata_evaluator import MetadataEvaluator
 from extraction.features.predictions.borehole_predictions import (
@@ -41,7 +45,7 @@ class Evaluator:
             ground_truth (GroundTruth): The ground truth.
 
         Returns:
-            AllBoreholePredictionsWithGroundTruth: all predictions per borehole with associated ground truth data.
+            FilePredictionsWithGroundTruth: all predictions per borehole with associated ground truth data.
         """
         boreholes = []
         ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
@@ -53,12 +57,27 @@ class Evaluator:
 
     @staticmethod
     def evaluate(file_predictions: FilePredictionsWithGroundTruth) -> tuple[BoreholeMetadataMetrics]:
+        """Evaluate layers, metadata, and groundwater for a single file prediction (mutates prediction flags).
+
+        Args:
+            file_predictions (FilePredictionsWithGroundTruth): Per-file borehole predictions
+                paired with their ground truth data.
+        """
         Evaluator.evaluate_layers(file_predictions)
         Evaluator.evaluate_metadata(file_predictions)
         Evaluator.evaluate_gw(file_predictions)
 
     @staticmethod
-    def evaluate_layers(file_predictions: FilePredictionsWithGroundTruth) -> None:
+    def evaluate_layers(file_predictions: FilePredictionsWithGroundTruth) -> tuple[Metrics, Metrics, Metrics]:
+        """Evaluate layer, depth-interval, and material-description metrics for a single file.
+
+        Args:
+            file_predictions (FilePredictionsWithGroundTruth): Per-file borehole predictions
+                paired with their ground truth data.
+
+        Returns:
+            tuple[Metrics, Metrics, Metrics]: (layer_metrics, depth_interval_metrics, material_description_metrics)
+        """
         return LayerEvaluator.evaluate(
             file_predictions=FileLayersWithGroundTruth(
                 file_predictions.filename,
@@ -100,7 +119,16 @@ class Evaluator:
         )
 
     @staticmethod
-    def evaluate_gw(file_predictions: FilePredictionsWithGroundTruth) -> OverallGroundwaterMetrics:
+    def evaluate_gw(file_predictions: FilePredictionsWithGroundTruth) -> GroundwaterMetrics:
+        """Evaluate groundwater metrics for a single file prediction.
+
+        Args:
+            file_predictions (FilePredictionsWithGroundTruth): Per-file borehole predictions
+                paired with their ground truth data.
+
+        Returns:
+            GroundwaterMetrics: The computed groundwater metrics for the file.
+        """
         return GroundwaterEvaluator.evaluate(
             file_predictions=FileGroundwaterWithGroundTruth(
                 file_predictions.filename,
@@ -143,6 +171,18 @@ class Evaluator:
     def evaluate_overall(
         overall_predictions: AllBoreholePredictionsWithGroundTruth,
     ) -> tuple[OverallMetricsCatalog, OverallBoreholeMetadataMetrics]:
+        """Evaluate all files and aggregate geology and metadata metrics.
+
+        Args:
+            overall_predictions (AllBoreholePredictionsWithGroundTruth): All per-file predictions
+                paired with their ground truth boreholes.
+
+        Returns:
+            tuple[OverallMetricsCatalog, OverallBoreholeMetadataMetrics]:
+                - OverallMetricsCatalog: aggregated geology metrics (layers, depth intervals,
+                  material descriptions, groundwater) globally and per language.
+                - OverallBoreholeMetadataMetrics: aggregated metadata metrics across all files.
+        """
         fp_languages = {fp.filename: fp.language for fp in overall_predictions.predictions_list}
         languages = set(fp_languages.values())
 

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -38,7 +38,7 @@ class Evaluator:
     ) -> FilePredictionsWithGroundTruth:
         """Match the extracted boreholes with corresponding boreholes in the ground truth data.
 
-        This is done by comparing the layers of the extracted boreholes with those in the groundtruth.
+        This is done by comparing the layers of the extracted boreholes with those in the ground truth.
 
         Args:
             file_predictions (FilePredictions): File predictions.
@@ -212,14 +212,14 @@ class Evaluator:
         overall_depth_interval_metrics = OverallMetrics()
         overall_material_description_metrics = OverallMetrics()
 
-        # iteration over all the file
+        # Iterate over all the file
         for file_predictions in overall_predictions.predictions_list:
             # Evaluate file
             layer_metrics, depth_interval_metrics, material_description_metrics, gw_metrics, metadata_metrics = (
                 Evaluator.evaluate(file_predictions)
             )
 
-            # Affect values to overall predictions
+            # Assign values to overall predictions
             overall_layer_metrics.metrics[file_predictions.filename] = layer_metrics
             overall_depth_interval_metrics.metrics[file_predictions.filename] = depth_interval_metrics
             overall_material_description_metrics.metrics[file_predictions.filename] = material_description_metrics

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -5,7 +5,7 @@ import logging
 from core.benchmark_utils import Metrics
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
 from extraction.evaluation.benchmark.metrics import OverallMetricsCatalog
-from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics, OverallBoreholeMetadataMetrics
+from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics
 from extraction.evaluation.groundwater_evaluator import (
     GroundwaterEvaluator,
     GroundwaterMetrics,
@@ -24,7 +24,6 @@ from extraction.features.predictions.borehole_predictions import (
 )
 from extraction.features.predictions.file_predictions import FilePredictions
 from extraction.features.predictions.overall_file_predictions import OverallFilePredictions
-from extraction.features.predictions.predictions import AllBoreholePredictionsWithGroundTruth
 
 logger = logging.getLogger(__name__)
 
@@ -161,97 +160,68 @@ class Evaluator:
         )
 
     @staticmethod
-    def match_overall_with_ground_truth(
-        overall_predictions: OverallFilePredictions, ground_truth: GroundTruth
-    ) -> AllBoreholePredictionsWithGroundTruth:
-        """Match all file predictions across multiple files with their corresponding ground truth data.
-
-        Iterates over each file in overall_predictions and delegates per-file matching to
-        LayerEvaluator. Files with no matching ground truth entry are included with an empty
-        borehole list.
+    def aggregate(
+        overall_predictions: OverallFilePredictions,
+    ) -> OverallMetricsCatalog:
+        """Aggregate all files prediction for geology and metadata metrics.
 
         Args:
-            overall_predictions (OverallFilePredictions): Predictions for all processed files.
-            ground_truth (GroundTruth): The ground truth dataset to match against.
-
-        Returns:
-            AllBoreholePredictionsWithGroundTruth: Predictions for every file, each paired with
-                its corresponding ground truth boreholes.
-        """
-        return AllBoreholePredictionsWithGroundTruth(
-            [
-                Evaluator.match_with_ground_truth(file_predictions=file, ground_truth=ground_truth)
-                for file in overall_predictions.file_predictions_list
-            ]
-        )
-
-    @staticmethod
-    def evaluate_overall(
-        overall_predictions: AllBoreholePredictionsWithGroundTruth,
-    ) -> tuple[OverallMetricsCatalog, OverallBoreholeMetadataMetrics]:
-        """Evaluate all files and aggregate geology and metadata metrics.
-
-        Args:
-            overall_predictions (AllBoreholePredictionsWithGroundTruth): All per-file predictions
+            overall_predictions (OverallFilePredictions): All per-file predictions
                 paired with their ground truth boreholes.
 
         Returns:
-            tuple[OverallMetricsCatalog, OverallBoreholeMetadataMetrics]:
+            tuple[OverallMetricsCatalog]:
                 - OverallMetricsCatalog: aggregated geology metrics (layers, depth intervals,
                   material descriptions, groundwater) globally and per language.
                 - OverallBoreholeMetadataMetrics: aggregated metadata metrics across all files.
         """
-        fp_languages = {fp.filename: fp.language for fp in overall_predictions.predictions_list}
+        fp_languages = {fp.filename: fp.language for fp in overall_predictions.file_predictions_list}
         languages = set(fp_languages.values())
 
-        overall_metadata_metrics = OverallBoreholeMetadataMetrics()
-        overall_geology_metrics = OverallMetricsCatalog(languages=languages)
+        overall_metrics_catalog = OverallMetricsCatalog(languages=languages)
         overall_groundwater_metrics = OverallGroundwaterMetrics()
 
         # Iterate over all the files
-        for file_predictions in overall_predictions.predictions_list:
-            # Evaluate file
-            layer_metrics, depth_interval_metrics, material_description_metrics, gw_metrics, metadata_metrics = (
-                Evaluator.evaluate(file_predictions)
-            )
-
-            # Assign geology metric for layer, depth and material
-            overall_geology_metrics.layer_metrics.metrics[file_predictions.filename] = layer_metrics
-            overall_geology_metrics.depth_interval_metrics.metrics[file_predictions.filename] = depth_interval_metrics
-            overall_geology_metrics.material_description_metrics.metrics[file_predictions.filename] = (
-                material_description_metrics
+        for predictions in overall_predictions.file_predictions_list:
+            overall_metrics_catalog.add_datapoint(
+                filename=predictions.filename,
+                material_description_metric=predictions.metrics.material_description_metrics,
+                layer_metrics=predictions.metrics.layer_metrics,
+                depth_interval_metric=predictions.metrics.depth_interval_metrics,
+                elevation_metric=predictions.metrics.metadata_metrics.elevation_metrics,
+                coordinates_metric=predictions.metrics.metadata_metrics.coordinates_metrics,
+                name_metric=predictions.metrics.metadata_metrics.name_metrics,
             )
 
             # Assign values to overall predictions
-            overall_groundwater_metrics.add_groundwater_metrics(gw_metrics)
-            overall_metadata_metrics.add_metadata_metrics(metadata_metrics)
+            overall_groundwater_metrics.add_groundwater_metrics(predictions.metrics.gw_metrics)
 
         # Set metrics for geology
-        overall_geology_metrics.groundwater_metrics = (
+        overall_metrics_catalog.groundwater_metrics = (
             overall_groundwater_metrics.groundwater_metrics_to_overall_metrics()
         )
-        overall_geology_metrics.groundwater_depth_metrics = (
+        overall_metrics_catalog.groundwater_depth_metrics = (
             overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
         )
 
         # Language subsets for geology
         for language in languages:
             setattr(
-                overall_geology_metrics,
+                overall_metrics_catalog,
                 f"{language}_layer_metrics",
-                overall_geology_metrics.layer_metrics.get_language_subset(fp_languages, language),
+                overall_metrics_catalog.layer_metrics.get_language_subset(fp_languages, language),
             )
 
             setattr(
-                overall_geology_metrics,
+                overall_metrics_catalog,
                 f"{language}_depth_interval_metrics",
-                overall_geology_metrics.depth_interval_metrics.get_language_subset(fp_languages, language),
+                overall_metrics_catalog.depth_interval_metrics.get_language_subset(fp_languages, language),
             )
 
             setattr(
-                overall_geology_metrics,
+                overall_metrics_catalog,
                 f"{language}_material_description_metrics",
-                overall_geology_metrics.material_description_metrics.get_language_subset(fp_languages, language),
+                overall_metrics_catalog.material_description_metrics.get_language_subset(fp_languages, language),
             )
 
-        return overall_geology_metrics, overall_metadata_metrics
+        return overall_metrics_catalog

--- a/src/extraction/evaluation/evaluator.py
+++ b/src/extraction/evaluation/evaluator.py
@@ -215,7 +215,7 @@ class Evaluator:
                 Evaluator.evaluate(file_predictions)
             )
 
-            # Assigne geology metric for layer, depth and material
+            # Assign geology metric for layer, depth and material
             overall_geology_metrics.layer_metrics.metrics[file_predictions.filename] = layer_metrics
             overall_geology_metrics.depth_interval_metrics.metrics[file_predictions.filename] = depth_interval_metrics
             overall_geology_metrics.material_description_metrics.metrics[file_predictions.filename] = (
@@ -234,7 +234,7 @@ class Evaluator:
             overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
         )
 
-        # Set metrics for each language
+        # Language subsets for geology
         for language in languages:
             setattr(
                 overall_geology_metrics,

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -13,11 +13,11 @@ from extraction.features.predictions.borehole_predictions import FileGroundwater
 class GroundwaterMetrics:
     """Class for storing the metrics of the groundwater information."""
 
-    groundwater_metrics: Metrics = None
-    groundwater_depth_metrics: Metrics = None
-    groundwater_elevation_metrics: Metrics = None
-    groundwater_date_metrics: Metrics = None
-    filename: str = None
+    filename: str
+    groundwater_metrics: Metrics = Metrics()
+    groundwater_depth_metrics: Metrics = Metrics()
+    groundwater_elevation_metrics: Metrics = Metrics()
+    groundwater_date_metrics: Metrics = Metrics()
 
     def to_json(self) -> dict:
         """Converts the object to a dictionary.
@@ -45,11 +45,11 @@ class GroundwaterMetrics:
             GroundwaterMetrics: The reconstructed groundwater metrics object.
         """
         return GroundwaterMetrics(
+            filename=filename,
             groundwater_metrics=Metrics.from_json(json["metrics"]),
             groundwater_depth_metrics=Metrics.from_json(json["depth_metrics"]),
             groundwater_elevation_metrics=Metrics.from_json(json["elevation_metrics"]),
             groundwater_date_metrics=Metrics.from_json(json["date_metrics"]),
-            filename=filename,
         )
 
 

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -1,6 +1,6 @@
 """Classes for evaluating the groundwater levels of a borehole."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from core.benchmark_utils import Metrics
 from extraction.evaluation.benchmark.metrics import OverallMetrics
@@ -24,7 +24,7 @@ class GroundwaterMetrics:
 class OverallGroundwaterMetrics:
     """Class for storing the overall metrics of the groundwater information."""
 
-    groundwater_metrics: list[GroundwaterMetrics]
+    groundwater_metrics: list[GroundwaterMetrics] = field(default_factory=list)
 
     def add_groundwater_metrics(self, groundwater_metrics: GroundwaterMetrics):
         """Add groundwater metrics to the list.

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -19,7 +19,13 @@ class GroundwaterMetrics:
     groundwater_date_metrics: Metrics = None
     filename: str = None
 
-    def to_json(self) -> dict[str, float]:
+    def to_json(self) -> dict:
+        """Converts the object to a dictionary.
+
+        Returns:
+            dict: The object as a dictionary, with source filename, nested metric sub-dictionaries
+                for depth, elevation, and date.
+        """
         return {
             "metrics": self.groundwater_metrics.to_json(),
             "depth_metrics": self.groundwater_depth_metrics.to_json(),
@@ -29,8 +35,15 @@ class GroundwaterMetrics:
         }
 
     @classmethod
-    def from_json(cls, json: dict) -> Metrics:
-        """TODO."""
+    def from_json(cls, json: dict) -> "GroundwaterMetrics":
+        """Construct a GroundwaterMetrics instance from a dictionary produced by `to_json`.
+
+        Args:
+            json (dict): Dictionary with groundwater metrics.
+
+        Returns:
+            GroundwaterMetrics: The reconstructed groundwater metrics object.
+        """
         return GroundwaterMetrics(
             groundwater_metrics=Metrics.from_json(json["metrics"]),
             groundwater_depth_metrics=Metrics.from_json(json["depth_metrics"]),

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -1,9 +1,8 @@
 """Classes for evaluating the groundwater levels of a borehole."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from core.benchmark_utils import Metrics
-from extraction.evaluation.benchmark.metrics import OverallMetrics
 from extraction.evaluation.utility import evaluate
 from extraction.features.groundwater.groundwater_extraction import Groundwater
 from extraction.features.predictions.borehole_predictions import FileGroundwaterWithGroundTruth
@@ -51,43 +50,6 @@ class GroundwaterMetrics:
             groundwater_elevation_metrics=Metrics.from_json(json["elevation_metrics"]),
             groundwater_date_metrics=Metrics.from_json(json["date_metrics"]),
         )
-
-
-@dataclass
-class OverallGroundwaterMetrics:
-    """Class for storing the overall metrics of the groundwater information."""
-
-    groundwater_metrics: list[GroundwaterMetrics] = field(default_factory=list)
-
-    def add_groundwater_metrics(self, groundwater_metrics: GroundwaterMetrics) -> None:
-        """Add groundwater metrics to the list.
-
-        Args:
-            groundwater_metrics (GroundwaterMetrics): The groundwater metrics to add.
-        """
-        self.groundwater_metrics.append(groundwater_metrics)
-
-    def groundwater_metrics_to_overall_metrics(self) -> OverallMetrics:
-        """Convert the per-file groundwater metrics to an OverallMetrics object.
-
-        Returns:
-            OverallMetrics: Mapping of filename → groundwater Metrics for all collected files.
-        """
-        overall_metrics = OverallMetrics()
-        for groundwater_metrics in self.groundwater_metrics:
-            overall_metrics.metrics[groundwater_metrics.filename] = groundwater_metrics.groundwater_metrics
-        return overall_metrics
-
-    def groundwater_depth_metrics_to_overall_metrics(self) -> OverallMetrics:
-        """Convert the per-file groundwater depth metrics to an OverallMetrics object.
-
-        Returns:
-            OverallMetrics: Mapping of filename → groundwater depth Metrics for all collected files.
-        """
-        overall_metrics = OverallMetrics()
-        for groundwater_metrics in self.groundwater_metrics:
-            overall_metrics.metrics[groundwater_metrics.filename] = groundwater_metrics.groundwater_depth_metrics
-        return overall_metrics
 
 
 class GroundwaterEvaluator:

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -31,15 +31,15 @@ class GroundwaterMetrics:
             "depth_metrics": self.groundwater_depth_metrics.to_json(),
             "elevation_metrics": self.groundwater_elevation_metrics.to_json(),
             "date_metrics": self.groundwater_date_metrics.to_json(),
-            "filename": self.filename,
         }
 
     @classmethod
-    def from_json(cls, json: dict) -> "GroundwaterMetrics":
+    def from_json(cls, json: dict, filename: str) -> "GroundwaterMetrics":
         """Construct a GroundwaterMetrics instance from a dictionary produced by `to_json`.
 
         Args:
             json (dict): Dictionary with groundwater metrics.
+            filename: (str): Linked filename.
 
         Returns:
             GroundwaterMetrics: The reconstructed groundwater metrics object.
@@ -49,7 +49,7 @@ class GroundwaterMetrics:
             groundwater_depth_metrics=Metrics.from_json(json["depth_metrics"]),
             groundwater_elevation_metrics=Metrics.from_json(json["elevation_metrics"]),
             groundwater_date_metrics=Metrics.from_json(json["date_metrics"]),
-            filename=json["filename"],
+            filename=filename,
         )
 
 

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -26,7 +26,7 @@ class OverallGroundwaterMetrics:
 
     groundwater_metrics: list[GroundwaterMetrics] = field(default_factory=list)
 
-    def add_groundwater_metrics(self, groundwater_metrics: GroundwaterMetrics):
+    def add_groundwater_metrics(self, groundwater_metrics: GroundwaterMetrics) -> None:
         """Add groundwater metrics to the list.
 
         Args:
@@ -34,15 +34,23 @@ class OverallGroundwaterMetrics:
         """
         self.groundwater_metrics.append(groundwater_metrics)
 
-    def groundwater_metrics_to_overall_metrics(self):
-        """Convert the overall groundwater metrics to an OverallMetrics object."""
+    def groundwater_metrics_to_overall_metrics(self) -> OverallMetrics:
+        """Convert the per-file groundwater metrics to an OverallMetrics object.
+
+        Returns:
+            OverallMetrics: Mapping of filename → groundwater Metrics for all collected files.
+        """
         overall_metrics = OverallMetrics()
         for groundwater_metrics in self.groundwater_metrics:
             overall_metrics.metrics[groundwater_metrics.filename] = groundwater_metrics.groundwater_metrics
         return overall_metrics
 
-    def groundwater_depth_metrics_to_overall_metrics(self):
-        """Convert the overall groundwater depth metrics to an OverallMetrics object."""
+    def groundwater_depth_metrics_to_overall_metrics(self) -> OverallMetrics:
+        """Convert the per-file groundwater depth metrics to an OverallMetrics object.
+
+        Returns:
+            OverallMetrics: Mapping of filename → groundwater depth Metrics for all collected files.
+        """
         overall_metrics = OverallMetrics()
         for groundwater_metrics in self.groundwater_metrics:
             overall_metrics.metrics[groundwater_metrics.filename] = groundwater_metrics.groundwater_depth_metrics

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -20,11 +20,11 @@ class GroundwaterMetrics:
     filename: str = None
 
 
+@dataclass
 class OverallGroundwaterMetrics:
     """Class for storing the overall metrics of the groundwater information."""
 
-    def __init__(self):
-        self.groundwater_metrics: list[GroundwaterMetrics] = []
+    groundwater_metrics: list[GroundwaterMetrics]
 
     def add_groundwater_metrics(self, groundwater_metrics: GroundwaterMetrics):
         """Add groundwater metrics to the list.
@@ -52,80 +52,66 @@ class OverallGroundwaterMetrics:
 class GroundwaterEvaluator:
     """Class for evaluating the extracted groundwater information of a borehole."""
 
-    def __init__(
-        self,
-        groundwater_list: list[FileGroundwaterWithGroundTruth],
-    ):
-        """Initializes the GroundwaterEvaluator object.
-
-        Args:
-            groundwater_list (list[FileGroundwaterWithGroundTruth]): A list of extracted groundwater data per
-                borehole, together with the ground truth data associated to it.
-        """
-        self.groundwater_list = groundwater_list
-
-    def evaluate(self) -> OverallGroundwaterMetrics:
+    @staticmethod
+    def evaluate(groundwater: FileGroundwaterWithGroundTruth) -> GroundwaterMetrics:
         """Evaluate the groundwater information of the file against the ground truth.
 
         Returns:
             OverallGroundwaterMetrics: The overall groundwater metrics.
         """
-        overall_groundwater_metrics = OverallGroundwaterMetrics()
+        # lists to contain the metrics
+        groundwater_metrics_list = []
+        groundwater_depth_metrics_list = []
+        groundwater_elevation_metrics_list = []
+        groundwater_date_metrics_list = []
 
-        for file in self.groundwater_list:
-            # lists to contain the metrics
-            groundwater_metrics_list = []
-            groundwater_depth_metrics_list = []
-            groundwater_elevation_metrics_list = []
-            groundwater_date_metrics_list = []
-
-            for borehole_data in file.boreholes:
-                ############################################################################################################
-                ### Compute the metadata correctness for the groundwater information.
-                ############################################################################################################
-                gt_groundwater = [
-                    Groundwater.from_json_values(
-                        depth=json_gt_data.get("depth"),
-                        date=json_gt_data.get("date"),
-                        elevation=json_gt_data.get("elevation"),
-                    )
-                    for json_gt_data in borehole_data.ground_truth
-                ]
-
-                entries = (
-                    [feature_on_page.feature for feature_on_page in borehole_data.groundwater.groundwater_feature_list]
-                    if borehole_data.groundwater
-                    else []
+        for borehole_data in groundwater.boreholes:
+            ############################################################################################################
+            ### Compute the metadata correctness for the groundwater information.
+            ############################################################################################################
+            gt_groundwater = [
+                Groundwater.from_json_values(
+                    depth=json_gt_data.get("depth"),
+                    date=json_gt_data.get("date"),
+                    elevation=json_gt_data.get("elevation"),
                 )
+                for json_gt_data in borehole_data.ground_truth
+            ]
 
-                groundwater_evaluation = evaluate(entries, gt_groundwater, self.match_groundwater)
-                groundwater_metrics_list.append(groundwater_evaluation.metrics)
-                for feature, is_correct in zip(entries, groundwater_evaluation.extracted_correct, strict=True):
-                    feature.is_correct = is_correct
-
-                groundwater_depth_metrics = evaluate(entries, gt_groundwater, self.match_groundwater_depth).metrics
-                groundwater_depth_metrics_list.append(groundwater_depth_metrics)
-
-                groundwater_elevation_metrics = evaluate(
-                    entries, gt_groundwater, self.match_groundwater_elevation
-                ).metrics
-                groundwater_elevation_metrics_list.append(groundwater_elevation_metrics)
-
-                groundwater_date_metrics = evaluate(entries, gt_groundwater, self.match_groundwater_date).metrics
-                groundwater_date_metrics_list.append(groundwater_date_metrics)
-
-            # we take the micro-average across boreholes
-            file_groundwater_metrics = GroundwaterMetrics(
-                groundwater_metrics=Metrics.micro_average(groundwater_metrics_list),
-                groundwater_depth_metrics=Metrics.micro_average(groundwater_depth_metrics_list),
-                groundwater_elevation_metrics=Metrics.micro_average(groundwater_elevation_metrics_list),
-                groundwater_date_metrics=Metrics.micro_average(groundwater_date_metrics_list),
-                filename=file.filename,
+            entries = (
+                [feature_on_page.feature for feature_on_page in borehole_data.groundwater.groundwater_feature_list]
+                if borehole_data.groundwater
+                else []
             )
 
-            overall_groundwater_metrics.add_groundwater_metrics(file_groundwater_metrics)
+            groundwater_evaluation = evaluate(entries, gt_groundwater, GroundwaterEvaluator.match_groundwater)
+            groundwater_metrics_list.append(groundwater_evaluation.metrics)
+            for feature, is_correct in zip(entries, groundwater_evaluation.extracted_correct, strict=True):
+                feature.is_correct = is_correct
 
-        return overall_groundwater_metrics
+            groundwater_depth_metrics = evaluate(
+                entries, gt_groundwater, GroundwaterEvaluator.match_groundwater_depth
+            ).metrics
+            groundwater_depth_metrics_list.append(groundwater_depth_metrics)
+
+            groundwater_elevation_metrics = evaluate(
+                entries, gt_groundwater, GroundwaterEvaluator.match_groundwater_elevation
+            ).metrics
+            groundwater_elevation_metrics_list.append(groundwater_elevation_metrics)
+
+            groundwater_date_metrics = evaluate(
+                entries, gt_groundwater, GroundwaterEvaluator.match_groundwater_date
+            ).metrics
+            groundwater_date_metrics_list.append(groundwater_date_metrics)
+
+        # we take the micro-average across boreholes
+        return GroundwaterMetrics(
+            groundwater_metrics=Metrics.micro_average(groundwater_metrics_list),
+            groundwater_depth_metrics=Metrics.micro_average(groundwater_depth_metrics_list),
+            groundwater_elevation_metrics=Metrics.micro_average(groundwater_elevation_metrics_list),
+            groundwater_date_metrics=Metrics.micro_average(groundwater_date_metrics_list),
+            filename=groundwater.filename,
+        )
 
     @staticmethod
     def match_groundwater(extracted: Groundwater, ground_truth: Groundwater) -> bool:

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -53,7 +53,7 @@ class GroundwaterEvaluator:
     """Class for evaluating the extracted groundwater information of a borehole."""
 
     @staticmethod
-    def evaluate(groundwater: FileGroundwaterWithGroundTruth) -> GroundwaterMetrics:
+    def evaluate(file_predictions: FileGroundwaterWithGroundTruth) -> GroundwaterMetrics:
         """Evaluate the groundwater information of the file against the ground truth.
 
         Returns:
@@ -65,7 +65,7 @@ class GroundwaterEvaluator:
         groundwater_elevation_metrics_list = []
         groundwater_date_metrics_list = []
 
-        for borehole_data in groundwater.boreholes:
+        for borehole_data in file_predictions.boreholes:
             ############################################################################################################
             ### Compute the metadata correctness for the groundwater information.
             ############################################################################################################
@@ -110,7 +110,7 @@ class GroundwaterEvaluator:
             groundwater_depth_metrics=Metrics.micro_average(groundwater_depth_metrics_list),
             groundwater_elevation_metrics=Metrics.micro_average(groundwater_elevation_metrics_list),
             groundwater_date_metrics=Metrics.micro_average(groundwater_date_metrics_list),
-            filename=groundwater.filename,
+            filename=file_predictions.filename,
         )
 
     @staticmethod

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -19,6 +19,26 @@ class GroundwaterMetrics:
     groundwater_date_metrics: Metrics = None
     filename: str = None
 
+    def to_json(self) -> dict[str, float]:
+        return {
+            "metrics": self.groundwater_metrics.to_json(),
+            "depth_metrics": self.groundwater_depth_metrics.to_json(),
+            "elevation_metrics": self.groundwater_elevation_metrics.to_json(),
+            "date_metrics": self.groundwater_date_metrics.to_json(),
+            "filename": self.filename,
+        }
+
+    @classmethod
+    def from_json(cls, json: dict) -> Metrics:
+        """TODO."""
+        return GroundwaterMetrics(
+            groundwater_metrics=Metrics.from_json(json["metrics"]),
+            groundwater_depth_metrics=Metrics.from_json(json["depth_metrics"]),
+            groundwater_elevation_metrics=Metrics.from_json(json["elevation_metrics"]),
+            groundwater_date_metrics=Metrics.from_json(json["date_metrics"]),
+            filename=json["filename"],
+        )
+
 
 @dataclass
 class OverallGroundwaterMetrics:

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -54,10 +54,14 @@ class GroundwaterEvaluator:
 
     @staticmethod
     def evaluate(file_predictions: FileGroundwaterWithGroundTruth) -> GroundwaterMetrics:
-        """Evaluate the groundwater information of the file against the ground truth.
+        """Evaluate the groundwater information of a single file against the ground truth.
+
+        Args:
+            file_predictions (FileGroundwaterWithGroundTruth): Groundwater predictions for each
+                borehole in the file, paired with their ground truth data.
 
         Returns:
-            OverallGroundwaterMetrics: The overall groundwater metrics.
+            GroundwaterMetrics: The computed groundwater metrics for the file.
         """
         # lists to contain the metrics
         groundwater_metrics_list = []

--- a/src/extraction/evaluation/groundwater_evaluator.py
+++ b/src/extraction/evaluation/groundwater_evaluator.py
@@ -19,12 +19,12 @@ class GroundwaterMetrics:
     groundwater_elevation_metrics: Metrics = Metrics()
     groundwater_date_metrics: Metrics = Metrics()
 
-    def to_json(self) -> dict:
+    def to_json(self) -> dict[str, dict]:
         """Converts the object to a dictionary.
 
         Returns:
-            dict: The object as a dictionary, with source filename, nested metric sub-dictionaries
-                for depth, elevation, and date.
+            dict[str, dict]: The object as a dictionary, with source filename, nested metric
+                sub-dictionaries for depth, elevation, and date.
         """
         return {
             "metrics": self.groundwater_metrics.to_json(),
@@ -39,7 +39,7 @@ class GroundwaterMetrics:
 
         Args:
             json (dict): Dictionary with groundwater metrics.
-            filename: (str): Linked filename.
+            filename (str): Linked filename.
 
         Returns:
             GroundwaterMetrics: The reconstructed groundwater metrics object.

--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -29,6 +29,14 @@ class LayerEvaluator:
 
     @staticmethod
     def get_layer_metrics(layers: FileLayersWithGroundTruth) -> OverallMetrics:
+        """Calculate layer-level metrics for the given file's predictions.
+
+        Args:
+            layers (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
+
+        Returns:
+            OverallMetrics: The computed layer metrics.
+        """
         return LayerEvaluator.calculate_metrics(
             layers=layers,
             num_ground_truth_fn=lambda ground_truth_layers: len(ground_truth_layers),
@@ -79,6 +87,7 @@ class LayerEvaluator:
         """Calculate metrics based on a condition per layer, after applying a filter.
 
         Args:
+            layers (FileLayersWithGroundTruth): Borehole layer predictions paired with ground truth.
             num_ground_truth_fn (Callable[[list[dict]], int]): Function that returns the number of ground truth.
             per_layer_filter (Callable[[LayerPrediction], bool]): Function to filter layers to consider.
             per_layer_condition (Callable[[LayerPrediction], bool]): Function that returns True if the layer is a hit.
@@ -122,12 +131,12 @@ class LayerEvaluator:
     def evaluate(file_predictions: FileLayersWithGroundTruth) -> tuple[Metrics, Metrics, Metrics]:
         """Evaluate all predicted layers for a borehole against the ground truth.
 
-        Also performs the matching groundtruth to prediction when there is more than one borehole in the document.
-        It is for this reason that the layers are the first element that needs to be elaluated.
-
         Args:
-            file_predictions (FilePredictions): all predictions for the file
-            ground_truth_for_file (dict): the ground truth for the file
+            file_predictions (FileLayersWithGroundTruth): Layer predictions with ground truth,
+                grouped by borehole.
+
+        Returns:
+            tuple[Metrics, Metrics, Metrics]: (layer_metrics, depth_interval_metrics, material_description_metrics)
         """
 
         # Utility functions to set correctness flags on predicted layers

--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -8,7 +8,6 @@ from typing import Any
 import Levenshtein
 
 from core.benchmark_utils import Metrics
-from extraction.evaluation.benchmark.metrics import OverallMetrics
 from extraction.features.predictions.borehole_predictions import (
     BoreholePredictionsWithGroundTruth,
     FileLayersWithGroundTruth,
@@ -28,14 +27,14 @@ class LayerEvaluator:
     """Class for evaluating the layer information of all boreholes in a document."""
 
     @staticmethod
-    def get_layer_metrics(layers: FileLayersWithGroundTruth) -> OverallMetrics:
+    def get_layer_metrics(layers: FileLayersWithGroundTruth) -> Metrics:
         """Calculate layer-level metrics for the given file's predictions.
 
         Args:
             layers (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
 
         Returns:
-            OverallMetrics: The computed layer metrics.
+            Metrics: The computed layer metrics.
         """
         return LayerEvaluator.calculate_metrics(
             layers=layers,
@@ -45,8 +44,8 @@ class LayerEvaluator:
         )
 
     @staticmethod
-    def get_material_description_metrics(layers: FileLayersWithGroundTruth) -> OverallMetrics:
-        """Calculate metircs for material description extraction across all boreholes in a file.
+    def get_material_description_metrics(layers: FileLayersWithGroundTruth) -> Metrics:
+        """Calculate metrics for material description extraction across all boreholes in a file.
 
         Args:
             layers (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
@@ -71,7 +70,7 @@ class LayerEvaluator:
         )
 
     @staticmethod
-    def get_depth_interval_metrics(layers: FileLayersWithGroundTruth) -> OverallMetrics:
+    def get_depth_interval_metrics(layers: FileLayersWithGroundTruth) -> Metrics:
         """Calculate metrics for depth interval extraction across all boreholes in a file.
 
         Args:
@@ -91,6 +90,7 @@ class LayerEvaluator:
             per_layer_condition=lambda layer: layer.depths is not None and layer.depths.is_correct,
         )
 
+    @staticmethod
     def calculate_metrics(
         layers: FileLayersWithGroundTruth,
         num_ground_truth_fn: Callable[[list[dict]], int],
@@ -103,9 +103,9 @@ class LayerEvaluator:
         Args:
             layers (FileLayersWithGroundTruth): Borehole layer predictions paired with ground truth.
             num_ground_truth_fn (Callable[[list[dict]], int]): Function that returns the number of ground truth.
-            per_layer_filter (Callable[[LayerPrediction], bool]): Function to filter layers to consider.
-            per_layer_condition (Callable[[LayerPrediction], bool]): Function that returns True if the layer is a hit.
-            per_layer_action (Optional[Callable[[LayerPrediction], None]]): Optional action to perform per layer.
+            per_layer_filter (Callable[[Layer], bool]): Function to filter layers to consider.
+            per_layer_condition (Callable[[Layer], bool]): Function that returns True if the layer is a hit.
+            per_layer_action (Optional[Callable[[Layer], None]]): Optional action to perform per layer.
 
         Returns:
             Metrics: The calculated metrics.

--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -12,6 +12,7 @@ from extraction.evaluation.benchmark.metrics import OverallMetrics
 from extraction.features.predictions.borehole_predictions import (
     BoreholePredictionsWithGroundTruth,
     FileLayersWithGroundTruth,
+    FilePredictionsWithGroundTruth,
 )
 from extraction.features.predictions.file_predictions import FilePredictions
 from extraction.features.stratigraphy.layer.layer import Layer
@@ -131,7 +132,7 @@ class LayerEvaluator:
         return overall_metrics
 
     @staticmethod
-    def match_predictions_with_ground_truth(file_predictions: FilePredictions, ground_truth_for_file: dict):
+    def evaluate(file_predictions: FilePredictionsWithGroundTruth) -> None:
         """Evaluate all predicted layers for a borehole against the ground truth.
 
         Also performs the matching groundtruth to prediction when there is more than one borehole in the document.
@@ -140,11 +141,7 @@ class LayerEvaluator:
         Args:
             file_predictions (FilePredictions): all predictions for the file
             ground_truth_for_file (dict): the ground truth for the file
-
-        Returns:
-            list[BoreholePredictionsWithGroundTruth]
         """
-        matched_boreholes = LayerEvaluator.match_boreholes_to_ground_truth(file_predictions, ground_truth_for_file)
 
         # Utility functions to set correctness flags on predicted layers
         def set_depths_flag(predicted_layer, ground_truth_layer):
@@ -167,7 +164,7 @@ class LayerEvaluator:
             )
 
         # now compute the real statistics for the matched pairs of boreholes
-        for borehole_data in matched_boreholes:
+        for borehole_data in file_predictions.boreholes:
             if borehole_data.predictions:
                 predicted_layers = borehole_data.predictions.layers_in_borehole.layers
 
@@ -184,8 +181,6 @@ class LayerEvaluator:
                     ground_truth_layers, predicted_layers, score_material_descriptions, set_material_description_flag
                 )
                 LayerEvaluator.apply_mapping(ground_truth_layers, predicted_layers, score_layer, set_layer_flag)
-
-        return matched_boreholes
 
     @staticmethod
     def apply_mapping(ground_truth_layers, predicted_layers, scoring_fn, set_flag_fn):

--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -27,28 +27,28 @@ class LayerEvaluator:
     """Class for evaluating the layer information of all boreholes in a document."""
 
     @staticmethod
-    def get_layer_metrics(layers: FileLayersWithGroundTruth) -> Metrics:
+    def get_layer_metrics(file_predictions: FileLayersWithGroundTruth) -> Metrics:
         """Calculate layer-level metrics for the given file's predictions.
 
         Args:
-            layers (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
+            file_predictions (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
 
         Returns:
             Metrics: The computed layer metrics.
         """
         return LayerEvaluator.calculate_metrics(
-            layers=layers,
+            file_predictions=file_predictions,
             num_ground_truth_fn=lambda ground_truth_layers: len(ground_truth_layers),
             per_layer_filter=lambda layer: True,
             per_layer_condition=lambda layer: layer.is_correct,
         )
 
     @staticmethod
-    def get_material_description_metrics(layers: FileLayersWithGroundTruth) -> Metrics:
+    def get_material_description_metrics(file_predictions: FileLayersWithGroundTruth) -> Metrics:
         """Calculate metrics for material description extraction across all boreholes in a file.
 
         Args:
-            layers (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
+            file_predictions (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
 
         Returns:
             Metrics: Aggregated material metrics across all boreholes.
@@ -62,7 +62,7 @@ class LayerEvaluator:
             return sum(lay["material_description"] is not None for lay in ground_truth_layers)
 
         return LayerEvaluator.calculate_metrics(
-            layers=layers,
+            file_predictions=file_predictions,
             num_ground_truth_fn=num_ground_truth_fn,
             per_layer_filter=lambda layer: True,
             per_layer_condition=lambda layer: layer.material_description.is_correct,
@@ -70,11 +70,11 @@ class LayerEvaluator:
         )
 
     @staticmethod
-    def get_depth_interval_metrics(layers: FileLayersWithGroundTruth) -> Metrics:
+    def get_depth_interval_metrics(file_predictions: FileLayersWithGroundTruth) -> Metrics:
         """Calculate metrics for depth interval extraction across all boreholes in a file.
 
         Args:
-            layers (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
+            file_predictions (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
 
         Returns:
             Metrics: Aggregated depth metrics across all boreholes.
@@ -84,7 +84,7 @@ class LayerEvaluator:
             return sum(lay["depth_interval"] is not None for lay in ground_truth_layers)
 
         return LayerEvaluator.calculate_metrics(
-            layers=layers,
+            file_predictions=file_predictions,
             num_ground_truth_fn=num_ground_truth_fn,
             per_layer_filter=lambda layer: True,
             per_layer_condition=lambda layer: layer.depths is not None and layer.depths.is_correct,
@@ -92,7 +92,7 @@ class LayerEvaluator:
 
     @staticmethod
     def calculate_metrics(
-        layers: FileLayersWithGroundTruth,
+        file_predictions: FileLayersWithGroundTruth,
         num_ground_truth_fn: Callable[[list[dict]], int],
         per_layer_filter: Callable[[Layer], bool],
         per_layer_condition: Callable[[Layer], bool],
@@ -101,7 +101,7 @@ class LayerEvaluator:
         """Calculate metrics based on a condition per layer, after applying a filter.
 
         Args:
-            layers (FileLayersWithGroundTruth): Borehole layer predictions paired with ground truth.
+            file_predictions (FileLayersWithGroundTruth): Borehole layer predictions paired with ground truth.
             num_ground_truth_fn (Callable[[list[dict]], int]): Function that returns the number of ground truth.
             per_layer_filter (Callable[[Layer], bool]): Function to filter layers to consider.
             per_layer_condition (Callable[[Layer], bool]): Function that returns True if the layer is a hit.
@@ -114,7 +114,7 @@ class LayerEvaluator:
         total_predictions_for_all_boreholes = 0
         fn_for_all_boreholes = 0
 
-        for borehole_data in layers.boreholes:
+        for borehole_data in file_predictions.boreholes:
             number_of_truth_values = num_ground_truth_fn(borehole_data.ground_truth)
             tp = 0
             total_predictions = 0

--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -12,7 +12,6 @@ from extraction.evaluation.benchmark.metrics import OverallMetrics
 from extraction.features.predictions.borehole_predictions import (
     BoreholePredictionsWithGroundTruth,
     FileLayersWithGroundTruth,
-    FilePredictionsWithGroundTruth,
 )
 from extraction.features.predictions.file_predictions import FilePredictions
 from extraction.features.stratigraphy.layer.layer import Layer
@@ -28,26 +27,17 @@ MAX_DEPTH_SCORE = 1.0
 class LayerEvaluator:
     """Class for evaluating the layer information of all boreholes in a document."""
 
-    def __init__(
-        self,
-        file_layers_list: list[FileLayersWithGroundTruth],
-    ):
-        """Initializes the LayerEvaluator object.
-
-        Args:
-            file_layers_list (list[FileLayersWithGroundTruth]): The layers to evaluate, grouped by borehole in a list,
-                with associated ground truth data for each borehole.
-        """
-        self.file_layers_list = file_layers_list
-
-    def get_layer_metrics(self) -> OverallMetrics:
-        return self.calculate_metrics(
+    @staticmethod
+    def get_layer_metrics(layers: FileLayersWithGroundTruth) -> OverallMetrics:
+        return LayerEvaluator.calculate_metrics(
+            layers=layers,
             num_ground_truth_fn=lambda ground_truth_layers: len(ground_truth_layers),
             per_layer_filter=lambda layer: True,
             per_layer_condition=lambda layer: layer.is_correct,
         )
 
-    def get_material_description_metrics(self) -> OverallMetrics:
+    @staticmethod
+    def get_material_description_metrics(layers: FileLayersWithGroundTruth) -> OverallMetrics:
         """Calculate metrics for layer predictions."""
 
         def per_layer_action(layer: Layer):
@@ -57,32 +47,35 @@ class LayerEvaluator:
         def num_ground_truth_fn(ground_truth_layers: list[dict]):
             return sum(lay["material_description"] is not None for lay in ground_truth_layers)
 
-        return self.calculate_metrics(
+        return LayerEvaluator.calculate_metrics(
+            layers=layers,
             num_ground_truth_fn=num_ground_truth_fn,
             per_layer_filter=lambda layer: True,
             per_layer_condition=lambda layer: layer.material_description.is_correct,
             per_layer_action=per_layer_action,
         )
 
-    def get_depth_interval_metrics(self) -> OverallMetrics:
+    @staticmethod
+    def get_depth_interval_metrics(layers: FileLayersWithGroundTruth) -> OverallMetrics:
         """Calculate metrics for depth interval predictions."""
 
         def num_ground_truth_fn(ground_truth_layers: list[dict]):
             return sum(lay["depth_interval"] is not None for lay in ground_truth_layers)
 
-        return self.calculate_metrics(
+        return LayerEvaluator.calculate_metrics(
+            layers=layers,
             num_ground_truth_fn=num_ground_truth_fn,
             per_layer_filter=lambda layer: True,
             per_layer_condition=lambda layer: layer.depths is not None and layer.depths.is_correct,
         )
 
     def calculate_metrics(
-        self,
+        layers: FileLayersWithGroundTruth,
         num_ground_truth_fn: Callable[[list[dict]], int],
         per_layer_filter: Callable[[Layer], bool],
         per_layer_condition: Callable[[Layer], bool],
         per_layer_action: Callable[[Layer], None] | None = None,
-    ) -> OverallMetrics:
+    ) -> Metrics:
         """Calculate metrics based on a condition per layer, after applying a filter.
 
         Args:
@@ -92,47 +85,41 @@ class LayerEvaluator:
             per_layer_action (Optional[Callable[[LayerPrediction], None]]): Optional action to perform per layer.
 
         Returns:
-            OverallMetrics: The calculated metrics.
+            Metrics: The calculated metrics.
         """
-        overall_metrics = OverallMetrics()
+        hits_for_all_borehole = 0
+        total_predictions_for_all_boreholes = 0
+        fn_for_all_boreholes = 0
 
-        # iteration over all the files
-        for file in self.file_layers_list:
-            hits_for_all_borehole = 0
-            total_predictions_for_all_boreholes = 0
-            fn_for_all_boreholes = 0
+        for borehole_data in layers.boreholes:
+            number_of_truth_values = num_ground_truth_fn(borehole_data.ground_truth)
+            tp = 0
+            total_predictions = 0
 
-            for borehole_data in file.boreholes:
-                number_of_truth_values = num_ground_truth_fn(borehole_data.ground_truth)
-                tp = 0
-                total_predictions = 0
+            layers = borehole_data.layers.layers if borehole_data.layers else []
+            for layer in layers:
+                if per_layer_action:
+                    per_layer_action(layer)
+                if per_layer_filter(layer):
+                    total_predictions += 1
+                    if per_layer_condition(layer):
+                        tp += 1
 
-                layers = borehole_data.layers.layers if borehole_data.layers else []
-                for layer in layers:
-                    if per_layer_action:
-                        per_layer_action(layer)
-                    if per_layer_filter(layer):
-                        total_predictions += 1
-                        if per_layer_condition(layer):
-                            tp += 1
+            fn = number_of_truth_values - tp
 
-                fn = number_of_truth_values - tp
+            hits_for_all_borehole += tp
+            total_predictions_for_all_boreholes += total_predictions
+            fn_for_all_boreholes += fn
 
-                hits_for_all_borehole += tp
-                total_predictions_for_all_boreholes += total_predictions
-                fn_for_all_boreholes += fn
-
-            # at this point we have the global statistics for all the boreholes in the document
-            overall_metrics.metrics[file.filename] = Metrics(
-                tp=hits_for_all_borehole,
-                fp=total_predictions_for_all_boreholes - hits_for_all_borehole,
-                fn=fn_for_all_boreholes,
-            )
-
-        return overall_metrics
+        # at this point we have the global statistics for all the boreholes in the document
+        return Metrics(
+            tp=hits_for_all_borehole,
+            fp=total_predictions_for_all_boreholes - hits_for_all_borehole,
+            fn=fn_for_all_boreholes,
+        )
 
     @staticmethod
-    def evaluate(file_predictions: FilePredictionsWithGroundTruth) -> None:
+    def evaluate(file_predictions: FileLayersWithGroundTruth) -> tuple[Metrics, Metrics, Metrics]:
         """Evaluate all predicted layers for a borehole against the ground truth.
 
         Also performs the matching groundtruth to prediction when there is more than one borehole in the document.
@@ -163,10 +150,9 @@ class LayerEvaluator:
                 >= MATERIAL_DESCRIPTION_SIMILARITY_THRESHOLD
             )
 
-        # now compute the real statistics for the matched pairs of boreholes
         for borehole_data in file_predictions.boreholes:
-            if borehole_data.predictions:
-                predicted_layers = borehole_data.predictions.layers_in_borehole.layers
+            if borehole_data.layers:
+                predicted_layers = borehole_data.layers.layers
 
                 for pred in predicted_layers:
                     pred.material_description.is_correct = False
@@ -174,13 +160,22 @@ class LayerEvaluator:
                         pred.depths.is_correct = False
                     pred.is_correct = False
 
-                ground_truth_layers = borehole_data.ground_truth.get("layers", [])
-
-                LayerEvaluator.apply_mapping(ground_truth_layers, predicted_layers, score_depths, set_depths_flag)
                 LayerEvaluator.apply_mapping(
-                    ground_truth_layers, predicted_layers, score_material_descriptions, set_material_description_flag
+                    borehole_data.ground_truth, predicted_layers, score_depths, set_depths_flag
                 )
-                LayerEvaluator.apply_mapping(ground_truth_layers, predicted_layers, score_layer, set_layer_flag)
+                LayerEvaluator.apply_mapping(
+                    borehole_data.ground_truth,
+                    predicted_layers,
+                    score_material_descriptions,
+                    set_material_description_flag,
+                )
+                LayerEvaluator.apply_mapping(borehole_data.ground_truth, predicted_layers, score_layer, set_layer_flag)
+
+        layer_metrics = LayerEvaluator.get_layer_metrics(file_predictions)
+        depth_interval_metrics = LayerEvaluator.get_depth_interval_metrics(file_predictions)
+        material_description_metrics = LayerEvaluator.get_material_description_metrics(file_predictions)
+
+        return layer_metrics, depth_interval_metrics, material_description_metrics
 
     @staticmethod
     def apply_mapping(ground_truth_layers, predicted_layers, scoring_fn, set_flag_fn):

--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -46,7 +46,14 @@ class LayerEvaluator:
 
     @staticmethod
     def get_material_description_metrics(layers: FileLayersWithGroundTruth) -> OverallMetrics:
-        """Calculate metrics for layer predictions."""
+        """Calculate metircs for material description extraction across all boreholes in a file.
+
+        Args:
+            layers (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
+
+        Returns:
+            Metrics: Aggregated material metrics across all boreholes.
+        """
 
         def per_layer_action(layer: Layer):
             if parse_text(layer.material_description.text) == "":
@@ -65,7 +72,14 @@ class LayerEvaluator:
 
     @staticmethod
     def get_depth_interval_metrics(layers: FileLayersWithGroundTruth) -> OverallMetrics:
-        """Calculate metrics for depth interval predictions."""
+        """Calculate metrics for depth interval extraction across all boreholes in a file.
+
+        Args:
+            layers (FileLayersWithGroundTruth): Layer predictions paired with ground truth.
+
+        Returns:
+            Metrics: Aggregated depth metrics across all boreholes.
+        """
 
         def num_ground_truth_fn(ground_truth_layers: list[dict]):
             return sum(lay["depth_interval"] is not None for lay in ground_truth_layers)

--- a/src/extraction/evaluation/metadata_evaluator.py
+++ b/src/extraction/evaluation/metadata_evaluator.py
@@ -21,7 +21,15 @@ class MetadataEvaluator:
 
     @staticmethod
     def evaluate(file_predictions: FileMetadataWithGroundTruth) -> BoreholeMetadataMetrics:
-        """Evaluate the metadata of the file against the ground truth."""
+        """Compute elevation, coordinate, and name metrics for a single file.
+
+        Args:
+            file_predictions (FileMetadataWithGroundTruth): Per-file metadata predictions
+                paired with their ground truth data.
+
+        Returns:
+            FileBoreholeMetadataMetrics: Metrics across all boreholes in the file.
+        """
         # create the lists that will contain the individual score of each borehole
         elevation_metrics_list = []
         coordinate_metrics_list = []

--- a/src/extraction/evaluation/metadata_evaluator.py
+++ b/src/extraction/evaluation/metadata_evaluator.py
@@ -3,9 +3,9 @@
 import math
 
 from extraction.evaluation.evaluation_dataclasses import (
+    BoreholeMetadataMetrics,
     FileBoreholeMetadataMetrics,
     Metrics,
-    OverallBoreholeMetadataMetrics,
 )
 from extraction.evaluation.utility import evaluate_single
 from extraction.features.metadata.borehole_name_extraction import BoreholeName, clean_borehole_name
@@ -19,92 +19,76 @@ name_detection_params = read_params("name_detection_params.yml")
 class MetadataEvaluator:
     """Class for evaluating the metadata of a borehole."""
 
-    def __init__(self, metadata_list: list[FileMetadataWithGroundTruth]) -> None:
-        """Initializes the MetadataEvaluator object.
-
-        Args:
-            metadata_list (list[FileMetadataWithGroundTruth]): a list of borehole metadata predictions, with
-                ground truth data associated for every borehole.
-        """
-        self.metadata_list = metadata_list
-
-    def evaluate(self) -> OverallBoreholeMetadataMetrics:
+    @staticmethod
+    def evaluate(file_predictions: FileMetadataWithGroundTruth) -> BoreholeMetadataMetrics:
         """Evaluate the metadata of the file against the ground truth."""
-        # Initialize the metadata correctness metrics
-        metadata_metrics_list = OverallBoreholeMetadataMetrics()
+        # create the lists that will contain the individual score of each borehole
+        elevation_metrics_list = []
+        coordinate_metrics_list = []
+        name_metrics_list = []
 
-        for file_data in self.metadata_list:
-            # create the lists that will contain the individual score of each borehole
-            elevation_metrics_list = []
-            coordinate_metrics_list = []
-            name_metrics_list = []
+        for borehole_data in file_predictions.boreholes:
+            if borehole_data.ground_truth is None:
+                # when the extraction detects more borehole than there actually is in the ground truth, the wosrt
+                # predictions have no match and must be skipped for the evaluation
+                continue
 
-            for borehole_data in file_data.boreholes:
-                if borehole_data.ground_truth is None:
-                    # when the extraction detects more borehole than there actually is in the ground truth, the wosrt
-                    # predictions have no match and must be skipped for the evaluation
-                    continue
-
-                ###########################################################################################################
-                ### Compute the metadata correctness for the coordinates.
-                ###########################################################################################################
-                extracted_coordinates = (
-                    borehole_data.metadata.coordinates.feature
-                    if borehole_data.metadata and borehole_data.metadata.coordinates
-                    else None
-                )
-                ground_truth_coordinates = borehole_data.ground_truth.get("coordinates")
-
-                evaluation_result = evaluate_single(
-                    extracted_coordinates, ground_truth_coordinates, self.match_coordinates
-                )
-                coordinate_metrics = evaluation_result.metrics
-                if borehole_data.metadata and borehole_data.metadata.coordinates:
-                    borehole_data.metadata.coordinates.feature.is_correct = coordinate_metrics.tp > 0
-                coordinate_metrics_list.append(coordinate_metrics)
-
-                ############################################################################################################
-                ### Compute the metadata correctness for the elevation.
-                ############################################################################################################
-                extracted_elevation = (
-                    borehole_data.metadata.elevation.feature.elevation
-                    if borehole_data.metadata and borehole_data.metadata.elevation
-                    else None
-                )
-                ground_truth_elevation = borehole_data.ground_truth.get("reference_elevation")
-                evaluation_result = evaluate_single(extracted_elevation, ground_truth_elevation, self.match_elevation)
-                elevation_metrics = evaluation_result.metrics
-                if borehole_data.metadata and borehole_data.metadata.elevation:
-                    borehole_data.metadata.elevation.feature.is_correct = elevation_metrics.tp > 0
-                elevation_metrics_list.append(elevation_metrics)
-
-                ###########################################################################################################
-                ### Compute the metadata correctness for the name.
-                ###########################################################################################################
-                extracted_name = (
-                    borehole_data.metadata.name.feature
-                    if borehole_data.metadata and borehole_data.metadata.name
-                    else None
-                )
-                ground_truth_name = borehole_data.ground_truth.get("original_name")
-
-                evaluation_result = evaluate_single(extracted_name, ground_truth_name, self.match_name)
-                name_metrics = evaluation_result.metrics
-                if borehole_data.metadata and borehole_data.metadata.name:
-                    borehole_data.metadata.name.feature.is_correct = name_metrics.tp > 0
-                name_metrics_list.append(name_metrics)
-
-            # perform micro-average to store the metrics of all the boreholes in the document
-            metadata_metrics_list.borehole_metadata_metrics.append(
-                FileBoreholeMetadataMetrics(
-                    elevation_metrics=Metrics.micro_average(elevation_metrics_list),
-                    coordinates_metrics=Metrics.micro_average(coordinate_metrics_list),
-                    name_metrics=Metrics.micro_average(name_metrics_list),
-                    filename=file_data.filename,
-                )
+            ###########################################################################################################
+            ### Compute the metadata correctness for the coordinates.
+            ###########################################################################################################
+            extracted_coordinates = (
+                borehole_data.metadata.coordinates.feature
+                if borehole_data.metadata and borehole_data.metadata.coordinates
+                else None
             )
+            ground_truth_coordinates = borehole_data.ground_truth.get("coordinates")
 
-        return metadata_metrics_list
+            evaluation_result = evaluate_single(
+                extracted_coordinates, ground_truth_coordinates, MetadataEvaluator.match_coordinates
+            )
+            coordinate_metrics = evaluation_result.metrics
+            if borehole_data.metadata and borehole_data.metadata.coordinates:
+                borehole_data.metadata.coordinates.feature.is_correct = coordinate_metrics.tp > 0
+            coordinate_metrics_list.append(coordinate_metrics)
+
+            ############################################################################################################
+            ### Compute the metadata correctness for the elevation.
+            ############################################################################################################
+            extracted_elevation = (
+                borehole_data.metadata.elevation.feature.elevation
+                if borehole_data.metadata and borehole_data.metadata.elevation
+                else None
+            )
+            ground_truth_elevation = borehole_data.ground_truth.get("reference_elevation")
+            evaluation_result = evaluate_single(
+                extracted_elevation, ground_truth_elevation, MetadataEvaluator.match_elevation
+            )
+            elevation_metrics = evaluation_result.metrics
+            if borehole_data.metadata and borehole_data.metadata.elevation:
+                borehole_data.metadata.elevation.feature.is_correct = elevation_metrics.tp > 0
+            elevation_metrics_list.append(elevation_metrics)
+
+            ###########################################################################################################
+            ### Compute the metadata correctness for the name.
+            ###########################################################################################################
+            extracted_name = (
+                borehole_data.metadata.name.feature if borehole_data.metadata and borehole_data.metadata.name else None
+            )
+            ground_truth_name = borehole_data.ground_truth.get("original_name")
+
+            evaluation_result = evaluate_single(extracted_name, ground_truth_name, MetadataEvaluator.match_name)
+            name_metrics = evaluation_result.metrics
+            if borehole_data.metadata and borehole_data.metadata.name:
+                borehole_data.metadata.name.feature.is_correct = name_metrics.tp > 0
+            name_metrics_list.append(name_metrics)
+
+        # perform micro-average to store the metrics of all the boreholes in the document
+        return FileBoreholeMetadataMetrics(
+            elevation_metrics=Metrics.micro_average(elevation_metrics_list),
+            coordinates_metrics=Metrics.micro_average(coordinate_metrics_list),
+            name_metrics=Metrics.micro_average(name_metrics_list),
+            filename=file_predictions.filename,
+        )
 
     @staticmethod
     def match_elevation(extracted_elevation: float, ground_truth_elevation: float):

--- a/src/extraction/evaluation/metadata_evaluator.py
+++ b/src/extraction/evaluation/metadata_evaluator.py
@@ -5,7 +5,6 @@ import math
 from core.benchmark_utils import Metrics
 from extraction.evaluation.evaluation_dataclasses import (
     BoreholeMetadataMetrics,
-    FileBoreholeMetadataMetrics,
 )
 from extraction.evaluation.utility import evaluate_single
 from extraction.features.metadata.borehole_name_extraction import BoreholeName, clean_borehole_name
@@ -85,11 +84,10 @@ class MetadataEvaluator:
             name_metrics_list.append(name_metrics)
 
         # perform micro-average to store the metrics of all the boreholes in the document
-        return FileBoreholeMetadataMetrics(
+        return BoreholeMetadataMetrics(
             elevation_metrics=Metrics.micro_average(elevation_metrics_list),
             coordinates_metrics=Metrics.micro_average(coordinate_metrics_list),
             name_metrics=Metrics.micro_average(name_metrics_list),
-            filename=file_predictions.filename,
         )
 
     @staticmethod

--- a/src/extraction/evaluation/metadata_evaluator.py
+++ b/src/extraction/evaluation/metadata_evaluator.py
@@ -37,7 +37,7 @@ class MetadataEvaluator:
 
         for borehole_data in file_predictions.boreholes:
             if borehole_data.ground_truth is None:
-                # when the extraction detects more borehole than there actually is in the ground truth, the wosrt
+                # when the extraction detects more borehole than there actually is in the ground truth, the worst
                 # predictions have no match and must be skipped for the evaluation
                 continue
 

--- a/src/extraction/evaluation/metadata_evaluator.py
+++ b/src/extraction/evaluation/metadata_evaluator.py
@@ -28,7 +28,7 @@ class MetadataEvaluator:
                 paired with their ground truth data.
 
         Returns:
-            FileBoreholeMetadataMetrics: Metrics across all boreholes in the file.
+            BoreholeMetadataMetrics: Metrics across all boreholes in the file.
         """
         # create the lists that will contain the individual score of each borehole
         elevation_metrics_list = []

--- a/src/extraction/evaluation/metadata_evaluator.py
+++ b/src/extraction/evaluation/metadata_evaluator.py
@@ -41,9 +41,7 @@ class MetadataEvaluator:
                 # predictions have no match and must be skipped for the evaluation
                 continue
 
-            ###########################################################################################################
-            ### Compute the metadata correctness for the coordinates.
-            ###########################################################################################################
+            # Compute the metadata correctness for the coordinates.
             extracted_coordinates = (
                 borehole_data.metadata.coordinates.feature
                 if borehole_data.metadata and borehole_data.metadata.coordinates
@@ -59,9 +57,7 @@ class MetadataEvaluator:
                 borehole_data.metadata.coordinates.feature.is_correct = coordinate_metrics.tp > 0
             coordinate_metrics_list.append(coordinate_metrics)
 
-            ############################################################################################################
-            ### Compute the metadata correctness for the elevation.
-            ############################################################################################################
+            # Compute the metadata correctness for the elevation.
             extracted_elevation = (
                 borehole_data.metadata.elevation.feature.elevation
                 if borehole_data.metadata and borehole_data.metadata.elevation
@@ -76,9 +72,7 @@ class MetadataEvaluator:
                 borehole_data.metadata.elevation.feature.is_correct = elevation_metrics.tp > 0
             elevation_metrics_list.append(elevation_metrics)
 
-            ###########################################################################################################
-            ### Compute the metadata correctness for the name.
-            ###########################################################################################################
+            # Compute the metadata correctness for the name.
             extracted_name = (
                 borehole_data.metadata.name.feature if borehole_data.metadata and borehole_data.metadata.name else None
             )

--- a/src/extraction/evaluation/metadata_evaluator.py
+++ b/src/extraction/evaluation/metadata_evaluator.py
@@ -2,10 +2,10 @@
 
 import math
 
+from core.benchmark_utils import Metrics
 from extraction.evaluation.evaluation_dataclasses import (
     BoreholeMetadataMetrics,
     FileBoreholeMetadataMetrics,
-    Metrics,
 )
 from extraction.evaluation.utility import evaluate_single
 from extraction.features.metadata.borehole_name_extraction import BoreholeName, clean_borehole_name

--- a/src/extraction/features/predictions/file_predictions.py
+++ b/src/extraction/features/predictions/file_predictions.py
@@ -54,12 +54,13 @@ class FilePredictionsMetrics:
         }
 
     @classmethod
-    def from_json(cls, json: dict) -> "FilePredictionsMetrics":
+    def from_json(cls, json: dict, filename: str) -> "FilePredictionsMetrics":
         """Construct a FilePredictionsMetrics instance from a dictionary produced by `to_json`.
 
         Args:
             json (dict): Dictionary with layer_metrics, depth_interval_metrics, material_description_metrics,
                 gw_metrics, and metadata_metrics.
+            filename (str): Linked filename.
 
         Returns:
             FilePredictionsMetrics: The reconstructed metrics object.
@@ -68,7 +69,7 @@ class FilePredictionsMetrics:
             layer_metrics=Metrics.from_json(json["layer_metrics"]),
             depth_interval_metrics=Metrics.from_json(json["depth_interval_metrics"]),
             material_description_metrics=Metrics.from_json(json["material_description_metrics"]),
-            gw_metrics=GroundwaterMetrics.from_json(json["gw_metrics"]),
+            gw_metrics=GroundwaterMetrics.from_json(json["gw_metrics"], filename),
             metadata_metrics=BoreholeMetadataMetrics.from_json(json["metadata_metrics"]),
         )
 
@@ -79,6 +80,7 @@ class FilePredictionsWithMetrics:
 
     language: str
     filename: str
+    file_metadata: FileMetadata
     boreholes: list[BoreholePredictions]
     metrics: FilePredictionsMetrics | None
 
@@ -89,25 +91,27 @@ class FilePredictionsWithMetrics:
             dict: The object as a dictionary.
         """
         return {
-            "filename": self.filename,
             "language": self.language,
+            "file_metadata": self.file_metadata.to_json(),
             "boreholes": [borehole.to_json() for borehole in self.boreholes],
             "metrics": self.metrics.to_json() if self.metrics else None,
         }
 
     @classmethod
-    def from_json(cls, json: dict) -> "FilePredictionsWithMetrics":
+    def from_json(cls, json: dict, filename: str) -> "FilePredictionsWithMetrics":
         """Construct a FilePredictionsWithMetrics instance from a dictionary produced by `to_json`.
 
         Args:
             json (dict): Dictionary with filename, language, boreholes, and metrics.
+            filename (str): Filename of the document.
 
         Returns:
             FilePredictionsWithMetrics: The reconstructed predictions object.
         """
         return FilePredictionsWithMetrics(
-            filename=json["filename"],
+            filename=filename,
             language=json["language"],
-            boreholes=[BoreholePredictions.from_json(bh_data, json["filename"]) for bh_data in json["boreholes"]],
-            metrics=FilePredictionsMetrics.from_json(json["metrics"]),
+            file_metadata=FileMetadata.from_json(json["file_metadata"], filename),
+            boreholes=[BoreholePredictions.from_json(bh_data, filename) for bh_data in json["boreholes"]],
+            metrics=FilePredictionsMetrics.from_json(json["metrics"], filename),
         )

--- a/src/extraction/features/predictions/file_predictions.py
+++ b/src/extraction/features/predictions/file_predictions.py
@@ -79,7 +79,7 @@ class FilePredictionsMetrics:
 
 @dataclasses.dataclass
 class FilePredictionsWithMetrics:
-    """A class to represent predictions for a single file."""
+    """Predictions for a single PDF file, including optional per-category evaluation metrics."""
 
     filename: str
     file_metadata: FileMetadata

--- a/src/extraction/features/predictions/file_predictions.py
+++ b/src/extraction/features/predictions/file_predictions.py
@@ -33,6 +33,7 @@ class FilePredictions:
 class FilePredictionsMetrics:
     """Evaluation metrics for a single extracted file, covering all extraction categories."""
 
+    language: str
     layer_metrics: Metrics
     depth_interval_metrics: Metrics
     material_description_metrics: Metrics
@@ -46,6 +47,7 @@ class FilePredictionsMetrics:
             dict: The object as a dictionary.
         """
         return {
+            "language": self.language,
             "layer_metrics": self.layer_metrics.to_json(),
             "depth_interval_metrics": self.depth_interval_metrics.to_json(),
             "material_description_metrics": self.material_description_metrics.to_json(),
@@ -66,6 +68,7 @@ class FilePredictionsMetrics:
             FilePredictionsMetrics: The reconstructed metrics object.
         """
         return FilePredictionsMetrics(
+            language=json["language"],
             layer_metrics=Metrics.from_json(json["layer_metrics"]),
             depth_interval_metrics=Metrics.from_json(json["depth_interval_metrics"]),
             material_description_metrics=Metrics.from_json(json["material_description_metrics"]),
@@ -78,7 +81,6 @@ class FilePredictionsMetrics:
 class FilePredictionsWithMetrics:
     """A class to represent predictions for a single file."""
 
-    language: str
     filename: str
     file_metadata: FileMetadata
     boreholes: list[BoreholePredictions]
@@ -91,7 +93,6 @@ class FilePredictionsWithMetrics:
             dict: The object as a dictionary.
         """
         return {
-            "language": self.language,
             "file_metadata": self.file_metadata.to_json(),
             "boreholes": [borehole.to_json() for borehole in self.boreholes],
             "metrics": self.metrics.to_json() if self.metrics else None,
@@ -102,7 +103,7 @@ class FilePredictionsWithMetrics:
         """Construct a FilePredictionsWithMetrics instance from a dictionary produced by `to_json`.
 
         Args:
-            json (dict): Dictionary with filename, language, boreholes, and metrics.
+            json (dict): Dictionary with filename, boreholes, and metrics.
             filename (str): Filename of the document.
 
         Returns:
@@ -110,8 +111,7 @@ class FilePredictionsWithMetrics:
         """
         return FilePredictionsWithMetrics(
             filename=filename,
-            language=json["language"],
             file_metadata=FileMetadata.from_json(json["file_metadata"], filename),
             boreholes=[BoreholePredictions.from_json(bh_data, filename) for bh_data in json["boreholes"]],
-            metrics=FilePredictionsMetrics.from_json(json["metrics"], filename),
+            metrics=FilePredictionsMetrics.from_json(json["metrics"], filename) if json.get("metrics") else None,
         )

--- a/src/extraction/features/predictions/file_predictions.py
+++ b/src/extraction/features/predictions/file_predictions.py
@@ -31,7 +31,7 @@ class FilePredictions:
 
 @dataclasses.dataclass
 class FilePredictionsMetrics:
-    """TODO."""
+    """Evaluation metrics for a single extracted file, covering all extraction categories."""
 
     layer_metrics: Metrics
     depth_interval_metrics: Metrics
@@ -55,7 +55,15 @@ class FilePredictionsMetrics:
 
     @classmethod
     def from_json(cls, json: dict) -> "FilePredictionsMetrics":
-        """TODO."""
+        """Construct a FilePredictionsMetrics instance from a dictionary produced by `to_json`.
+
+        Args:
+            json (dict): Dictionary with layer_metrics, depth_interval_metrics, material_description_metrics,
+                gw_metrics, and metadata_metrics.
+
+        Returns:
+            FilePredictionsMetrics: The reconstructed metrics object.
+        """
         return FilePredictionsMetrics(
             layer_metrics=Metrics.from_json(json["layer_metrics"]),
             depth_interval_metrics=Metrics.from_json(json["depth_interval_metrics"]),
@@ -89,6 +97,14 @@ class FilePredictionsWithMetrics:
 
     @classmethod
     def from_json(cls, json: dict) -> "FilePredictionsWithMetrics":
+        """Construct a FilePredictionsWithMetrics instance from a dictionary produced by `to_json`.
+
+        Args:
+            json (dict): Dictionary with filename, language, boreholes, and metrics.
+
+        Returns:
+            FilePredictionsWithMetrics: The reconstructed predictions object.
+        """
         return FilePredictionsWithMetrics(
             filename=json["filename"],
             language=json["language"],

--- a/src/extraction/features/predictions/file_predictions.py
+++ b/src/extraction/features/predictions/file_predictions.py
@@ -2,6 +2,9 @@
 
 import dataclasses
 
+from core.benchmark_utils import Metrics
+from extraction.evaluation.evaluation_dataclasses import BoreholeMetadataMetrics
+from extraction.evaluation.groundwater_evaluator import GroundwaterMetrics
 from extraction.features.metadata.metadata import FileMetadata
 from extraction.features.predictions.borehole_predictions import BoreholePredictions
 
@@ -24,3 +27,71 @@ class FilePredictions:
             **self.file_metadata.to_json(),
             "boreholes": [borehole.to_json() for borehole in self.borehole_predictions_list],
         }
+
+
+@dataclasses.dataclass
+class FilePredictionsMetrics:
+    """TODO."""
+
+    layer_metrics: Metrics
+    depth_interval_metrics: Metrics
+    material_description_metrics: Metrics
+    gw_metrics: GroundwaterMetrics
+    metadata_metrics: BoreholeMetadataMetrics
+
+    def to_json(self) -> dict:
+        """Converts the object to a dictionary.
+
+        Returns:
+            dict: The object as a dictionary.
+        """
+        return {
+            "layer_metrics": self.layer_metrics.to_json(),
+            "depth_interval_metrics": self.depth_interval_metrics.to_json(),
+            "material_description_metrics": self.material_description_metrics.to_json(),
+            "gw_metrics": self.gw_metrics.to_json(),
+            "metadata_metrics": self.metadata_metrics.to_json(),
+        }
+
+    @classmethod
+    def from_json(cls, json: dict) -> "FilePredictionsMetrics":
+        """TODO."""
+        return FilePredictionsMetrics(
+            layer_metrics=Metrics.from_json(json["layer_metrics"]),
+            depth_interval_metrics=Metrics.from_json(json["depth_interval_metrics"]),
+            material_description_metrics=Metrics.from_json(json["material_description_metrics"]),
+            gw_metrics=GroundwaterMetrics.from_json(json["gw_metrics"]),
+            metadata_metrics=BoreholeMetadataMetrics.from_json(json["metadata_metrics"]),
+        )
+
+
+@dataclasses.dataclass
+class FilePredictionsWithMetrics:
+    """A class to represent predictions for a single file."""
+
+    language: str
+    filename: str
+    boreholes: list[BoreholePredictions]
+    metrics: FilePredictionsMetrics | None
+
+    def to_json(self) -> dict:
+        """Converts the object to a dictionary.
+
+        Returns:
+            dict: The object as a dictionary.
+        """
+        return {
+            "filename": self.filename,
+            "language": self.language,
+            "boreholes": [borehole.to_json() for borehole in self.boreholes],
+            "metrics": self.metrics.to_json() if self.metrics else None,
+        }
+
+    @classmethod
+    def from_json(cls, json: dict) -> "FilePredictionsWithMetrics":
+        return FilePredictionsWithMetrics(
+            filename=json["filename"],
+            language=json["language"],
+            boreholes=[BoreholePredictions.from_json(bh_data, json["filename"]) for bh_data in json["boreholes"]],
+            metrics=FilePredictionsMetrics.from_json(json["metrics"]),
+        )

--- a/src/extraction/features/predictions/overall_file_predictions.py
+++ b/src/extraction/features/predictions/overall_file_predictions.py
@@ -26,7 +26,7 @@ class OverallFilePredictions:
         """Add file predictions to the list of file predictions.
 
         Args:
-            file_predictions (FilePredictions): The file predictions to add.
+            file_predictions (FilePredictionsWithMetrics): The file predictions to add.
         """
         self.file_predictions_list.append(file_predictions)
 

--- a/src/extraction/features/predictions/overall_file_predictions.py
+++ b/src/extraction/features/predictions/overall_file_predictions.py
@@ -65,6 +65,6 @@ class OverallFilePredictions:
             OverallFilePredictions: The object.
         """
         overall_file_predictions = OverallFilePredictions()
-        for file_data in prediction_from_file.values():
-            overall_file_predictions.add_file_predictions(FilePredictionsWithMetrics.from_json(file_data))
+        for filename, file_data in prediction_from_file.items():
+            overall_file_predictions.add_file_predictions(FilePredictionsWithMetrics.from_json(file_data, filename))
         return overall_file_predictions

--- a/src/extraction/features/predictions/overall_file_predictions.py
+++ b/src/extraction/features/predictions/overall_file_predictions.py
@@ -2,15 +2,11 @@
 
 import dataclasses
 
-from extraction.evaluation.benchmark.ground_truth import GroundTruth
-from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.features.metadata.metadata import FileMetadata
 from extraction.features.predictions.borehole_predictions import (
     BoreholePredictions,
-    FilePredictionsWithGroundTruth,
 )
 from extraction.features.predictions.file_predictions import FilePredictions
-from extraction.features.predictions.predictions import AllBoreholePredictionsWithGroundTruth
 
 
 @dataclasses.dataclass
@@ -79,27 +75,3 @@ class OverallFilePredictions:
 
             overall_file_predictions.add_file_predictions(FilePredictions(borehole_list, file_metadata, file_name))
         return overall_file_predictions
-
-    def match_with_ground_truth(self, ground_truth: GroundTruth) -> AllBoreholePredictionsWithGroundTruth:
-        """Match the extracted boreholes with corresponding boreholes in the ground truth data.
-
-        This is done by comparing the layers of the extracted boreholes with those in the groundtruth.
-
-        Args:
-            ground_truth (GroundTruth): The ground truth.
-
-        Returns:
-            AllBoreholePredictionsWithGroundTruth: all predictions per borehole with associated ground truth data.
-        """
-        files = []
-        for file_predictions in self.file_predictions_list:
-            boreholes = []
-            ground_truth_for_file = ground_truth.for_file(file_predictions.file_name)
-            if ground_truth_for_file:
-                boreholes = LayerEvaluator.match_predictions_with_ground_truth(file_predictions, ground_truth_for_file)
-            files.append(
-                FilePredictionsWithGroundTruth(
-                    file_predictions.file_name, file_predictions.file_metadata.language, boreholes
-                )
-            )
-        return AllBoreholePredictionsWithGroundTruth(files)

--- a/src/extraction/features/predictions/overall_file_predictions.py
+++ b/src/extraction/features/predictions/overall_file_predictions.py
@@ -38,8 +38,7 @@ class OverallFilePredictions:
         """
         return {
             "_".join([file_prediction.filename, str(borehole_prediction.borehole_index)]): {
-                # TODO Add metadata
-                # "file_metadata": file_prediction.file_metadata.to_json(),
+                "file_metadata": file_prediction.file_metadata.to_json(),
                 "borehole_metadata": borehole_prediction.metadata.to_json(),
             }
             for file_prediction in self.file_predictions_list

--- a/src/extraction/features/predictions/overall_file_predictions.py
+++ b/src/extraction/features/predictions/overall_file_predictions.py
@@ -2,18 +2,14 @@
 
 import dataclasses
 
-from extraction.features.metadata.metadata import FileMetadata
-from extraction.features.predictions.borehole_predictions import (
-    BoreholePredictions,
-)
-from extraction.features.predictions.file_predictions import FilePredictions
+from extraction.features.predictions.file_predictions import FilePredictionsWithMetrics
 
 
 @dataclasses.dataclass
 class OverallFilePredictions:
     """A class to represent predictions for all files."""
 
-    file_predictions_list: list[FilePredictions] = dataclasses.field(default_factory=list)
+    file_predictions_list: list[FilePredictionsWithMetrics] = dataclasses.field(default_factory=list)
 
     def contains(self, filename: str) -> bool:
         """Check if `file_predictions_list` contains `filename`.
@@ -24,9 +20,9 @@ class OverallFilePredictions:
         Returns:
             bool: True if `file_predictions_list` contains `filename`, else False.
         """
-        return any(file.file_name == filename for file in self.file_predictions_list)
+        return any(file.filename == filename for file in self.file_predictions_list)
 
-    def add_file_predictions(self, file_predictions: FilePredictions) -> None:
+    def add_file_predictions(self, file_predictions: FilePredictionsWithMetrics) -> None:
         """Add file predictions to the list of file predictions.
 
         Args:
@@ -41,12 +37,13 @@ class OverallFilePredictions:
             dict: The metadata of the predictions as a dictionary.
         """
         return {
-            "_".join([file_prediction.file_name, str(borehole_prediction.borehole_index)]): {
-                "file_metadata": file_prediction.file_metadata.to_json(),
+            "_".join([file_prediction.filename, str(borehole_prediction.borehole_index)]): {
+                # TODO Add metadata
+                # "file_metadata": file_prediction.file_metadata.to_json(),
                 "borehole_metadata": borehole_prediction.metadata.to_json(),
             }
             for file_prediction in self.file_predictions_list
-            for borehole_prediction in file_prediction.borehole_predictions_list
+            for borehole_prediction in file_prediction.boreholes
         }
 
     def to_json(self) -> dict:
@@ -55,7 +52,7 @@ class OverallFilePredictions:
         Returns:
             dict: A dictionary representation of the object.
         """
-        return {fp.file_name: fp.to_json() for fp in self.file_predictions_list}
+        return {fp.filename: fp.to_json() for fp in self.file_predictions_list}
 
     @classmethod
     def from_json(cls, prediction_from_file: dict) -> "OverallFilePredictions":
@@ -68,10 +65,6 @@ class OverallFilePredictions:
             OverallFilePredictions: The object.
         """
         overall_file_predictions = OverallFilePredictions()
-        for file_name, file_data in prediction_from_file.items():
-            file_metadata = FileMetadata.from_json(file_data, file_name)
-
-            borehole_list = [BoreholePredictions.from_json(bh_data, file_name) for bh_data in file_data["boreholes"]]
-
-            overall_file_predictions.add_file_predictions(FilePredictions(borehole_list, file_metadata, file_name))
+        for file_data in prediction_from_file.values():
+            overall_file_predictions.add_file_predictions(FilePredictionsWithMetrics.from_json(file_data))
         return overall_file_predictions

--- a/src/extraction/features/predictions/predictions.py
+++ b/src/extraction/features/predictions/predictions.py
@@ -6,9 +6,6 @@ from collections import defaultdict
 from copy import deepcopy
 from typing import TypeVar
 
-from extraction.evaluation.benchmark.metrics import OverallMetricsCatalog
-from extraction.evaluation.groundwater_evaluator import GroundwaterEvaluator
-from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.features.groundwater.groundwater_extraction import (
     GroundwaterInDocument,
     GroundwatersInBorehole,
@@ -18,11 +15,7 @@ from extraction.features.metadata.coordinate_extraction import Coordinate
 from extraction.features.metadata.elevation_extraction import Elevation
 from extraction.features.metadata.metadata import BoreholeMetadata
 from extraction.features.predictions.borehole_predictions import (
-    BoreholeGroundwaterWithGroundTruth,
-    BoreholeLayersWithGroundTruth,
     BoreholePredictions,
-    FileGroundwaterWithGroundTruth,
-    FileLayersWithGroundTruth,
     FilePredictionsWithGroundTruth,
 )
 from extraction.features.stratigraphy.layer.layer import LayersInBorehole, LayersInDocument
@@ -260,78 +253,3 @@ class AllBoreholePredictionsWithGroundTruth:
     """Class for evaluating all files, after individual boreholes have been match with their ground truth data."""
 
     predictions_list: list[FilePredictionsWithGroundTruth]
-
-    def evaluate_geology(self, verbose: bool = True) -> OverallMetricsCatalog:
-        """Evaluate the borehole extraction predictions.
-
-        Args:
-            verbose (bool): If True, log all metrics for the current evaluation.
-
-        Returns:
-            OverallMetricsCatalog: A OverallMetricsCatalog that maps a metrics name to the corresponding
-            OverallMetrics object. If no ground truth is available, None is returned.
-        """
-        languages = set(fp.language for fp in self.predictions_list)
-        all_metrics = OverallMetricsCatalog(languages=languages)
-
-        layers_list = [
-            FileLayersWithGroundTruth(
-                file.filename,
-                file.language,
-                [
-                    BoreholeLayersWithGroundTruth(
-                        predictions.predictions.layers_in_borehole if predictions.predictions else None,
-                        predictions.ground_truth.get("layers", []),
-                    )
-                    for predictions in file.boreholes
-                ],
-            )
-            for file in self.predictions_list
-        ]
-        evaluator = LayerEvaluator(layers_list)
-        all_metrics.material_description_metrics = evaluator.get_material_description_metrics()
-        all_metrics.depth_interval_metrics = evaluator.get_depth_interval_metrics()
-        all_metrics.layer_metrics = evaluator.get_layer_metrics()
-
-        predictions_by_language = {language: [] for language in languages}
-        for borehole_data in layers_list:
-            # even if metadata can be different for boreholes in the same document, langage is the same (take index 0)
-            predictions_by_language[borehole_data.language].append(borehole_data)
-
-        for language, language_predictions_list in predictions_by_language.items():
-            evaluator = LayerEvaluator(language_predictions_list)
-            setattr(all_metrics, f"{language}_layer_metrics", evaluator.get_layer_metrics())
-            setattr(all_metrics, f"{language}_depth_interval_metrics", evaluator.get_depth_interval_metrics())
-            setattr(
-                all_metrics, f"{language}_material_description_metrics", evaluator.get_material_description_metrics()
-            )
-
-        if verbose:
-            logger.info("Macro avg:")
-            logger.info(
-                "layer f1: %.1f%%, depth interval f1: %.1f%%, material description f1: %.1f%%",
-                all_metrics.layer_metrics.macro_f1() * 100,
-                all_metrics.depth_interval_metrics.macro_f1() * 100,
-                all_metrics.material_description_metrics.macro_f1() * 100,
-            )
-
-        # TODO groundwater should not be in evaluate_geology(), it should be handle by a higher-level function call
-        groundwater_list = [
-            FileGroundwaterWithGroundTruth(
-                file.filename,
-                [
-                    BoreholeGroundwaterWithGroundTruth(
-                        predictions.predictions.groundwater_in_borehole if predictions.predictions else None,
-                        predictions.ground_truth.get("groundwater", []) or [],  # value can be `None`
-                    )
-                    for predictions in file.boreholes
-                ],
-            )
-            for file in self.predictions_list
-        ]
-        overall_groundwater_metrics = GroundwaterEvaluator(groundwater_list).evaluate()
-        all_metrics.groundwater_metrics = overall_groundwater_metrics.groundwater_metrics_to_overall_metrics()
-        all_metrics.groundwater_depth_metrics = (
-            overall_groundwater_metrics.groundwater_depth_metrics_to_overall_metrics()
-        )
-        return all_metrics

--- a/src/extraction/features/predictions/predictions.py
+++ b/src/extraction/features/predictions/predictions.py
@@ -1,6 +1,5 @@
 """This module contains classes for predictions."""
 
-import dataclasses
 import logging
 from collections import defaultdict
 from copy import deepcopy
@@ -16,7 +15,6 @@ from extraction.features.metadata.elevation_extraction import Elevation
 from extraction.features.metadata.metadata import BoreholeMetadata
 from extraction.features.predictions.borehole_predictions import (
     BoreholePredictions,
-    FilePredictionsWithGroundTruth,
 )
 from extraction.features.stratigraphy.layer.layer import LayersInBorehole, LayersInDocument
 from extraction.features.stratigraphy.layer.page_bounding_boxes import PageBoundingBoxes
@@ -246,10 +244,3 @@ class BoreholeListBuilder:
         element_center = (feat.rect.top_left + feat.rect.bottom_right) / 2
         dist = element_center.distance_to(outer_rect)
         return dist
-
-
-@dataclasses.dataclass
-class AllBoreholePredictionsWithGroundTruth:
-    """Class for evaluating all files, after individual boreholes have been match with their ground truth data."""
-
-    predictions_list: list[FilePredictionsWithGroundTruth]

--- a/src/extraction/features/predictions/predictions.py
+++ b/src/extraction/features/predictions/predictions.py
@@ -7,10 +7,8 @@ from copy import deepcopy
 from typing import TypeVar
 
 from extraction.evaluation.benchmark.metrics import OverallMetricsCatalog
-from extraction.evaluation.evaluation_dataclasses import OverallBoreholeMetadataMetrics
 from extraction.evaluation.groundwater_evaluator import GroundwaterEvaluator
 from extraction.evaluation.layer_evaluator import LayerEvaluator
-from extraction.evaluation.metadata_evaluator import MetadataEvaluator
 from extraction.features.groundwater.groundwater_extraction import (
     GroundwaterInDocument,
     GroundwatersInBorehole,
@@ -22,11 +20,9 @@ from extraction.features.metadata.metadata import BoreholeMetadata
 from extraction.features.predictions.borehole_predictions import (
     BoreholeGroundwaterWithGroundTruth,
     BoreholeLayersWithGroundTruth,
-    BoreholeMetadataWithGroundTruth,
     BoreholePredictions,
     FileGroundwaterWithGroundTruth,
     FileLayersWithGroundTruth,
-    FileMetadataWithGroundTruth,
     FilePredictionsWithGroundTruth,
 )
 from extraction.features.stratigraphy.layer.layer import LayersInBorehole, LayersInDocument
@@ -264,28 +260,6 @@ class AllBoreholePredictionsWithGroundTruth:
     """Class for evaluating all files, after individual boreholes have been match with their ground truth data."""
 
     predictions_list: list[FilePredictionsWithGroundTruth]
-
-    def evaluate_metadata_extraction(self) -> OverallBoreholeMetadataMetrics:
-        """Evaluate the metadata extraction of the predictions against the ground truth.
-
-        Returns:
-            OverallBoreholeMetadataMetrics: the computed metrics for the metadata.
-        """
-        metadata_list = [
-            FileMetadataWithGroundTruth(
-                file.filename,
-                [
-                    BoreholeMetadataWithGroundTruth(
-                        predictions.predictions.metadata if predictions.predictions else None,
-                        predictions.ground_truth.get("metadata", {}),
-                    )
-                    for predictions in file.boreholes
-                ],
-            )
-            for file in self.predictions_list
-        ]
-
-        return MetadataEvaluator(metadata_list).evaluate()
 
     def evaluate_geology(self, verbose: bool = True) -> OverallMetricsCatalog:
         """Evaluate the borehole extraction predictions.

--- a/src/extraction/features/stratigraphy/layer/layer.py
+++ b/src/extraction/features/stratigraphy/layer/layer.py
@@ -24,7 +24,7 @@ class LayerDepthsEntry(RectWithPageMixin):
         self.value = value
         self.rect_with_page = RectWithPage(rect, page_number)
 
-    def to_json(self):
+    def to_json(self) -> dict:
         """Convert the LayerDepthsEntry object to a JSON serializable format."""
         return {
             "value": self.value,
@@ -106,7 +106,7 @@ class LayerDepths(ExtractedFeature):
 
         return rect
 
-    def to_json(self):
+    def to_json(self) -> dict:
         """Convert the LayerDepths object to a JSON serializable format."""
         return {"start": self.start.to_json() if self.start else None, "end": self.end.to_json() if self.end else None}
 
@@ -222,7 +222,7 @@ class LayersInBorehole:
 
     layers: list[Layer]
 
-    def to_json(self):
+    def to_json(self) -> dict:
         """Converts the object to a dictionary.
 
         Returns:

--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -179,7 +179,6 @@ class ExtractionPipelineRunner(PipelineRunner[OverallFilePredictions, Extraction
 
         logger.info(f"Metadata written to {self.metadata_path}")
         with open(self.metadata_path, "w", encoding="utf8") as file:
-            # TODO: check that part
             json.dump(run_result.result.get_metadata_as_dict(), file, ensure_ascii=False, indent=2)
 
         if self.options.matching_analytics and self.analytics is not None:

--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -144,23 +144,17 @@ class ExtractionPipelineRunner(PipelineRunner[OverallFilePredictions, Extraction
                 continue
 
             logger.info(f"Processing file: {pdf_file.name}")
-            try:
-                result = extract(
-                    file=pdf_file, filename=pdf_file.name, part=self.options.part, analytics=self.analytics
-                )
-                predictions.add_file_predictions(result.predictions)
 
-                if self.on_file_done is not None:
-                    # Evaluate results
-                    result.predictions = evaluate_prediction(result.predictions, ground_truth)
-                    # Pass updated results to callback
-                    self.on_file_done(result, self.out_directory, pdf_file)
+            result = extract(file=pdf_file, filename=pdf_file.name, part=self.options.part, analytics=self.analytics)
+            prediction_with_metrics = evaluate_prediction(result.predictions, ground_truth)
+            predictions.add_file_predictions(prediction_with_metrics)
 
-                logger.info(f"Writing predictions to tmp JSON file {predictions_path_tmp}")
-                write_json_predictions(path=predictions_path_tmp, predictions=predictions)
+            if self.on_file_done is not None:
+                # Pass updated results to callback
+                self.on_file_done(result, self.out_directory, pdf_file)
 
-            except Exception as e:
-                logger.error(f"Unexpected error in file {pdf_file.name}. Trace: {e}")
+            logger.info(f"Writing predictions to tmp JSON file {predictions_path_tmp}")
+            write_json_predictions(path=predictions_path_tmp, predictions=predictions)
 
         return PipelineRunResult(result=predictions, n_documents=n_documents)
 
@@ -185,7 +179,7 @@ class ExtractionPipelineRunner(PipelineRunner[OverallFilePredictions, Extraction
 
         logger.info(f"Metadata written to {self.metadata_path}")
         with open(self.metadata_path, "w", encoding="utf8") as file:
-            json.dump(run_result.result.get_metadata_as_dict(), file, ensure_ascii=False)
+            json.dump(run_result.result.get_metadata_as_dict(), file, ensure_ascii=False, indent=2)
 
         if self.options.matching_analytics and self.analytics is not None:
             analytics_output_path = self.out_directory / "matching_params_analytics.json"

--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -208,8 +208,7 @@ def run_extraction_predictions(
 
         logger.info(f"Processing file: {pdf_file.name}")
         result = extract(file=pdf_file, filename=pdf_file.name, part=options.part, analytics=analytics)
-        prediction = evaluate_prediction(result.predictions, ground_truth)
-        predictions.add_file_predictions(prediction)
+        predictions.add_file_predictions(result.predictions)
 
         if options.csv:
             all_csv_paths.extend(write_csv_for_file(result.predictions, out_directory))

--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -18,7 +18,7 @@ from extraction.evaluation.benchmark.ground_truth import GroundTruth
 from extraction.evaluation.benchmark.score import (
     ExtractionBenchmarkSummary,
     evaluate_all_predictions,
-    evaluate_single_prediction,
+    evaluate_prediction,
 )
 from extraction.evaluation.benchmark.spec import BenchmarkSpec
 from extraction.features.predictions.file_predictions import FilePredictions
@@ -209,7 +209,7 @@ def run_extraction_predictions(
         logger.info(f"Processing file: {pdf_file.name}")
         try:
             result = extract(file=pdf_file, filename=pdf_file.name, part=options.part, analytics=analytics)
-            prediction = evaluate_single_prediction(result.predictions, ground_truth)
+            prediction = evaluate_prediction(result.predictions, ground_truth)
             predictions.add_file_predictions(prediction)
 
             if options.csv:
@@ -217,7 +217,7 @@ def run_extraction_predictions(
 
             if any_draw:
                 # Run evaluation for current file drawing
-                result.predictions = evaluate_single_prediction(result.predictions, ground_truth)
+                result.predictions = evaluate_prediction(result.predictions, ground_truth)
 
                 draw_file_predictions(
                     result=result,

--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -207,34 +207,30 @@ def run_extraction_predictions(
             continue
 
         logger.info(f"Processing file: {pdf_file.name}")
-        try:
-            result = extract(file=pdf_file, filename=pdf_file.name, part=options.part, analytics=analytics)
-            prediction = evaluate_prediction(result.predictions, ground_truth)
-            predictions.add_file_predictions(prediction)
+        result = extract(file=pdf_file, filename=pdf_file.name, part=options.part, analytics=analytics)
+        prediction = evaluate_prediction(result.predictions, ground_truth)
+        predictions.add_file_predictions(prediction)
 
-            if options.csv:
-                all_csv_paths.extend(write_csv_for_file(result.predictions, out_directory))
+        if options.csv:
+            all_csv_paths.extend(write_csv_for_file(result.predictions, out_directory))
 
-            if any_draw:
-                # Run evaluation for current file drawing
-                result.predictions = evaluate_prediction(result.predictions, ground_truth)
+        if any_draw:
+            # Run evaluation for current file drawing
+            result.predictions = evaluate_prediction(result.predictions, ground_truth)
 
-                draw_file_predictions(
-                    result=result,
-                    file=pdf_file,
-                    filename=pdf_file.name,
-                    out_directory=out_directory,
-                    skip_draw_predictions=options.skip_draw_predictions,
-                    draw_lines=options.draw_lines,
-                    draw_tables=options.draw_tables,
-                    draw_strip_logs=options.draw_strip_logs,
-                )
+            draw_file_predictions(
+                result=result,
+                file=pdf_file,
+                filename=pdf_file.name,
+                out_directory=out_directory,
+                skip_draw_predictions=options.skip_draw_predictions,
+                draw_lines=options.draw_lines,
+                draw_tables=options.draw_tables,
+                draw_strip_logs=options.draw_strip_logs,
+            )
 
-            logger.info(f"Writing predictions to tmp JSON file {predictions_path_tmp}")
-            write_json_predictions(path=predictions_path_tmp, predictions=predictions)
-
-        except Exception as e:
-            logger.error(f"Unexpected error in file {pdf_file.name}. Trace: {e}")
+        logger.info(f"Writing predictions to tmp JSON file {predictions_path_tmp}")
+        write_json_predictions(path=predictions_path_tmp, predictions=predictions)
 
     return predictions, n_documents, all_csv_paths
 

--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -179,6 +179,7 @@ class ExtractionPipelineRunner(PipelineRunner[OverallFilePredictions, Extraction
 
         logger.info(f"Metadata written to {self.metadata_path}")
         with open(self.metadata_path, "w", encoding="utf8") as file:
+            # TODO: check that part
             json.dump(run_result.result.get_metadata_as_dict(), file, ensure_ascii=False, indent=2)
 
         if self.options.matching_analytics and self.analytics is not None:

--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -18,6 +18,7 @@ from extraction.evaluation.benchmark.ground_truth import GroundTruth
 from extraction.evaluation.benchmark.score import (
     ExtractionBenchmarkSummary,
     evaluate_all_predictions,
+    evaluate_single_prediction,
 )
 from extraction.evaluation.benchmark.spec import BenchmarkSpec
 from extraction.features.predictions.file_predictions import FilePredictions
@@ -162,6 +163,7 @@ def run_extraction_predictions(
     out_directory: Path,
     predictions_path_tmp: Path,
     options: ExtractionOptions,
+    ground_truth: GroundTruth | None = None,
     analytics: MatchingParamsAnalytics | None = None,
 ) -> tuple[OverallFilePredictions, int, list[Path]]:
     """Discover PDF files, run extract() on each, and write incremental predictions.
@@ -177,6 +179,7 @@ def run_extraction_predictions(
         predictions_path_tmp (Path): Path to the incremental tmp predictions file. Existing content
             is used to resume; the file is updated after each successfully processed file.
         options (ExtractionOptions): Extraction run options.
+        ground_truth (GroundTruth | None): Ground truth for evaluation.
         analytics (MatchingParamsAnalytics | None, optional): Analytics object for tracking matching
             parameters. Defaults to None.
 
@@ -212,6 +215,9 @@ def run_extraction_predictions(
                 all_csv_paths.extend(write_csv_for_file(result.predictions, out_directory))
 
             if any_draw:
+                # Run evaluation for current file drawing
+                result.predictions = evaluate_single_prediction(result.predictions, ground_truth)
+
                 draw_file_predictions(
                     result=result,
                     file=pdf_file,
@@ -279,6 +285,7 @@ class ExtractionPipelineRunner(PipelineRunner[_ExtractionResult, ExtractionBench
             out_directory=self.out_directory,
             predictions_path_tmp=predictions_path_tmp,
             options=self.options,
+            ground_truth=None,
             analytics=self.analytics,
         )
         return PipelineRunResult(

--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -280,12 +280,13 @@ class ExtractionPipelineRunner(PipelineRunner[_ExtractionResult, ExtractionBench
         )
 
     def run_predictions(self, predictions_path_tmp: Path) -> PipelineRunResult[_ExtractionResult]:
+        ground_truth = GroundTruth(self.ground_truth_path) if self.ground_truth_path else None
         predictions, n_documents, csv_paths = run_extraction_predictions(
             input_directory=self.input_directory,
             out_directory=self.out_directory,
             predictions_path_tmp=predictions_path_tmp,
             options=self.options,
-            ground_truth=None,
+            ground_truth=ground_truth,
             analytics=self.analytics,
         )
         return PipelineRunResult(

--- a/src/extraction/runner.py
+++ b/src/extraction/runner.py
@@ -209,7 +209,8 @@ def run_extraction_predictions(
         logger.info(f"Processing file: {pdf_file.name}")
         try:
             result = extract(file=pdf_file, filename=pdf_file.name, part=options.part, analytics=analytics)
-            predictions.add_file_predictions(result.predictions)
+            prediction = evaluate_single_prediction(result.predictions, ground_truth)
+            predictions.add_file_predictions(prediction)
 
             if options.csv:
                 all_csv_paths.extend(write_csv_for_file(result.predictions, out_directory))

--- a/src/swissgeol_doc_processing/text/textblock.py
+++ b/src/swissgeol_doc_processing/text/textblock.py
@@ -21,7 +21,7 @@ class MaterialDescriptionLine(ExtractedFeature):
 
     text: str
 
-    def to_json(self):
+    def to_json(self) -> dict:
         """Convert the MaterialDescriptionLine object to a JSON serializable dictionary."""
         return {"text": self.text}
 
@@ -65,7 +65,7 @@ class MaterialDescription(ExtractedFeature):
         """Get the bounding rectangle for a specific page."""
         return next((p_rect.rect for p_rect in self.rects_with_pages if p_rect.page_number == page_number), None)
 
-    def to_json(self):
+    def to_json(self) -> dict:
         """Convert the MaterialDescription object to a JSON serializable dictionary."""
         return {"text": self.text, "lines": [line.to_json() for line in self.lines]}
 

--- a/src/swissgeol_doc_processing/text/textline.py
+++ b/src/swissgeol_doc_processing/text/textline.py
@@ -139,7 +139,7 @@ class TextLine(RectWithPageMixin):
 
         return exact_points >= 3 or (exact_points >= 2 and indentation_points >= 1)
 
-    def to_json(self):
+    def to_json(self) -> dict:
         """Convert the TextLine object to a JSON serializable dictionary."""
         return {
             "text": self.text,

--- a/tests/test_groundwater.py
+++ b/tests/test_groundwater.py
@@ -173,48 +173,48 @@ def test_evaluate_multiple_documents(groundtruth, groundwater_at_2m22, groundwat
     gt_matching_index_example = {0: 0}
     gt_matching_index_example_2 = {0: 1, 1: 0}
 
-    overall_metrics = OverallGroundwaterMetrics(
-        [
-            GroundwaterEvaluator.evaluate(
-                FileGroundwaterWithGroundTruth(
-                    filename="example_borehole_profile.pdf",
-                    boreholes=[
-                        BoreholeGroundwaterWithGroundTruth(
-                            groundwater=GroundwatersInBorehole([groundwater_at_2m22, groundwater_at_3m22]),
-                            ground_truth=groundtruth.for_file("example_borehole_profile.pdf").get(
-                                gt_matching_index_example[0]
-                            )["groundwater"],
-                        )
-                    ],
+    gw_1 = GroundwaterEvaluator.evaluate(
+        FileGroundwaterWithGroundTruth(
+            filename="example_borehole_profile.pdf",
+            boreholes=[
+                BoreholeGroundwaterWithGroundTruth(
+                    groundwater=GroundwatersInBorehole([groundwater_at_2m22, groundwater_at_3m22]),
+                    ground_truth=groundtruth.for_file("example_borehole_profile.pdf").get(
+                        gt_matching_index_example[0]
+                    )["groundwater"],
                 )
-            ),
-            GroundwaterEvaluator.evaluate(
-                FileGroundwaterWithGroundTruth(
-                    filename="example_borehole_profile_2.pdf",
-                    boreholes=[
-                        BoreholeGroundwaterWithGroundTruth(
-                            groundwater=GroundwatersInBorehole([groundwater_at_2m22]),
-                            ground_truth=groundtruth.for_file("example_borehole_profile_2.pdf").get(
-                                gt_matching_index_example_2[0]
-                            )["groundwater"],
-                        ),
-                        BoreholeGroundwaterWithGroundTruth(
-                            groundwater=GroundwatersInBorehole([groundwater_at_3m22]),
-                            ground_truth=groundtruth.for_file("example_borehole_profile_2.pdf").get(
-                                gt_matching_index_example_2[1]
-                            )["groundwater"],
-                        ),
-                    ],
+            ],
+        )
+    )
+    gw_2 = GroundwaterEvaluator.evaluate(
+        FileGroundwaterWithGroundTruth(
+            filename="example_borehole_profile_2.pdf",
+            boreholes=[
+                BoreholeGroundwaterWithGroundTruth(
+                    groundwater=GroundwatersInBorehole([groundwater_at_2m22]),
+                    ground_truth=groundtruth.for_file("example_borehole_profile_2.pdf").get(
+                        gt_matching_index_example_2[0]
+                    )["groundwater"],
                 ),
-            ),
-        ]
+                BoreholeGroundwaterWithGroundTruth(
+                    groundwater=GroundwatersInBorehole([groundwater_at_3m22]),
+                    ground_truth=groundtruth.for_file("example_borehole_profile_2.pdf").get(
+                        gt_matching_index_example_2[1]
+                    )["groundwater"],
+                ),
+            ],
+        ),
     )
 
     # Assertions
-    assert len(overall_metrics.groundwater_metrics) == 2
-    assert overall_metrics.groundwater_metrics[0].filename == "example_borehole_profile.pdf"
-    assert overall_metrics.groundwater_metrics[1].filename == "example_borehole_profile_2.pdf"
-    assert overall_metrics.groundwater_metrics[0].groundwater_metrics.f1 == 1.0
-    assert overall_metrics.groundwater_metrics[1].groundwater_metrics.tp == 2.0
-    assert overall_metrics.groundwater_metrics[1].groundwater_metrics.fn == 0.0
-    assert overall_metrics.groundwater_metrics[1].groundwater_metrics.fp == 0.0
+    assert gw_1.filename == "example_borehole_profile.pdf"
+    assert gw_1.groundwater_metrics.f1 == 1.0
+    assert gw_1.groundwater_metrics.tp == 2.0
+    assert gw_1.groundwater_metrics.fn == 0.0
+    assert gw_1.groundwater_metrics.fp == 0.0
+
+    assert gw_2.filename == "example_borehole_profile_2.pdf"
+    assert gw_2.groundwater_metrics.f1 == 1.0
+    assert gw_2.groundwater_metrics.tp == 2.0
+    assert gw_2.groundwater_metrics.fn == 0.0
+    assert gw_2.groundwater_metrics.fp == 0.0

--- a/tests/test_groundwater.py
+++ b/tests/test_groundwater.py
@@ -8,8 +8,6 @@ from core.benchmark_utils import Metrics
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
 from extraction.evaluation.groundwater_evaluator import (
     GroundwaterEvaluator,
-    GroundwaterMetrics,
-    OverallGroundwaterMetrics,
 )
 from extraction.features.groundwater.groundwater_extraction import Groundwater, GroundwatersInBorehole
 from extraction.features.groundwater.utility import extract_date
@@ -85,80 +83,33 @@ def test_extract_date(date_test_cases):
         assert extract_date(text) == (expected_date, expected_str)
 
 
-def test_add_groundwater_metrics(sample_metrics):
-    """Test adding GroundwaterMetrics to OverallGroundwaterMetrics."""
-    overall_metrics = OverallGroundwaterMetrics()
-    gw_metrics = GroundwaterMetrics(
-        groundwater_metrics=sample_metrics,
-        groundwater_depth_metrics=sample_metrics,
-        groundwater_elevation_metrics=sample_metrics,
-        groundwater_date_metrics=sample_metrics,
-        filename="test_file_1",
-    )
-    overall_metrics.add_groundwater_metrics(gw_metrics)
-    assert len(overall_metrics.groundwater_metrics) == 1
-    assert overall_metrics.groundwater_metrics[0].filename == "test_file_1"
-
-
-def test_groundwater_metrics_to_overall_metrics(sample_metrics):
-    """Test conversion of groundwater metrics to OverallMetrics."""
-    overall_metrics = OverallGroundwaterMetrics()
-    gw_metrics1 = GroundwaterMetrics(groundwater_metrics=sample_metrics, filename="file1")
-    gw_metrics2 = GroundwaterMetrics(groundwater_metrics=sample_metrics, filename="file2")
-    overall_metrics.add_groundwater_metrics(gw_metrics1)
-    overall_metrics.add_groundwater_metrics(gw_metrics2)
-    overall = overall_metrics.groundwater_metrics_to_overall_metrics()
-    assert "file1" in overall.metrics
-    assert "file2" in overall.metrics
-    assert overall.metrics["file1"] == gw_metrics1.groundwater_metrics
-    assert overall.metrics["file2"] == gw_metrics2.groundwater_metrics
-
-
-def test_groundwater_depth_metrics_to_overall_metrics(sample_metrics):
-    """Test conversion of groundwater depth metrics to OverallMetrics."""
-    overall_metrics = OverallGroundwaterMetrics()
-    gw_metrics = GroundwaterMetrics(groundwater_depth_metrics=sample_metrics, filename="file_depth")
-    overall_metrics.add_groundwater_metrics(gw_metrics)
-    overall = overall_metrics.groundwater_depth_metrics_to_overall_metrics()
-    assert "file_depth" in overall.metrics
-    assert overall.metrics["file_depth"] == gw_metrics.groundwater_depth_metrics
-
-
 def test_evaluate_with_ground_truth(groundtruth, groundwater_at_2m22, groundwater_at_3m22):
     """Test the evaluate method with available ground truth data."""
     # In this test, there is one borehole, with two groundwater measurement for it.
-    groundwater_entries = {
-        "example_borehole_profile.pdf": [GroundwatersInBorehole([groundwater_at_2m22, groundwater_at_3m22])]
-    }
+    groundwaterinborehole_list = [GroundwatersInBorehole([groundwater_at_2m22, groundwater_at_3m22])]
 
     # dictionary used to "manually" build the FileGroundwaterWithGroundTruth object
-    pred_to_gt_matching = {"example_borehole_profile.pdf": {0: 0}}
+    filename = "example_borehole_profile.pdf"
+    pred_to_gt_matching = {filename: {0: 0}}
 
-    overall_metrics = OverallGroundwaterMetrics(
-        [
-            GroundwaterEvaluator.evaluate(
-                FileGroundwaterWithGroundTruth(
-                    filename=filename,
-                    boreholes=[
-                        BoreholeGroundwaterWithGroundTruth(
-                            groundwater=groundwaterinborehole,
-                            ground_truth=groundtruth.for_file(filename).get(pred_to_gt_matching[filename][pred_idx])[
-                                "groundwater"
-                            ],
-                        )
-                        for pred_idx, groundwaterinborehole in enumerate(groundwaterinborehole_list)
+    groundwater_metric = GroundwaterEvaluator.evaluate(
+        FileGroundwaterWithGroundTruth(
+            filename=filename,
+            boreholes=[
+                BoreholeGroundwaterWithGroundTruth(
+                    groundwater=groundwaterinborehole,
+                    ground_truth=groundtruth.for_file(filename).get(pred_to_gt_matching[filename][pred_idx])[
+                        "groundwater"
                     ],
                 )
-            )
-            for filename, groundwaterinborehole_list in groundwater_entries.items()
-        ]
+                for pred_idx, groundwaterinborehole in enumerate(groundwaterinborehole_list)
+            ],
+        )
     )
 
     # Assertions
-    assert isinstance(overall_metrics, OverallGroundwaterMetrics)
-    assert len(overall_metrics.groundwater_metrics) == 1
-    assert overall_metrics.groundwater_metrics[0].filename == "example_borehole_profile.pdf"
-    assert overall_metrics.groundwater_metrics[0].groundwater_metrics.precision == 1.0
+    assert groundwater_metric.filename == filename
+    assert groundwater_metric.groundwater_metrics.precision == 1.0
 
 
 def test_evaluate_multiple_documents(groundtruth, groundwater_at_2m22, groundwater_at_3m22):

--- a/tests/test_groundwater.py
+++ b/tests/test_groundwater.py
@@ -133,24 +133,26 @@ def test_evaluate_with_ground_truth(groundtruth, groundwater_at_2m22, groundwate
 
     # dictionary used to "manually" build the FileGroundwaterWithGroundTruth object
     pred_to_gt_matching = {"example_borehole_profile.pdf": {0: 0}}
-    evaluator = GroundwaterEvaluator(
-        groundwater_list=[
-            FileGroundwaterWithGroundTruth(
-                filename=filename,
-                boreholes=[
-                    BoreholeGroundwaterWithGroundTruth(
-                        groundwater=groundwaterinborehole,
-                        ground_truth=groundtruth.for_file(filename).get(pred_to_gt_matching[filename][pred_idx])[
-                            "groundwater"
-                        ],
-                    )
-                    for pred_idx, groundwaterinborehole in enumerate(groundwaterinborehole_list)
-                ],
+
+    overall_metrics = OverallGroundwaterMetrics(
+        [
+            GroundwaterEvaluator.evaluate(
+                FileGroundwaterWithGroundTruth(
+                    filename=filename,
+                    boreholes=[
+                        BoreholeGroundwaterWithGroundTruth(
+                            groundwater=groundwaterinborehole,
+                            ground_truth=groundtruth.for_file(filename).get(pred_to_gt_matching[filename][pred_idx])[
+                                "groundwater"
+                            ],
+                        )
+                        for pred_idx, groundwaterinborehole in enumerate(groundwaterinborehole_list)
+                    ],
+                )
             )
             for filename, groundwaterinborehole_list in groundwater_entries.items()
         ]
     )
-    overall_metrics = evaluator.evaluate()
 
     # Assertions
     assert isinstance(overall_metrics, OverallGroundwaterMetrics)
@@ -170,39 +172,43 @@ def test_evaluate_multiple_documents(groundtruth, groundwater_at_2m22, groundwat
     # Sample groundwater entries
     gt_matching_index_example = {0: 0}
     gt_matching_index_example_2 = {0: 1, 1: 0}
-    evaluator = GroundwaterEvaluator(
-        groundwater_list=[
-            FileGroundwaterWithGroundTruth(
-                filename="example_borehole_profile.pdf",
-                boreholes=[
-                    BoreholeGroundwaterWithGroundTruth(
-                        groundwater=GroundwatersInBorehole([groundwater_at_2m22, groundwater_at_3m22]),
-                        ground_truth=groundtruth.for_file("example_borehole_profile.pdf").get(
-                            gt_matching_index_example[0]
-                        )["groundwater"],
-                    )
-                ],
+
+    overall_metrics = OverallGroundwaterMetrics(
+        [
+            GroundwaterEvaluator.evaluate(
+                FileGroundwaterWithGroundTruth(
+                    filename="example_borehole_profile.pdf",
+                    boreholes=[
+                        BoreholeGroundwaterWithGroundTruth(
+                            groundwater=GroundwatersInBorehole([groundwater_at_2m22, groundwater_at_3m22]),
+                            ground_truth=groundtruth.for_file("example_borehole_profile.pdf").get(
+                                gt_matching_index_example[0]
+                            )["groundwater"],
+                        )
+                    ],
+                )
             ),
-            FileGroundwaterWithGroundTruth(
-                filename="example_borehole_profile_2.pdf",
-                boreholes=[
-                    BoreholeGroundwaterWithGroundTruth(
-                        groundwater=GroundwatersInBorehole([groundwater_at_2m22]),
-                        ground_truth=groundtruth.for_file("example_borehole_profile_2.pdf").get(
-                            gt_matching_index_example_2[0]
-                        )["groundwater"],
-                    ),
-                    BoreholeGroundwaterWithGroundTruth(
-                        groundwater=GroundwatersInBorehole([groundwater_at_3m22]),
-                        ground_truth=groundtruth.for_file("example_borehole_profile_2.pdf").get(
-                            gt_matching_index_example_2[1]
-                        )["groundwater"],
-                    ),
-                ],
+            GroundwaterEvaluator.evaluate(
+                FileGroundwaterWithGroundTruth(
+                    filename="example_borehole_profile_2.pdf",
+                    boreholes=[
+                        BoreholeGroundwaterWithGroundTruth(
+                            groundwater=GroundwatersInBorehole([groundwater_at_2m22]),
+                            ground_truth=groundtruth.for_file("example_borehole_profile_2.pdf").get(
+                                gt_matching_index_example_2[0]
+                            )["groundwater"],
+                        ),
+                        BoreholeGroundwaterWithGroundTruth(
+                            groundwater=GroundwatersInBorehole([groundwater_at_3m22]),
+                            ground_truth=groundtruth.for_file("example_borehole_profile_2.pdf").get(
+                                gt_matching_index_example_2[1]
+                            )["groundwater"],
+                        ),
+                    ],
+                ),
             ),
         ]
     )
-    overall_metrics = evaluator.evaluate()
 
     # Assertions
     assert len(overall_metrics.groundwater_metrics) == 2

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -7,7 +7,6 @@ import pymupdf
 import pytest
 
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
-from extraction.evaluation.evaluator import Evaluator
 from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.evaluation.utility import evaluate, evaluate_single
 from extraction.features.groundwater.groundwater_extraction import Groundwater, GroundwatersInBorehole
@@ -21,7 +20,6 @@ from extraction.features.predictions.borehole_predictions import (
 )
 from extraction.features.predictions.file_predictions import FilePredictions
 from extraction.features.predictions.overall_file_predictions import OverallFilePredictions
-from extraction.features.predictions.predictions import AllBoreholePredictionsWithGroundTruth
 from extraction.features.stratigraphy.layer.continuation_detection import merge_boreholes
 from extraction.features.stratigraphy.layer.layer import (
     ExtractedBorehole,
@@ -248,16 +246,6 @@ def test_evaluate_layer_matching(
             for pred in sample_file_prediction_with_ground_truth
         ]
     )
-
-
-def test_evaluate_metadata_extraction(sample_file_prediction_with_ground_truth: FilePredictionsWithGroundTruth):
-    """Test evaluate_metadata_extraction method of OverallFilePredictions."""
-    all_predictions_with_gt = AllBoreholePredictionsWithGroundTruth([sample_file_prediction_with_ground_truth])
-    geology_metrics, metadata_metrics = Evaluator.evaluate_overall(all_predictions_with_gt)
-
-    # Ensure the evaluation returns a result
-    assert metadata_metrics is not None
-    assert geology_metrics is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -345,11 +345,11 @@ def test_groundwater_metrics_to_overall_metrics(sample_metrics):
         groundwater_depth_metrics=sample_metrics,
     )
 
-    assert filename in overall.material_description_metric
-    assert filename in overall.layer_metrics
-    assert filename in overall.depth_interval_metric
-    assert filename in overall.elevation_metric
-    assert filename in overall.coordinates_metric
-    assert filename in overall.name_metric
-    assert filename in overall.groundwater_metrics
-    assert filename in overall.groundwater_depth_metrics
+    assert filename in overall.material_description_metrics.metrics
+    assert filename in overall.layer_metrics.metrics
+    assert filename in overall.depth_interval_metrics.metrics
+    assert filename in overall.elevation_metrics.metrics
+    assert filename in overall.coordinates_metrics.metrics
+    assert filename in overall.name_metrics.metrics
+    assert filename in overall.groundwater_metrics.metrics
+    assert filename in overall.groundwater_depth_metrics.metrics

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -6,7 +6,9 @@ from unittest.mock import Mock
 import pymupdf
 import pytest
 
+from core.benchmark_utils import Metrics
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
+from extraction.evaluation.benchmark.metrics import OverallMetricsCatalog
 from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.evaluation.utility import evaluate, evaluate_single
 from extraction.features.groundwater.groundwater_extraction import Groundwater, GroundwatersInBorehole
@@ -31,6 +33,12 @@ from swissgeol_doc_processing.text.textblock import MaterialDescription
 from swissgeol_doc_processing.text.textline import TextLine, TextWord
 from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 from swissgeol_doc_processing.utils.file_utils import read_params
+
+
+@pytest.fixture
+def sample_metrics():
+    """Sample metrics for testing."""
+    return Metrics(tp=3, fn=2, fp=1)
 
 
 @pytest.fixture
@@ -318,3 +326,30 @@ def test_merge_boreholes():
     assert merged_boreholes[0].predictions[1].material_description.text == "second layer"
     assert merged_boreholes[0].predictions[1].depths.start.value == 1
     assert merged_boreholes[0].predictions[1].depths.end.value == 2
+
+
+def test_groundwater_metrics_to_overall_metrics(sample_metrics):
+    """Test adding single datapoint to overall metric."""
+    filename = "file"
+    overall = OverallMetricsCatalog(languages=[])
+
+    overall.add_datapoint(
+        filename=filename,
+        material_description_metric=sample_metrics,
+        layer_metrics=sample_metrics,
+        depth_interval_metric=sample_metrics,
+        elevation_metric=sample_metrics,
+        coordinates_metric=sample_metrics,
+        name_metric=sample_metrics,
+        groundwater_metrics=sample_metrics,
+        groundwater_depth_metrics=sample_metrics,
+    )
+
+    assert filename in overall.material_description_metric
+    assert filename in overall.layer_metrics
+    assert filename in overall.depth_interval_metric
+    assert filename in overall.elevation_metric
+    assert filename in overall.coordinates_metric
+    assert filename in overall.name_metric
+    assert filename in overall.groundwater_metrics
+    assert filename in overall.groundwater_depth_metrics

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -19,7 +19,6 @@ from extraction.features.predictions.borehole_predictions import (
     FilePredictionsWithGroundTruth,
 )
 from extraction.features.predictions.file_predictions import FilePredictions
-from extraction.features.predictions.overall_file_predictions import OverallFilePredictions
 from extraction.features.stratigraphy.layer.continuation_detection import merge_boreholes
 from extraction.features.stratigraphy.layer.layer import (
     ExtractedBorehole,
@@ -218,17 +217,6 @@ def test_to_json(sample_file_prediction: FilePredictions):
     assert result["boreholes"][0]["metadata"]["coordinates"]["E"] == 2789456
     assert result["language"] == "en"
     assert result["boreholes"][0]["metadata"]["name"]["name"] == "SST KB5"
-
-
-def test_overall_file_predictions(sample_file_prediction: FilePredictions):
-    """Test OverallFilePredictions class functionality."""
-    overall_predictions = OverallFilePredictions()
-
-    overall_predictions.add_file_predictions(sample_file_prediction)
-    result = overall_predictions.to_json()
-
-    assert len(result) == 1
-    assert set(result.keys()) == {"example_borehole_profile.pdf"}
 
 
 def test_evaluate_layer_matching(

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -7,6 +7,7 @@ import pymupdf
 import pytest
 
 from extraction.evaluation.benchmark.ground_truth import GroundTruth
+from extraction.evaluation.evaluator import Evaluator
 from extraction.evaluation.layer_evaluator import LayerEvaluator
 from extraction.evaluation.utility import evaluate, evaluate_single
 from extraction.features.groundwater.groundwater_extraction import Groundwater, GroundwatersInBorehole
@@ -237,8 +238,8 @@ def test_evaluate_layer_matching(
 ):
     """Test the matching of predictions to ground truths when multiple boreholes are present in one document."""
     groundtruth_for_file = groundtruth_with_two_boreholes.for_file("example_borehole_profile.pdf")
-    sample_file_prediction_with_ground_truth: FilePredictionsWithGroundTruth = (
-        LayerEvaluator.match_predictions_with_ground_truth(file_prediction_with_two_boreholes, groundtruth_for_file)
+    sample_file_prediction_with_ground_truth: list[BoreholePredictionsWithGroundTruth] = (
+        LayerEvaluator.match_boreholes_to_ground_truth(file_prediction_with_two_boreholes, groundtruth_for_file)
     )
     # We test the matching by comparing the number of layers, one borehole has 2, the other has 3.
     assert all(
@@ -252,9 +253,11 @@ def test_evaluate_layer_matching(
 def test_evaluate_metadata_extraction(sample_file_prediction_with_ground_truth: FilePredictionsWithGroundTruth):
     """Test evaluate_metadata_extraction method of OverallFilePredictions."""
     all_predictions_with_gt = AllBoreholePredictionsWithGroundTruth([sample_file_prediction_with_ground_truth])
-    metadata_metrics = all_predictions_with_gt.evaluate_metadata_extraction()
+    geology_metrics, metadata_metrics = Evaluator.evaluate_overall(all_predictions_with_gt)
 
-    assert metadata_metrics is not None  # Ensure the evaluation returns a result
+    # Ensure the evaluation returns a result
+    assert metadata_metrics is not None
+    assert geology_metrics is not None
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -7,8 +7,116 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-23T11:03:45.764808Z"
+exclude-newer = "2026-04-07T09:23:38.110214Z"
 exclude-newer-span = "P7D"
+
+[[package]]
+name = "accelerate"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/66/be171836d86dc5b8698b3a9bf4b9eb10cb53369729939f88bf650167588b/accelerate-1.10.0.tar.gz", hash = "sha256:8270568fda9036b5cccdc09703fef47872abccd56eb5f6d53b54ea5fb7581496", size = 392261, upload-time = "2025-08-07T10:54:51.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/dd/0107f0aa179869ee9f47ef5a2686abd5e022fdc82af901d535e52fe91ce1/accelerate-1.10.0-py3-none-any.whl", hash = "sha256:260a72b560e100e839b517a331ec85ed495b3889d12886e79d1913071993c5a3", size = 374718, upload-time = "2025-08-07T10:54:49.988Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/f5/a20c4ac64aeaef1679e25c9983573618ff765d7aa829fa2b84ae7573169e/aiohttp-3.13.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ab7229b6f9b5c1ba4910d6c41a9eb11f543eadb3f384df1b4c293f4e73d44d6", size = 757513, upload-time = "2026-03-31T21:57:02.146Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/39fa6c6b179b53fcb3e4b3d2b6d6cad0180854eda17060c7218540102bef/aiohttp-3.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f14c50708bb156b3a3ca7230b3d820199d56a48e3af76fa21c2d6087190fe3d", size = 506748, upload-time = "2026-03-31T21:57:04.275Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/e38ce072e724fd7add6243613f8d1810da084f54175353d25ccf9f9c7e5a/aiohttp-3.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7d2f8616f0ff60bd332022279011776c3ac0faa0f1b463f7bb12326fbc97a1c", size = 501673, upload-time = "2026-03-31T21:57:06.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ba/3bc7525d7e2beaa11b309a70d48b0d3cfc3c2089ec6a7d0820d59c657053/aiohttp-3.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2567b72e1ffc3ab25510db43f355b29eeada56c0a622e58dcdb19530eb0a3cb", size = 1763757, upload-time = "2026-03-31T21:57:07.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ab/e87744cf18f1bd78263aba24924d4953b41086bd3a31d22452378e9028a0/aiohttp-3.13.5-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fb0540c854ac9c0c5ad495908fdfd3e332d553ec731698c0e29b1877ba0d2ec6", size = 1720152, upload-time = "2026-03-31T21:57:09.946Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f3/ed17a6f2d742af17b50bae2d152315ed1b164b07a5fd5cc1754d99e4dfa5/aiohttp-3.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9883051c6972f58bfc4ebb2116345ee2aa151178e99c3f2b2bbe2af712abd13", size = 1818010, upload-time = "2026-03-31T21:57:12.157Z" },
+    { url = "https://files.pythonhosted.org/packages/53/06/ecbc63dc937192e2a5cb46df4d3edb21deb8225535818802f210a6ea5816/aiohttp-3.13.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2294172ce08a82fb7c7273485895de1fa1186cc8294cfeb6aef4af42ad261174", size = 1907251, upload-time = "2026-03-31T21:57:14.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a5/0521aa32c1ddf3aa1e71dcc466be0b7db2771907a13f18cddaa45967d97b/aiohttp-3.13.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a807cabd5115fb55af198b98178997a5e0e57dead43eb74a93d9c07d6d4a7dc", size = 1759969, upload-time = "2026-03-31T21:57:16.146Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/78/a38f8c9105199dd3b9706745865a8a59d0041b6be0ca0cc4b2ccf1bab374/aiohttp-3.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6d0d932e0f39c02b80744273cd5c388a2d9bc07760a03164f229c8e02662f6", size = 1616871, upload-time = "2026-03-31T21:57:17.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/41/27392a61ead8ab38072105c71aa44ff891e71653fe53d576a7067da2b4e8/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60869c7ac4aaabe7110f26499f3e6e5696eae98144735b12a9c3d9eae2b51a49", size = 1739844, upload-time = "2026-03-31T21:57:19.679Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/55/5564e7ae26d94f3214250009a0b1c65a0c6af4bf88924ccb6fdab901de28/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:26d2f8546f1dfa75efa50c3488215a903c0168d253b75fba4210f57ab77a0fb8", size = 1731969, upload-time = "2026-03-31T21:57:22.006Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/c5/705a3929149865fc941bcbdd1047b238e4a72bcb215a9b16b9d7a2e8d992/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1162a1492032c82f14271e831c8f4b49f2b6078f4f5fc74de2c912fa225d51d", size = 1795193, upload-time = "2026-03-31T21:57:24.256Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/19/edabed62f718d02cff7231ca0db4ef1c72504235bc467f7b67adb1679f48/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8b14eb3262fad0dc2f89c1a43b13727e709504972186ff6a99a3ecaa77102b6c", size = 1606477, upload-time = "2026-03-31T21:57:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/de/fc/76f80ef008675637d88d0b21584596dc27410a990b0918cb1e5776545b5b/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ca9ac61ac6db4eb6c2a0cd1d0f7e1357647b638ccc92f7e9d8d133e71ed3c6ac", size = 1813198, upload-time = "2026-03-31T21:57:28.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/67/5b3ac26b80adb20ea541c487f73730dc8fa107d632c998f25bbbab98fcda/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7996023b2ed59489ae4762256c8516df9820f751cf2c5da8ed2fb20ee50abab3", size = 1752321, upload-time = "2026-03-31T21:57:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/88/06/e4a2e49255ea23fa4feeb5ab092d90240d927c15e47b5b5c48dff5a9ce29/aiohttp-3.13.5-cp311-cp311-win32.whl", hash = "sha256:77dfa48c9f8013271011e51c00f8ada19851f013cde2c48fca1ba5e0caf5bb06", size = 439069, upload-time = "2026-03-31T21:57:32.388Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/43/8c7163a596dab4f8be12c190cf467a1e07e4734cf90eebb39f7f5d53fc6a/aiohttp-3.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:d3a4834f221061624b8887090637db9ad4f61752001eae37d56c52fddade2dc8", size = 462859, upload-time = "2026-03-31T21:57:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6f/353954c29e7dcce7cf00280a02c75f30e133c00793c7a2ed3776d7b2f426/aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9", size = 748876, upload-time = "2026-03-31T21:57:36.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1b/428a7c64687b3b2e9cd293186695affc0e1e54a445d0361743b231f11066/aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416", size = 499557, upload-time = "2026-03-31T21:57:38.236Z" },
+    { url = "https://files.pythonhosted.org/packages/29/47/7be41556bfbb6917069d6a6634bb7dd5e163ba445b783a90d40f5ac7e3a7/aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2", size = 500258, upload-time = "2026-03-31T21:57:39.923Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/c9ecc5828cb0b3695856c07c0a6817a99d51e2473400f705275a2b3d9239/aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4", size = 1749199, upload-time = "2026-03-31T21:57:41.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/3c6d610e66b495657622edb6ae7c7fd31b2e9086b4ec50b47897ad6042a9/aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9", size = 1721013, upload-time = "2026-03-31T21:57:43.904Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a0/24409c12217456df0bae7babe3b014e460b0b38a8e60753d6cb339f6556d/aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5", size = 1781501, upload-time = "2026-03-31T21:57:46.285Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9d/b65ec649adc5bccc008b0957a9a9c691070aeac4e41cea18559fef49958b/aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e", size = 1878981, upload-time = "2026-03-31T21:57:48.734Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1", size = 1767934, upload-time = "2026-03-31T21:57:51.171Z" },
+    { url = "https://files.pythonhosted.org/packages/31/04/d3f8211f273356f158e3464e9e45484d3fb8c4ce5eb2f6fe9405c3273983/aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286", size = 1566671, upload-time = "2026-03-31T21:57:53.326Z" },
+    { url = "https://files.pythonhosted.org/packages/41/db/073e4ebe00b78e2dfcacff734291651729a62953b48933d765dc513bf798/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9", size = 1705219, upload-time = "2026-03-31T21:57:55.385Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/7dfba71a2f9fd97b15c95c06819de7eb38113d2cdb6319669195a7d64270/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88", size = 1743049, upload-time = "2026-03-31T21:57:57.341Z" },
+    { url = "https://files.pythonhosted.org/packages/18/71/901db0061e0f717d226386a7f471bb59b19566f2cae5f0d93874b017271f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3", size = 1749557, upload-time = "2026-03-31T21:57:59.626Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d5/41eebd16066e59cd43728fe74bce953d7402f2b4ddfdfef2c0e9f17ca274/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b", size = 1558931, upload-time = "2026-03-31T21:58:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e6/4a799798bf05740e66c3a1161079bda7a3dd8e22ca392481d7a7f9af82a6/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe", size = 1774125, upload-time = "2026-03-31T21:58:04.007Z" },
+    { url = "https://files.pythonhosted.org/packages/84/63/7749337c90f92bc2cb18f9560d67aa6258c7060d1397d21529b8004fcf6f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14", size = 1732427, upload-time = "2026-03-31T21:58:06.337Z" },
+    { url = "https://files.pythonhosted.org/packages/98/de/cf2f44ff98d307e72fb97d5f5bbae3bfcb442f0ea9790c0bf5c5c2331404/aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3", size = 433534, upload-time = "2026-03-31T21:58:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/eadf6f9c8fa5e31d40993e3db153fb5ed0b11008ad5d9de98a95045bed84/aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1", size = 460446, upload-time = "2026-03-31T21:58:10.945Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e9/d76bf503005709e390122d34e15256b88f7008e246c4bdbe915cd4f1adce/aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61", size = 742930, upload-time = "2026-03-31T21:58:13.155Z" },
+    { url = "https://files.pythonhosted.org/packages/57/00/4b7b70223deaebd9bb85984d01a764b0d7bd6526fcdc73cca83bcbe7243e/aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832", size = 496927, upload-time = "2026-03-31T21:58:15.073Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f5/0fb20fb49f8efdcdce6cd8127604ad2c503e754a8f139f5e02b01626523f/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9", size = 497141, upload-time = "2026-03-31T21:58:17.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090", size = 1732476, upload-time = "2026-03-31T21:58:18.925Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e5/4e161f84f98d80c03a238671b4136e6530453d65262867d989bbe78244d0/aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b", size = 1706507, upload-time = "2026-03-31T21:58:21.094Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/56/ea11a9f01518bd5a2a2fcee869d248c4b8a0cfa0bb13401574fa31adf4d4/aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a", size = 1773465, upload-time = "2026-03-31T21:58:23.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/40/333ca27fb74b0383f17c90570c748f7582501507307350a79d9f9f3c6eb1/aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8", size = 1873523, upload-time = "2026-03-31T21:58:25.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665", size = 1754113, upload-time = "2026-03-31T21:58:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/56/3f653d7f53c89669301ec9e42c95233e2a0c0a6dd051269e6e678db4fdb0/aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540", size = 1562351, upload-time = "2026-03-31T21:58:29.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a6/9b3e91eb8ae791cce4ee736da02211c85c6f835f1bdfac0594a8a3b7018c/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb", size = 1693205, upload-time = "2026-03-31T21:58:32.214Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fc/bfb437a99a2fcebd6b6eaec609571954de2ed424f01c352f4b5504371dd3/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46", size = 1730618, upload-time = "2026-03-31T21:58:34.728Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b6/c8534862126191a034f68153194c389addc285a0f1347d85096d349bbc15/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8", size = 1745185, upload-time = "2026-03-31T21:58:36.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/93/4ca8ee2ef5236e2707e0fd5fecb10ce214aee1ff4ab307af9c558bda3b37/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d", size = 1557311, upload-time = "2026-03-31T21:58:39.38Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ae/76177b15f18c5f5d094f19901d284025db28eccc5ae374d1d254181d33f4/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6", size = 1773147, upload-time = "2026-03-31T21:58:41.476Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a4/62f05a0a98d88af59d93b7fcac564e5f18f513cb7471696ac286db970d6a/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c", size = 1730356, upload-time = "2026-03-31T21:58:44.049Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/85/fc8601f59dfa8c9523808281f2da571f8b4699685f9809a228adcc90838d/aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc", size = 432637, upload-time = "2026-03-31T21:58:46.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/ac685a8882896acf0f6b31d689e3792199cfe7aba37969fa91da63a7fa27/aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83", size = 458896, upload-time = "2026-03-31T21:58:48.119Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
 
 [[package]]
 name = "alembic"
@@ -44,6 +152,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -496,6 +613,39 @@ wheels = [
 ]
 
 [[package]]
+name = "datasets"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/9d/348ed92110ba5f9b70b51ca1078d4809767a835aa2b7ce7e74ad2b98323d/datasets-4.0.0.tar.gz", hash = "sha256:9657e7140a9050db13443ba21cb5de185af8af944479b00e7ff1e00a61c8dbf1", size = 569566, upload-time = "2025-07-09T14:35:52.431Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/62/eb8157afb21bd229c864521c1ab4fa8e9b4f1b06bafdd8c4668a7a31b5dd/datasets-4.0.0-py3-none-any.whl", hash = "sha256:7ef95e62025fd122882dbce6cb904c8cd3fbc829de6669a5eb939c77d50e203d", size = 494825, upload-time = "2025-07-09T14:35:50.658Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/4d/ac7ffa80c69ea1df30a8aa11b3578692a5118e7cd1aa157e3ef73b092d15/dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca", size = 184847, upload-time = "2024-01-27T23:42:16.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7a/cef76fd8438a42f96db64ddaa85280485a9c395e7df3db8158cfec1eee34/dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7", size = 116252, upload-time = "2024-01-27T23:42:14.239Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -675,6 +825,93 @@ wheels = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/03/077f869d540370db12165c0aa51640a873fb661d8b315d1d4d67b284d7ac/frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84", size = 86912, upload-time = "2025-10-06T05:35:45.98Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b5/7610b6bd13e4ae77b96ba85abea1c8cb249683217ef09ac9e0ae93f25a91/frozenlist-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17c883ab0ab67200b5f964d2b9ed6b00971917d5d8a92df149dc2c9779208ee9", size = 50046, upload-time = "2025-10-06T05:35:47.009Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ef/0e8f1fe32f8a53dd26bdd1f9347efe0778b0fddf62789ea683f4cc7d787d/frozenlist-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa47e444b8ba08fffd1c18e8cdb9a75db1b6a27f17507522834ad13ed5922b93", size = 50119, upload-time = "2025-10-06T05:35:48.38Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b1/71a477adc7c36e5fb628245dfbdea2166feae310757dea848d02bd0689fd/frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f", size = 231067, upload-time = "2025-10-06T05:35:49.97Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7e/afe40eca3a2dc19b9904c0f5d7edfe82b5304cb831391edec0ac04af94c2/frozenlist-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e7c38f250991e48a9a73e6423db1bb9dd14e722a10f6b8bb8e16a0f55f695", size = 233160, upload-time = "2025-10-06T05:35:51.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/aa/7416eac95603ce428679d273255ffc7c998d4132cfae200103f164b108aa/frozenlist-1.8.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8585e3bb2cdea02fc88ffa245069c36555557ad3609e83be0ec71f54fd4abb52", size = 228544, upload-time = "2025-10-06T05:35:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3d/2a2d1f683d55ac7e3875e4263d28410063e738384d3adc294f5ff3d7105e/frozenlist-1.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edee74874ce20a373d62dc28b0b18b93f645633c2943fd90ee9d898550770581", size = 243797, upload-time = "2025-10-06T05:35:54.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1e/2d5565b589e580c296d3bb54da08d206e797d941a83a6fdea42af23be79c/frozenlist-1.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c9a63152fe95756b85f31186bddf42e4c02c6321207fd6601a1c89ebac4fe567", size = 247923, upload-time = "2025-10-06T05:35:55.861Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/65872fcf1d326a7f101ad4d86285c403c87be7d832b7470b77f6d2ed5ddc/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b6db2185db9be0a04fecf2f241c70b63b1a242e2805be291855078f2b404dd6b", size = 230886, upload-time = "2025-10-06T05:35:57.399Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/ac9ced601d62f6956f03cc794f9e04c81719509f85255abf96e2510f4265/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f4be2e3d8bc8aabd566f8d5b8ba7ecc09249d74ba3c9ed52e54dc23a293f0b92", size = 245731, upload-time = "2025-10-06T05:35:58.563Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/49/ecccb5f2598daf0b4a1415497eba4c33c1e8ce07495eb07d2860c731b8d5/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c8d1634419f39ea6f5c427ea2f90ca85126b54b50837f31497f3bf38266e853d", size = 241544, upload-time = "2025-10-06T05:35:59.719Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/ddf24113323c0bbcc54cb38c8b8916f1da7165e07b8e24a717b4a12cbf10/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a7fa382a4a223773ed64242dbe1c9c326ec09457e6b8428efb4118c685c3dfd", size = 241806, upload-time = "2025-10-06T05:36:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fb/9b9a084d73c67175484ba2789a59f8eebebd0827d186a8102005ce41e1ba/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11847b53d722050808926e785df837353bd4d75f1d494377e59b23594d834967", size = 229382, upload-time = "2025-10-06T05:36:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a3/c8fb25aac55bf5e12dae5c5aa6a98f85d436c1dc658f21c3ac73f9fa95e5/frozenlist-1.8.0-cp311-cp311-win32.whl", hash = "sha256:27c6e8077956cf73eadd514be8fb04d77fc946a7fe9f7fe167648b0b9085cc25", size = 39647, upload-time = "2025-10-06T05:36:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f5/603d0d6a02cfd4c8f2a095a54672b3cf967ad688a60fb9faf04fc4887f65/frozenlist-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac913f8403b36a2c8610bbfd25b8013488533e71e62b4b4adce9c86c8cea905b", size = 44064, upload-time = "2025-10-06T05:36:04.368Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/c2c9ab44e181f043a86f9a8f84d5124b62dbcb3a02c0977ec72b9ac1d3e0/frozenlist-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:d4d3214a0f8394edfa3e303136d0575eece0745ff2b47bd2cb2e66dd92d4351a", size = 39937, upload-time = "2025-10-06T05:36:05.669Z" },
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/40/0832c31a37d60f60ed79e9dfb5a92e1e2af4f40a16a29abcc7992af9edff/frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a", size = 85717, upload-time = "2025-10-06T05:36:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ba/b0b3de23f40bc55a7057bd38434e25c34fa48e17f20ee273bbde5e0650f3/frozenlist-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96153e77a591c8adc2ee805756c61f59fef4cf4073a9275ee86fe8cba41241f7", size = 49651, upload-time = "2025-10-06T05:36:28.855Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ab/6e5080ee374f875296c4243c381bbdef97a9ac39c6e3ce1d5f7d42cb78d6/frozenlist-1.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f21f00a91358803399890ab167098c131ec2ddd5f8f5fd5fe9c9f2c6fcd91e40", size = 49417, upload-time = "2025-10-06T05:36:29.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027", size = 234391, upload-time = "2025-10-06T05:36:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/40/76/c202df58e3acdf12969a7895fd6f3bc016c642e6726aa63bd3025e0fc71c/frozenlist-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa352d7047a31d87dafcacbabe89df0aa506abb5b1b85a2fb91bc3faa02d822", size = 233048, upload-time = "2025-10-06T05:36:32.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c0/8746afb90f17b73ca5979c7a3958116e105ff796e718575175319b5bb4ce/frozenlist-1.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:03ae967b4e297f58f8c774c7eabcce57fe3c2434817d4385c50661845a058121", size = 226549, upload-time = "2025-10-06T05:36:33.706Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/eb/4c7eefc718ff72f9b6c4893291abaae5fbc0c82226a32dcd8ef4f7a5dbef/frozenlist-1.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6292f1de555ffcc675941d65fffffb0a5bcd992905015f85d0592201793e0e5", size = 239833, upload-time = "2025-10-06T05:36:34.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/e5c02187cf704224f8b21bee886f3d713ca379535f16893233b9d672ea71/frozenlist-1.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29548f9b5b5e3460ce7378144c3010363d8035cea44bc0bf02d57f5a685e084e", size = 245363, upload-time = "2025-10-06T05:36:36.534Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/96/cb85ec608464472e82ad37a17f844889c36100eed57bea094518bf270692/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ec3cc8c5d4084591b4237c0a272cc4f50a5b03396a47d9caaf76f5d7b38a4f11", size = 229314, upload-time = "2025-10-06T05:36:38.582Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6f/4ae69c550e4cee66b57887daeebe006fe985917c01d0fff9caab9883f6d0/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:517279f58009d0b1f2e7c1b130b377a349405da3f7621ed6bfae50b10adf20c1", size = 243365, upload-time = "2025-10-06T05:36:40.152Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/58/afd56de246cf11780a40a2c28dc7cbabbf06337cc8ddb1c780a2d97e88d8/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:db1e72ede2d0d7ccb213f218df6a078a9c09a7de257c2fe8fcef16d5925230b1", size = 237763, upload-time = "2025-10-06T05:36:41.355Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/36/cdfaf6ed42e2644740d4a10452d8e97fa1c062e2a8006e4b09f1b5fd7d63/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b4dec9482a65c54a5044486847b8a66bf10c9cb4926d42927ec4e8fd5db7fed8", size = 240110, upload-time = "2025-10-06T05:36:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a8/9ea226fbefad669f11b52e864c55f0bd57d3c8d7eb07e9f2e9a0b39502e1/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:21900c48ae04d13d416f0e1e0c4d81f7931f73a9dfa0b7a8746fb2fe7dd970ed", size = 233717, upload-time = "2025-10-06T05:36:44.251Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/1b5531611e83ba7d13ccc9988967ea1b51186af64c42b7a7af465dcc9568/frozenlist-1.8.0-cp313-cp313-win32.whl", hash = "sha256:8b7b94a067d1c504ee0b16def57ad5738701e4ba10cec90529f13fa03c833496", size = 39628, upload-time = "2025-10-06T05:36:45.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cf/174c91dbc9cc49bc7b7aab74d8b734e974d1faa8f191c74af9b7e80848e6/frozenlist-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:878be833caa6a3821caf85eb39c5ba92d28e85df26d57afb06b35b2efd937231", size = 43882, upload-time = "2025-10-06T05:36:46.796Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/17/502cd212cbfa96eb1388614fe39a3fc9ab87dbbe042b66f97acb57474834/frozenlist-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:44389d135b3ff43ba8cc89ff7f51f5a0bb6b63d829c8300f79a2fe4fe61bcc62", size = 39676, upload-time = "2025-10-06T05:36:47.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5c/3bbfaa920dfab09e76946a5d2833a7cbdf7b9b4a91c714666ac4855b88b4/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e25ac20a2ef37e91c1b39938b591457666a0fa835c7783c3a8f33ea42870db94", size = 89235, upload-time = "2025-10-06T05:36:48.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d6/f03961ef72166cec1687e84e8925838442b615bd0b8854b54923ce5b7b8a/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07cdca25a91a4386d2e76ad992916a85038a9b97561bf7a3fd12d5d9ce31870c", size = 50742, upload-time = "2025-10-06T05:36:49.837Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bb/a6d12b7ba4c3337667d0e421f7181c82dda448ce4e7ad7ecd249a16fa806/frozenlist-1.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e0c11f2cc6717e0a741f84a527c52616140741cd812a50422f83dc31749fb52", size = 51725, upload-time = "2025-10-06T05:36:50.851Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/71/d1fed0ffe2c2ccd70b43714c6cab0f4188f09f8a67a7914a6b46ee30f274/frozenlist-1.8.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3210649ee28062ea6099cfda39e147fa1bc039583c8ee4481cb7811e2448c51", size = 284533, upload-time = "2025-10-06T05:36:51.898Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/fb1685a7b009d89f9bf78a42d94461bc06581f6e718c39344754a5d9bada/frozenlist-1.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581ef5194c48035a7de2aefc72ac6539823bb71508189e5de01d60c9dcd5fa65", size = 292506, upload-time = "2025-10-06T05:36:53.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3b/b991fe1612703f7e0d05c0cf734c1b77aaf7c7d321df4572e8d36e7048c8/frozenlist-1.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ef2d026f16a2b1866e1d86fc4e1291e1ed8a387b2c333809419a2f8b3a77b82", size = 274161, upload-time = "2025-10-06T05:36:54.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ec/c5c618767bcdf66e88945ec0157d7f6c4a1322f1473392319b7a2501ded7/frozenlist-1.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5500ef82073f599ac84d888e3a8c1f77ac831183244bfd7f11eaa0289fb30714", size = 294676, upload-time = "2025-10-06T05:36:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ce/3934758637d8f8a88d11f0585d6495ef54b2044ed6ec84492a91fa3b27aa/frozenlist-1.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50066c3997d0091c411a66e710f4e11752251e6d2d73d70d8d5d4c76442a199d", size = 300638, upload-time = "2025-10-06T05:36:56.758Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/4f/a7e4d0d467298f42de4b41cbc7ddaf19d3cfeabaf9ff97c20c6c7ee409f9/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c1c8e78426e59b3f8005e9b19f6ff46e5845895adbde20ece9218319eca6506", size = 283067, upload-time = "2025-10-06T05:36:57.965Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/48/c7b163063d55a83772b268e6d1affb960771b0e203b632cfe09522d67ea5/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:eefdba20de0d938cec6a89bd4d70f346a03108a19b9df4248d3cf0d88f1b0f51", size = 292101, upload-time = "2025-10-06T05:36:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d0/2366d3c4ecdc2fd391e0afa6e11500bfba0ea772764d631bbf82f0136c9d/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cf253e0e1c3ceb4aaff6df637ce033ff6535fb8c70a764a8f46aafd3d6ab798e", size = 289901, upload-time = "2025-10-06T05:37:00.811Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/94/daff920e82c1b70e3618a2ac39fbc01ae3e2ff6124e80739ce5d71c9b920/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0", size = 289395, upload-time = "2025-10-06T05:37:02.115Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/20/bba307ab4235a09fdcd3cc5508dbabd17c4634a1af4b96e0f69bfe551ebd/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6da155091429aeba16851ecb10a9104a108bcd32f6c1642867eadaee401c1c41", size = 283659, upload-time = "2025-10-06T05:37:03.711Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/00/04ca1c3a7a124b6de4f8a9a17cc2fcad138b4608e7a3fc5877804b8715d7/frozenlist-1.8.0-cp313-cp313t-win32.whl", hash = "sha256:0f96534f8bfebc1a394209427d0f8a63d343c9779cda6fc25e8e121b5fd8555b", size = 43492, upload-time = "2025-10-06T05:37:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5e/c69f733a86a94ab10f68e496dc6b7e8bc078ebb415281d5698313e3af3a1/frozenlist-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5d63a068f978fc69421fb0e6eb91a9603187527c86b7cd3f534a5b77a592b888", size = 48034, upload-time = "2025-10-06T05:37:06.343Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6c/be9d79775d8abe79b05fa6d23da99ad6e7763a1d080fbae7290b286093fd/frozenlist-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf0a7e10b077bf5fb9380ad3ae8ce20ef919a6ad93b4552896419ac7e1d8e042", size = 41749, upload-time = "2025-10-06T05:37:07.431Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2025.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/f4/5721faf47b8c499e776bc34c6a8fc17efdf7fdef0b00f398128bc5dcb4ac/fsspec-2025.3.0.tar.gz", hash = "sha256:a935fd1ea872591f2b5148907d103488fc523295e6c64b835cfad8c3eca44972", size = 298491, upload-time = "2025-03-07T21:47:56.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/53/eb690efa8513166adef3e0669afd31e95ffde69fb3c52ec2ac7223ed6018/fsspec-2025.3.0-py3-none-any.whl", hash = "sha256:efb87af3efa9103f94ca91a7f8cb7a4df91af9f74fc106c9c7ea0efd7277c1b3", size = 193615, upload-time = "2025-03-07T21:47:54.809Z" },
+]
+
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
+]
+
+[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -802,6 +1039,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -827,6 +1088,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [[package]]
@@ -1278,6 +1558,112 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626, upload-time = "2026-01-26T02:43:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", size = 44706, upload-time = "2026-01-26T02:43:27.607Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", size = 44356, upload-time = "2026-01-26T02:43:28.661Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/0a36c8473f0cbaeadd5db6c8b72d15bbceeec275807772bfcd059bef487d/multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3", size = 244355, upload-time = "2026-01-26T02:43:31.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/8c65be997fd7dd311b7d39c7b6e71a0cb449bad093761481eccbbe4b42a2/multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e", size = 246433, upload-time = "2026-01-26T02:43:32.581Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fb/4dbd7e848d2799c6a026ec88ad39cf2b8416aa167fcc903baa55ecaa045c/multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a", size = 225376, upload-time = "2026-01-26T02:43:34.417Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4a3a6341eac3830f6053062f8fbc9a9e54407c80755b3f05bc427295c2d0/multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8", size = 257365, upload-time = "2026-01-26T02:43:35.741Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a2/dd575a69c1aa206e12d27d0770cdf9b92434b48a9ef0cd0d1afdecaa93c4/multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0", size = 254747, upload-time = "2026-01-26T02:43:36.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/21b27c560c13822ed93133f08aa6372c53a8e067f11fbed37b4adcdac922/multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144", size = 246293, upload-time = "2026-01-26T02:43:38.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/23466059dc3854763423d0ad6c0f3683a379d97673b1b89ec33826e46728/multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49", size = 242962, upload-time = "2026-01-26T02:43:40.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/51dd754a3524d685958001e8fa20a0f5f90a6a856e0a9dcabff69be3dbb7/multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71", size = 237360, upload-time = "2026-01-26T02:43:41.752Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3f/036dfc8c174934d4b55d86ff4f978e558b0e585cef70cfc1ad01adc6bf18/multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3", size = 245940, upload-time = "2026-01-26T02:43:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/20/6214d3c105928ebc353a1c644a6ef1408bc5794fcb4f170bb524a3c16311/multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c", size = 253502, upload-time = "2026-01-26T02:43:44.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/c653bc4ae1be70a0f836b82172d643fcf1dade042ba2676ab08ec08bff0f/multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0", size = 247065, upload-time = "2026-01-26T02:43:45.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/a854b4154cd3bd8b1fd375e8a8ca9d73be37610c361543d56f764109509b/multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa", size = 241870, upload-time = "2026-01-26T02:43:47.054Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bf/9676c0392309b5fdae322333d22a829715b570edb9baa8016a517b55b558/multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a", size = 41302, upload-time = "2026-01-26T02:43:48.753Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", size = 45981, upload-time = "2026-01-26T02:43:49.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", size = 43159, upload-time = "2026-01-26T02:43:51.635Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/22/929c141d6c0dba87d3e1d38fbdf1ba8baba86b7776469f2bc2d3227a1e67/multidict-6.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2b41f5fed0ed563624f1c17630cb9941cf2309d4df00e494b551b5f3e3d67a23", size = 76174, upload-time = "2026-01-26T02:44:18.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/75/bc704ae15fee974f8fccd871305e254754167dce5f9e42d88a2def741a1d/multidict-6.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84e61e3af5463c19b67ced91f6c634effb89ef8bfc5ca0267f954451ed4bb6a2", size = 45116, upload-time = "2026-01-26T02:44:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/76/55cd7186f498ed080a18440c9013011eb548f77ae1b297206d030eb1180a/multidict-6.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:935434b9853c7c112eee7ac891bc4cb86455aa631269ae35442cb316790c1445", size = 43524, upload-time = "2026-01-26T02:44:21.571Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3c/414842ef8d5a1628d68edee29ba0e5bcf235dbfb3ccd3ea303a7fe8c72ff/multidict-6.7.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:432feb25a1cb67fe82a9680b4d65fb542e4635cb3166cd9c01560651ad60f177", size = 249368, upload-time = "2026-01-26T02:44:22.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/32/befed7f74c458b4a525e60519fe8d87eef72bb1e99924fa2b0f9d97a221e/multidict-6.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e82d14e3c948952a1a85503817e038cba5905a3352de76b9a465075d072fba23", size = 256952, upload-time = "2026-01-26T02:44:24.306Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/c878a44ba877f366630c860fdf74bfb203c33778f12b6ac274936853c451/multidict-6.7.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4cfb48c6ea66c83bcaaf7e4dfa7ec1b6bbcf751b7db85a328902796dfde4c060", size = 240317, upload-time = "2026-01-26T02:44:25.772Z" },
+    { url = "https://files.pythonhosted.org/packages/68/49/57421b4d7ad2e9e60e25922b08ceb37e077b90444bde6ead629095327a6f/multidict-6.7.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d540e51b7e8e170174555edecddbd5538105443754539193e3e1061864d444d", size = 267132, upload-time = "2026-01-26T02:44:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/fe/ec0edd52ddbcea2a2e89e174f0206444a61440b40f39704e64dc807a70bd/multidict-6.7.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:273d23f4b40f3dce4d6c8a821c741a86dec62cded82e1175ba3d99be128147ed", size = 268140, upload-time = "2026-01-26T02:44:29.588Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429", size = 254277, upload-time = "2026-01-26T02:44:30.902Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b2/5fb8c124d7561a4974c342bc8c778b471ebbeb3cc17df696f034a7e9afe7/multidict-6.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:12fad252f8b267cc75b66e8fc51b3079604e8d43a75428ffe193cd9e2195dfd6", size = 252291, upload-time = "2026-01-26T02:44:32.31Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/96/51d4e4e06bcce92577fcd488e22600bd38e4fd59c20cb49434d054903bd2/multidict-6.7.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9", size = 250156, upload-time = "2026-01-26T02:44:33.734Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6b/420e173eec5fba721a50e2a9f89eda89d9c98fded1124f8d5c675f7a0c0f/multidict-6.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:90efbcf47dbe33dcf643a1e400d67d59abeac5db07dc3f27d6bdeae497a2198c", size = 249742, upload-time = "2026-01-26T02:44:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a3/ec5b5bd98f306bc2aa297b8c6f11a46714a56b1e6ef5ebda50a4f5d7c5fb/multidict-6.7.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c4b9bfc148f5a91be9244d6264c53035c8a0dcd2f51f1c3c6e30e30ebaa1c84", size = 262221, upload-time = "2026-01-26T02:44:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f7/e8c0d0da0cd1e28d10e624604e1a36bcc3353aaebdfdc3a43c72bc683a12/multidict-6.7.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:401c5a650f3add2472d1d288c26deebc540f99e2fb83e9525007a74cd2116f1d", size = 258664, upload-time = "2026-01-26T02:44:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/52/da/151a44e8016dd33feed44f730bd856a66257c1ee7aed4f44b649fb7edeb3/multidict-6.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97891f3b1b3ffbded884e2916cacf3c6fc87b66bb0dde46f7357404750559f33", size = 249490, upload-time = "2026-01-26T02:44:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/87/af/a3b86bf9630b732897f6fc3f4c4714b90aa4361983ccbdcd6c0339b21b0c/multidict-6.7.1-cp313-cp313-win32.whl", hash = "sha256:e1c5988359516095535c4301af38d8a8838534158f649c05dd1050222321bcb3", size = 41695, upload-time = "2026-01-26T02:44:41.318Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/35/e994121b0e90e46134673422dd564623f93304614f5d11886b1b3e06f503/multidict-6.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:960c83bf01a95b12b08fd54324a4eb1d5b52c88932b5cba5d6e712bb3ed12eb5", size = 45884, upload-time = "2026-01-26T02:44:42.488Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/61/42d3e5dbf661242a69c97ea363f2d7b46c567da8eadef8890022be6e2ab0/multidict-6.7.1-cp313-cp313-win_arm64.whl", hash = "sha256:563fe25c678aaba333d5399408f5ec3c383ca5b663e7f774dd179a520b8144df", size = 43122, upload-time = "2026-01-26T02:44:43.664Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b3/e6b21c6c4f314bb956016b0b3ef2162590a529b84cb831c257519e7fde44/multidict-6.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c76c4bec1538375dad9d452d246ca5368ad6e1c9039dadcf007ae59c70619ea1", size = 83175, upload-time = "2026-01-26T02:44:44.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/76/23ecd2abfe0957b234f6c960f4ade497f55f2c16aeb684d4ecdbf1c95791/multidict-6.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:57b46b24b5d5ebcc978da4ec23a819a9402b4228b8a90d9c656422b4bdd8a963", size = 48460, upload-time = "2026-01-26T02:44:46.106Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/a0ed92b23f3a042c36bc4227b72b97eca803f5f1801c1ab77c8a212d455e/multidict-6.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e954b24433c768ce78ab7929e84ccf3422e46deb45a4dc9f93438f8217fa2d34", size = 46930, upload-time = "2026-01-26T02:44:47.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/66/02ec7ace29162e447f6382c495dc95826bf931d3818799bbef11e8f7df1a/multidict-6.7.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3bd231490fa7217cc832528e1cd8752a96f0125ddd2b5749390f7c3ec8721b65", size = 242582, upload-time = "2026-01-26T02:44:48.604Z" },
+    { url = "https://files.pythonhosted.org/packages/58/18/64f5a795e7677670e872673aca234162514696274597b3708b2c0d276cce/multidict-6.7.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:253282d70d67885a15c8a7716f3a73edf2d635793ceda8173b9ecc21f2fb8292", size = 250031, upload-time = "2026-01-26T02:44:50.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ed/e192291dbbe51a8290c5686f482084d31bcd9d09af24f63358c3d42fd284/multidict-6.7.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b4c48648d7649c9335cf1927a8b87fa692de3dcb15faa676c6a6f1f1aabda43", size = 228596, upload-time = "2026-01-26T02:44:51.951Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/3562a15a60cf747397e7f2180b0a11dc0c38d9175a650e75fa1b4d325e15/multidict-6.7.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:98bc624954ec4d2c7cb074b8eefc2b5d0ce7d482e410df446414355d158fe4ca", size = 257492, upload-time = "2026-01-26T02:44:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/24/02/7d0f9eae92b5249bb50ac1595b295f10e263dd0078ebb55115c31e0eaccd/multidict-6.7.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b99af4d9eec0b49927b4402bcbb58dea89d3e0db8806a4086117019939ad3dd", size = 255899, upload-time = "2026-01-26T02:44:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/9b60ed9e23e64c73a5cde95269ef1330678e9c6e34dd4eb6b431b85b5a10/multidict-6.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aac4f16b472d5b7dc6f66a0d49dd57b0e0902090be16594dc9ebfd3d17c47e7", size = 247970, upload-time = "2026-01-26T02:44:56.783Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/06/538e58a63ed5cfb0bd4517e346b91da32fde409d839720f664e9a4ae4f9d/multidict-6.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:21f830fe223215dffd51f538e78c172ed7c7f60c9b96a2bf05c4848ad49921c3", size = 245060, upload-time = "2026-01-26T02:44:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2f/d743a3045a97c895d401e9bd29aaa09b94f5cbdf1bd561609e5a6c431c70/multidict-6.7.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f5dd81c45b05518b9aa4da4aa74e1c93d715efa234fd3e8a179df611cc85e5f4", size = 235888, upload-time = "2026-01-26T02:44:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/38/83/5a325cac191ab28b63c52f14f1131f3b0a55ba3b9aa65a6d0bf2a9b921a0/multidict-6.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:eb304767bca2bb92fb9c5bd33cedc95baee5bb5f6c88e63706533a1c06ad08c8", size = 243554, upload-time = "2026-01-26T02:45:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/9d2327086bd15da2725ef6aae624208e2ef828ed99892b17f60c344e57ed/multidict-6.7.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c9035dde0f916702850ef66460bc4239d89d08df4d02023a5926e7446724212c", size = 252341, upload-time = "2026-01-26T02:45:02.484Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2c/2a1aa0280cf579d0f6eed8ee5211c4f1730bd7e06c636ba2ee6aafda302e/multidict-6.7.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:af959b9beeb66c822380f222f0e0a1889331597e81f1ded7f374f3ecb0fd6c52", size = 246391, upload-time = "2026-01-26T02:45:03.862Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/03/7ca022ffc36c5a3f6e03b179a5ceb829be9da5783e6fe395f347c0794680/multidict-6.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:41f2952231456154ee479651491e94118229844dd7226541788be783be2b5108", size = 243422, upload-time = "2026-01-26T02:45:05.296Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/1d/b31650eab6c5778aceed46ba735bd97f7c7d2f54b319fa916c0f96e7805b/multidict-6.7.1-cp313-cp313t-win32.whl", hash = "sha256:df9f19c28adcb40b6aae30bbaa1478c389efd50c28d541d76760199fc1037c32", size = 47770, upload-time = "2026-01-26T02:45:06.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/2d2d1d522e51285bd61b1e20df8f47ae1a9d80839db0b24ea783b3832832/multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8", size = 53109, upload-time = "2026-01-26T02:45:08.044Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a3/cc409ba012c83ca024a308516703cf339bdc4b696195644a7215a5164a24/multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118", size = 45573, upload-time = "2026-01-26T02:45:09.349Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "multiprocess"
+version = "0.70.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/ae/04f39c5d0d0def03247c2893d6f2b83c136bf3320a2154d7b8858f2ba72d/multiprocess-0.70.16.tar.gz", hash = "sha256:161af703d4652a0e1410be6abccecde4a7ddffd19341be0a7011b94aeb171ac1", size = 1772603, upload-time = "2024-01-28T18:52:34.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/f7/7ec7fddc92e50714ea3745631f79bd9c96424cb2702632521028e57d3a36/multiprocess-0.70.16-py310-none-any.whl", hash = "sha256:c4a9944c67bd49f823687463660a2d6daae94c289adff97e0f9d696ba6371d02", size = 134824, upload-time = "2024-01-28T18:52:26.062Z" },
+    { url = "https://files.pythonhosted.org/packages/50/15/b56e50e8debaf439f44befec5b2af11db85f6e0f344c3113ae0be0593a91/multiprocess-0.70.16-py311-none-any.whl", hash = "sha256:af4cabb0dac72abfb1e794fa7855c325fd2b55a10a44628a3c1ad3311c04127a", size = 143519, upload-time = "2024-01-28T18:52:28.115Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7d/a988f258104dcd2ccf1ed40fdc97e26c4ac351eeaf81d76e266c52d84e2f/multiprocess-0.70.16-py312-none-any.whl", hash = "sha256:fc0544c531920dde3b00c29863377f87e1632601092ea2daca74e4beb40faa2e", size = 146741, upload-time = "2024-01-28T18:52:29.395Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/89/38df130f2c799090c978b366cfdf5b96d08de5b29a4a293df7f7429fa50b/multiprocess-0.70.16-py38-none-any.whl", hash = "sha256:a71d82033454891091a226dfc319d0cfa8019a4e888ef9ca910372a446de4435", size = 132628, upload-time = "2024-01-28T18:52:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d9/f7f9379981e39b8c2511c9e0326d212accacb82f12fbfdc1aa2ce2a7b2b6/multiprocess-0.70.16-py39-none-any.whl", hash = "sha256:a0bafd3ae1b732eac64be2e72038231c1ba97724b60b09400d68f229fcc2fbf3", size = 133351, upload-time = "2024-01-28T18:52:31.981Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1356,6 +1742,132 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
     { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
     { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/5b/4e4fff7bad39adf89f735f2bc87248c81db71205b62bcc0d5ca5b606b3c3/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adf27ccf4238253e0b826bce3ff5fa532d65fc42322c8bfdfaf28024c0fbe039", size = 322364134, upload-time = "2025-06-03T21:58:04.013Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
 ]
 
 [[package]]
@@ -1562,6 +2074,75 @@ wheels = [
 ]
 
 [[package]]
+name = "propcache"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/d4/4e2c9aaf7ac2242b9358f98dccd8f90f2605402f5afeff6c578682c2c491/propcache-0.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60a8fda9644b7dfd5dece8c61d8a85e271cb958075bfc4e01083c148b61a7caf", size = 80208, upload-time = "2025-10-08T19:46:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/21/d7b68e911f9c8e18e4ae43bdbc1e1e9bbd971f8866eb81608947b6f585ff/propcache-0.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c30b53e7e6bda1d547cabb47c825f3843a0a1a42b0496087bb58d8fedf9f41b5", size = 45777, upload-time = "2025-10-08T19:46:25.733Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/1d/11605e99ac8ea9435651ee71ab4cb4bf03f0949586246476a25aadfec54a/propcache-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6918ecbd897443087a3b7cd978d56546a812517dcaaca51b49526720571fa93e", size = 47647, upload-time = "2025-10-08T19:46:27.304Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1a/3c62c127a8466c9c843bccb503d40a273e5cc69838805f322e2826509e0d/propcache-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d902a36df4e5989763425a8ab9e98cd8ad5c52c823b34ee7ef307fd50582566", size = 214929, upload-time = "2025-10-08T19:46:28.62Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b9/8fa98f850960b367c4b8fe0592e7fc341daa7a9462e925228f10a60cf74f/propcache-0.4.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a9695397f85973bb40427dedddf70d8dc4a44b22f1650dd4af9eedf443d45165", size = 221778, upload-time = "2025-10-08T19:46:30.358Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a6/0ab4f660eb59649d14b3d3d65c439421cf2f87fe5dd68591cbe3c1e78a89/propcache-0.4.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2bb07ffd7eaad486576430c89f9b215f9e4be68c4866a96e97db9e97fead85dc", size = 228144, upload-time = "2025-10-08T19:46:32.607Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6a/57f43e054fb3d3a56ac9fc532bc684fc6169a26c75c353e65425b3e56eef/propcache-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd6f30fdcf9ae2a70abd34da54f18da086160e4d7d9251f81f3da0ff84fc5a48", size = 210030, upload-time = "2025-10-08T19:46:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e2/27e6feebb5f6b8408fa29f5efbb765cd54c153ac77314d27e457a3e993b7/propcache-0.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fc38cba02d1acba4e2869eef1a57a43dfbd3d49a59bf90dda7444ec2be6a5570", size = 208252, upload-time = "2025-10-08T19:46:35.309Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f8/91c27b22ccda1dbc7967f921c42825564fa5336a01ecd72eb78a9f4f53c2/propcache-0.4.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:67fad6162281e80e882fb3ec355398cf72864a54069d060321f6cd0ade95fe85", size = 202064, upload-time = "2025-10-08T19:46:36.993Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/26/7f00bd6bd1adba5aafe5f4a66390f243acab58eab24ff1a08bebb2ef9d40/propcache-0.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f10207adf04d08bec185bae14d9606a1444715bc99180f9331c9c02093e1959e", size = 212429, upload-time = "2025-10-08T19:46:38.398Z" },
+    { url = "https://files.pythonhosted.org/packages/84/89/fd108ba7815c1117ddca79c228f3f8a15fc82a73bca8b142eb5de13b2785/propcache-0.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e9b0d8d0845bbc4cfcdcbcdbf5086886bc8157aa963c31c777ceff7846c77757", size = 216727, upload-time = "2025-10-08T19:46:39.732Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/3ec3f7e3173e73f1d600495d8b545b53802cbf35506e5732dd8578db3724/propcache-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:981333cb2f4c1896a12f4ab92a9cc8f09ea664e9b7dbdc4eff74627af3a11c0f", size = 205097, upload-time = "2025-10-08T19:46:41.025Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b0/b2631c19793f869d35f47d5a3a56fb19e9160d3c119f15ac7344fc3ccae7/propcache-0.4.1-cp311-cp311-win32.whl", hash = "sha256:f1d2f90aeec838a52f1c1a32fe9a619fefd5e411721a9117fbf82aea638fe8a1", size = 38084, upload-time = "2025-10-08T19:46:42.693Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/78/6cce448e2098e9f3bfc91bb877f06aa24b6ccace872e39c53b2f707c4648/propcache-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:364426a62660f3f699949ac8c621aad6977be7126c5807ce48c0aeb8e7333ea6", size = 41637, upload-time = "2025-10-08T19:46:43.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e9/754f180cccd7f51a39913782c74717c581b9cc8177ad0e949f4d51812383/propcache-0.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:e53f3a38d3510c11953f3e6a33f205c6d1b001129f972805ca9b42fc308bc239", size = 38064, upload-time = "2025-10-08T19:46:44.872Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/0f/f17b1b2b221d5ca28b4b876e8bb046ac40466513960646bda8e1853cdfa2/propcache-0.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e153e9cd40cc8945138822807139367f256f89c6810c2634a4f6902b52d3b4e2", size = 80061, upload-time = "2025-10-08T19:46:46.075Z" },
+    { url = "https://files.pythonhosted.org/packages/76/47/8ccf75935f51448ba9a16a71b783eb7ef6b9ee60f5d14c7f8a8a79fbeed7/propcache-0.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd547953428f7abb73c5ad82cbb32109566204260d98e41e5dfdc682eb7f8403", size = 46037, upload-time = "2025-10-08T19:46:47.23Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/b6/5c9a0e42df4d00bfb4a3cbbe5cf9f54260300c88a0e9af1f47ca5ce17ac0/propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f048da1b4f243fc44f205dfd320933a951b8d89e0afd4c7cacc762a8b9165207", size = 47324, upload-time = "2025-10-08T19:46:48.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d3/6c7ee328b39a81ee877c962469f1e795f9db87f925251efeb0545e0020d0/propcache-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec17c65562a827bba85e3872ead335f95405ea1674860d96483a02f5c698fa72", size = 225505, upload-time = "2025-10-08T19:46:50.055Z" },
+    { url = "https://files.pythonhosted.org/packages/01/5d/1c53f4563490b1d06a684742cc6076ef944bc6457df6051b7d1a877c057b/propcache-0.4.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:405aac25c6394ef275dee4c709be43745d36674b223ba4eb7144bf4d691b7367", size = 230242, upload-time = "2025-10-08T19:46:51.815Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/ce4620633b0e2422207c3cb774a0ee61cac13abc6217763a7b9e2e3f4a12/propcache-0.4.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0013cb6f8dde4b2a2f66903b8ba740bdfe378c943c4377a200551ceb27f379e4", size = 238474, upload-time = "2025-10-08T19:46:53.208Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/3aae6835b8e5f44ea6a68348ad90f78134047b503765087be2f9912140ea/propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15932ab57837c3368b024473a525e25d316d8353016e7cc0e5ba9eb343fbb1cf", size = 221575, upload-time = "2025-10-08T19:46:54.511Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a5/8a5e8678bcc9d3a1a15b9a29165640d64762d424a16af543f00629c87338/propcache-0.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:031dce78b9dc099f4c29785d9cf5577a3faf9ebf74ecbd3c856a7b92768c3df3", size = 216736, upload-time = "2025-10-08T19:46:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/63/b7b215eddeac83ca1c6b934f89d09a625aa9ee4ba158338854c87210cc36/propcache-0.4.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ab08df6c9a035bee56e31af99be621526bd237bea9f32def431c656b29e41778", size = 213019, upload-time = "2025-10-08T19:46:57.595Z" },
+    { url = "https://files.pythonhosted.org/packages/57/74/f580099a58c8af587cac7ba19ee7cb418506342fbbe2d4a4401661cca886/propcache-0.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4d7af63f9f93fe593afbf104c21b3b15868efb2c21d07d8732c0c4287e66b6a6", size = 220376, upload-time = "2025-10-08T19:46:59.067Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ee/542f1313aff7eaf19c2bb758c5d0560d2683dac001a1c96d0774af799843/propcache-0.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cfc27c945f422e8b5071b6e93169679e4eb5bf73bbcbf1ba3ae3a83d2f78ebd9", size = 226988, upload-time = "2025-10-08T19:47:00.544Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/18/9c6b015dd9c6930f6ce2229e1f02fb35298b847f2087ea2b436a5bfa7287/propcache-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35c3277624a080cc6ec6f847cbbbb5b49affa3598c4535a0a4682a697aaa5c75", size = 215615, upload-time = "2025-10-08T19:47:01.968Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/e7b85720b98c45a45e1fca6a177024934dc9bc5f4d5dd04207f216fc33ed/propcache-0.4.1-cp312-cp312-win32.whl", hash = "sha256:671538c2262dadb5ba6395e26c1731e1d52534bfe9ae56d0b5573ce539266aa8", size = 38066, upload-time = "2025-10-08T19:47:03.503Z" },
+    { url = "https://files.pythonhosted.org/packages/54/09/d19cff2a5aaac632ec8fc03737b223597b1e347416934c1b3a7df079784c/propcache-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:cb2d222e72399fcf5890d1d5cc1060857b9b236adff2792ff48ca2dfd46c81db", size = 41655, upload-time = "2025-10-08T19:47:04.973Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/6b5c191bb5de08036a8c697b265d4ca76148efb10fa162f14af14fb5f076/propcache-0.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:204483131fb222bdaaeeea9f9e6c6ed0cac32731f75dfc1d4a567fc1926477c1", size = 37789, upload-time = "2025-10-08T19:47:06.077Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/df/6d9c1b6ac12b003837dde8a10231a7344512186e87b36e855bef32241942/propcache-0.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:43eedf29202c08550aac1d14e0ee619b0430aaef78f85864c1a892294fbc28cf", size = 77750, upload-time = "2025-10-08T19:47:07.648Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/e8/677a0025e8a2acf07d3418a2e7ba529c9c33caf09d3c1f25513023c1db56/propcache-0.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d62cdfcfd89ccb8de04e0eda998535c406bf5e060ffd56be6c586cbcc05b3311", size = 44780, upload-time = "2025-10-08T19:47:08.851Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a4/92380f7ca60f99ebae761936bc48a72a639e8a47b29050615eef757cb2a7/propcache-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cae65ad55793da34db5f54e4029b89d3b9b9490d8abe1b4c7ab5d4b8ec7ebf74", size = 46308, upload-time = "2025-10-08T19:47:09.982Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/48/c5ac64dee5262044348d1d78a5f85dd1a57464a60d30daee946699963eb3/propcache-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:333ddb9031d2704a301ee3e506dc46b1fe5f294ec198ed6435ad5b6a085facfe", size = 208182, upload-time = "2025-10-08T19:47:11.319Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0c/cd762dd011a9287389a6a3eb43aa30207bde253610cca06824aeabfe9653/propcache-0.4.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fd0858c20f078a32cf55f7e81473d96dcf3b93fd2ccdb3d40fdf54b8573df3af", size = 211215, upload-time = "2025-10-08T19:47:13.146Z" },
+    { url = "https://files.pythonhosted.org/packages/30/3e/49861e90233ba36890ae0ca4c660e95df565b2cd15d4a68556ab5865974e/propcache-0.4.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:678ae89ebc632c5c204c794f8dab2837c5f159aeb59e6ed0539500400577298c", size = 218112, upload-time = "2025-10-08T19:47:14.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8b/544bc867e24e1bd48f3118cecd3b05c694e160a168478fa28770f22fd094/propcache-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d472aeb4fbf9865e0c6d622d7f4d54a4e101a89715d8904282bb5f9a2f476c3f", size = 204442, upload-time = "2025-10-08T19:47:16.277Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a6/4282772fd016a76d3e5c0df58380a5ea64900afd836cec2c2f662d1b9bb3/propcache-0.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4d3df5fa7e36b3225954fba85589da77a0fe6a53e3976de39caf04a0db4c36f1", size = 199398, upload-time = "2025-10-08T19:47:17.962Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ec/d8a7cd406ee1ddb705db2139f8a10a8a427100347bd698e7014351c7af09/propcache-0.4.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ee17f18d2498f2673e432faaa71698032b0127ebf23ae5974eeaf806c279df24", size = 196920, upload-time = "2025-10-08T19:47:19.355Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/f38ab64af3764f431e359f8baf9e0a21013e24329e8b85d2da32e8ed07ca/propcache-0.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:580e97762b950f993ae618e167e7be9256b8353c2dcd8b99ec100eb50f5286aa", size = 203748, upload-time = "2025-10-08T19:47:21.338Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e3/fa846bd70f6534d647886621388f0a265254d30e3ce47e5c8e6e27dbf153/propcache-0.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:501d20b891688eb8e7aa903021f0b72d5a55db40ffaab27edefd1027caaafa61", size = 205877, upload-time = "2025-10-08T19:47:23.059Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/39/8163fc6f3133fea7b5f2827e8eba2029a0277ab2c5beee6c1db7b10fc23d/propcache-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a0bd56e5b100aef69bd8562b74b46254e7c8812918d3baa700c8a8009b0af66", size = 199437, upload-time = "2025-10-08T19:47:24.445Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/caa9089970ca49c7c01662bd0eeedfe85494e863e8043565aeb6472ce8fe/propcache-0.4.1-cp313-cp313-win32.whl", hash = "sha256:bcc9aaa5d80322bc2fb24bb7accb4a30f81e90ab8d6ba187aec0744bc302ad81", size = 37586, upload-time = "2025-10-08T19:47:25.736Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/ab/f76ec3c3627c883215b5c8080debb4394ef5a7a29be811f786415fc1e6fd/propcache-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:381914df18634f5494334d201e98245c0596067504b9372d8cf93f4bb23e025e", size = 40790, upload-time = "2025-10-08T19:47:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/59/1b/e71ae98235f8e2ba5004d8cb19765a74877abf189bc53fc0c80d799e56c3/propcache-0.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:8873eb4460fd55333ea49b7d189749ecf6e55bf85080f11b1c4530ed3034cba1", size = 37158, upload-time = "2025-10-08T19:47:27.961Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ce/a31bbdfc24ee0dcbba458c8175ed26089cf109a55bbe7b7640ed2470cfe9/propcache-0.4.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:92d1935ee1f8d7442da9c0c4fa7ac20d07e94064184811b685f5c4fada64553b", size = 81451, upload-time = "2025-10-08T19:47:29.445Z" },
+    { url = "https://files.pythonhosted.org/packages/25/9c/442a45a470a68456e710d96cacd3573ef26a1d0a60067e6a7d5e655621ed/propcache-0.4.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:473c61b39e1460d386479b9b2f337da492042447c9b685f28be4f74d3529e566", size = 46374, upload-time = "2025-10-08T19:47:30.579Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/bf/b1d5e21dbc3b2e889ea4327044fb16312a736d97640fb8b6aa3f9c7b3b65/propcache-0.4.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c0ef0aaafc66fbd87842a3fe3902fd889825646bc21149eafe47be6072725835", size = 48396, upload-time = "2025-10-08T19:47:31.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/04/5b4c54a103d480e978d3c8a76073502b18db0c4bc17ab91b3cb5092ad949/propcache-0.4.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95393b4d66bfae908c3ca8d169d5f79cd65636ae15b5e7a4f6e67af675adb0e", size = 275950, upload-time = "2025-10-08T19:47:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c1/86f846827fb969c4b78b0af79bba1d1ea2156492e1b83dea8b8a6ae27395/propcache-0.4.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c07fda85708bc48578467e85099645167a955ba093be0a2dcba962195676e859", size = 273856, upload-time = "2025-10-08T19:47:34.906Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1d/fc272a63c8d3bbad6878c336c7a7dea15e8f2d23a544bda43205dfa83ada/propcache-0.4.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:af223b406d6d000830c6f65f1e6431783fc3f713ba3e6cc8c024d5ee96170a4b", size = 280420, upload-time = "2025-10-08T19:47:36.338Z" },
+    { url = "https://files.pythonhosted.org/packages/07/0c/01f2219d39f7e53d52e5173bcb09c976609ba30209912a0680adfb8c593a/propcache-0.4.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a78372c932c90ee474559c5ddfffd718238e8673c340dc21fe45c5b8b54559a0", size = 263254, upload-time = "2025-10-08T19:47:37.692Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/18/cd28081658ce597898f0c4d174d4d0f3c5b6d4dc27ffafeef835c95eb359/propcache-0.4.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:564d9f0d4d9509e1a870c920a89b2fec951b44bf5ba7d537a9e7c1ccec2c18af", size = 261205, upload-time = "2025-10-08T19:47:39.659Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/71/1f9e22eb8b8316701c2a19fa1f388c8a3185082607da8e406a803c9b954e/propcache-0.4.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:17612831fda0138059cc5546f4d12a2aacfb9e47068c06af35c400ba58ba7393", size = 247873, upload-time = "2025-10-08T19:47:41.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/65/3d4b61f36af2b4eddba9def857959f1016a51066b4f1ce348e0cf7881f58/propcache-0.4.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:41a89040cb10bd345b3c1a873b2bf36413d48da1def52f268a055f7398514874", size = 262739, upload-time = "2025-10-08T19:47:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/42/26746ab087faa77c1c68079b228810436ccd9a5ce9ac85e2b7307195fd06/propcache-0.4.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e35b88984e7fa64aacecea39236cee32dd9bd8c55f57ba8a75cf2399553f9bd7", size = 263514, upload-time = "2025-10-08T19:47:43.927Z" },
+    { url = "https://files.pythonhosted.org/packages/94/13/630690fe201f5502d2403dd3cfd451ed8858fe3c738ee88d095ad2ff407b/propcache-0.4.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f8b465489f927b0df505cbe26ffbeed4d6d8a2bbc61ce90eb074ff129ef0ab1", size = 257781, upload-time = "2025-10-08T19:47:45.448Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f7/1d4ec5841505f423469efbfc381d64b7b467438cd5a4bbcbb063f3b73d27/propcache-0.4.1-cp313-cp313t-win32.whl", hash = "sha256:2ad890caa1d928c7c2965b48f3a3815c853180831d0e5503d35cf00c472f4717", size = 41396, upload-time = "2025-10-08T19:47:47.202Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f0/615c30622316496d2cbbc29f5985f7777d3ada70f23370608c1d3e081c1f/propcache-0.4.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f7ee0e597f495cf415bcbd3da3caa3bd7e816b74d0d52b8145954c5e6fd3ff37", size = 44897, upload-time = "2025-10-08T19:47:48.336Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ca/6002e46eccbe0e33dcd4069ef32f7f1c9e243736e07adca37ae8c4830ec3/propcache-0.4.1-cp313-cp313t-win_arm64.whl", hash = "sha256:929d7cbe1f01bb7baffb33dc14eb5691c95831450a26354cd210a8155170c93a", size = 39789, upload-time = "2025-10-08T19:47:49.876Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1574,6 +2155,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -2149,6 +2752,28 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+]
+
+[[package]]
 name = "scikit-image"
 version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2265,6 +2890,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
     { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
     { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]
@@ -2438,6 +3072,8 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "accelerate" },
+    { name = "datasets" },
     { name = "matplotlib" },
     { name = "mlflow" },
     { name = "moto" },
@@ -2446,7 +3082,15 @@ all = [
     { name = "pyinstrument" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "torch" },
     { name = "tqdm" },
+    { name = "transformers" },
+]
+deep-learning = [
+    { name = "accelerate" },
+    { name = "datasets" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 devtools = [
     { name = "pyinstrument" },
@@ -2470,11 +3114,15 @@ visualize = [
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", marker = "extra == 'all'", specifier = "==1.10.0" },
+    { name = "accelerate", marker = "extra == 'deep-learning'", specifier = "==1.10.0" },
     { name = "awslambdaric", specifier = "==3.1.1" },
     { name = "backoff", specifier = "==2.2.1" },
     { name = "boto3", specifier = "==1.40.12" },
     { name = "click", specifier = "==8.2.1" },
     { name = "compound-split", specifier = "==1.0.2" },
+    { name = "datasets", marker = "extra == 'all'", specifier = "==4.0.0" },
+    { name = "datasets", marker = "extra == 'deep-learning'", specifier = "==4.0.0" },
     { name = "fast-langdetect", specifier = "==1.0.0" },
     { name = "fastapi", specifier = "==0.116.1" },
     { name = "fastquadtree", specifier = "==2.0.2" },
@@ -2511,11 +3159,27 @@ requires-dist = [
     { name = "regex", specifier = "==2025.7.34" },
     { name = "scikit-image", specifier = "==0.25.2" },
     { name = "scikit-learn", specifier = "==1.7.1" },
+    { name = "torch", marker = "extra == 'all'", specifier = "==2.8.0" },
+    { name = "torch", marker = "extra == 'deep-learning'", specifier = "==2.8.0" },
     { name = "tqdm", marker = "extra == 'all'", specifier = "==4.67.1" },
     { name = "tqdm", marker = "extra == 'devtools'", specifier = "==4.67.1" },
+    { name = "transformers", marker = "extra == 'all'", specifier = "==4.55.2" },
+    { name = "transformers", marker = "extra == 'deep-learning'", specifier = "==4.55.2" },
     { name = "uvicorn", specifier = "==0.35.0" },
 ]
-provides-extras = ["all", "devtools", "experiment-tracking", "lint", "test", "visualize"]
+provides-extras = ["all", "deep-learning", "devtools", "experiment-tracking", "lint", "test", "visualize"]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
 
 [[package]]
 name = "threadpoolctl"
@@ -2536,6 +3200,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6e/1c/19fc653e2b05ec0defae511b03b330ca60c95f2c47fcaaf21c52c6e84aa8/tifffile-2026.2.24.tar.gz", hash = "sha256:d73cfa6d7a8f5775a1e3c9f3bfca77c992946639fb41a5bbe888878cb6964dc6", size = 387373, upload-time = "2026-02-24T23:59:11.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/fe/80250dc06cd4a3a5afe7059875a8d53e97a78528c5dd9ea8c3f981fb897a/tifffile-2026.2.24-py3-none-any.whl", hash = "sha256:38ef6258c2bd8dd3551c7480c6d75a36c041616262e6cd55a50dd16046b71863", size = 243223, upload-time = "2026-02-24T23:59:10.131Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/2f/402986d0823f8d7ca139d969af2917fefaa9b947d1fb32f6168c509f2492/tokenizers-0.21.4.tar.gz", hash = "sha256:fa23f85fbc9a02ec5c6978da172cdcbac23498c3ca9f3645c5c68740ac007880", size = 351253, upload-time = "2025-07-28T15:48:54.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/c6/fdb6f72bf6454f52eb4a2510be7fb0f614e541a2554d6210e370d85efff4/tokenizers-0.21.4-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2ccc10a7c3bcefe0f242867dc914fc1226ee44321eb618cfe3019b5df3400133", size = 2863987, upload-time = "2025-07-28T15:48:44.877Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a6/28975479e35ddc751dc1ddc97b9b69bf7fcf074db31548aab37f8116674c/tokenizers-0.21.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:5e2f601a8e0cd5be5cc7506b20a79112370b9b3e9cb5f13f68ab11acd6ca7d60", size = 2732457, upload-time = "2025-07-28T15:48:43.265Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/8f/24f39d7b5c726b7b0be95dca04f344df278a3fe3a4deb15a975d194cbb32/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39b376f5a1aee67b4d29032ee85511bbd1b99007ec735f7f35c8a2eb104eade5", size = 3012624, upload-time = "2025-07-28T13:22:43.895Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/26358925717687a58cb74d7a508de96649544fad5778f0cd9827398dc499/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2107ad649e2cda4488d41dfd031469e9da3fcbfd6183e74e4958fa729ffbf9c6", size = 2939681, upload-time = "2025-07-28T13:22:47.499Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/cc300fea5db2ab5ddc2c8aea5757a27b89c84469899710c3aeddc1d39801/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c73012da95afafdf235ba80047699df4384fdc481527448a078ffd00e45a7d9", size = 3247445, upload-time = "2025-07-28T15:48:39.711Z" },
+    { url = "https://files.pythonhosted.org/packages/be/bf/98cb4b9c3c4afd8be89cfa6423704337dc20b73eb4180397a6e0d456c334/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f23186c40395fc390d27f519679a58023f368a0aad234af145e0f39ad1212732", size = 3428014, upload-time = "2025-07-28T13:22:49.569Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/96c1cc780e6ca7f01a57c13235dd05b7bc1c0f3588512ebe9d1331b5f5ae/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc88bb34e23a54cc42713d6d98af5f1bf79c07653d24fe984d2d695ba2c922a2", size = 3193197, upload-time = "2025-07-28T13:22:51.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/90/273b6c7ec78af547694eddeea9e05de771278bd20476525ab930cecaf7d8/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51b7eabb104f46c1c50b486520555715457ae833d5aee9ff6ae853d1130506ff", size = 3115426, upload-time = "2025-07-28T15:48:41.439Z" },
+    { url = "https://files.pythonhosted.org/packages/91/43/c640d5a07e95f1cf9d2c92501f20a25f179ac53a4f71e1489a3dcfcc67ee/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:714b05b2e1af1288bd1bc56ce496c4cebb64a20d158ee802887757791191e6e2", size = 9089127, upload-time = "2025-07-28T15:48:46.472Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a1/dd23edd6271d4dca788e5200a807b49ec3e6987815cd9d0a07ad9c96c7c2/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1340ff877ceedfa937544b7d79f5b7becf33a4cfb58f89b3b49927004ef66f78", size = 9055243, upload-time = "2025-07-28T15:48:48.539Z" },
+    { url = "https://files.pythonhosted.org/packages/21/2b/b410d6e9021c4b7ddb57248304dc817c4d4970b73b6ee343674914701197/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3c1f4317576e465ac9ef0d165b247825a2a4078bcd01cba6b54b867bdf9fdd8b", size = 9298237, upload-time = "2025-07-28T15:48:50.443Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/0a/42348c995c67e2e6e5c89ffb9cfd68507cbaeb84ff39c49ee6e0a6dd0fd2/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c212aa4e45ec0bb5274b16b6f31dd3f1c41944025c2358faaa5782c754e84c24", size = 9461980, upload-time = "2025-07-28T15:48:52.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d3/dacccd834404cd71b5c334882f3ba40331ad2120e69ded32cf5fda9a7436/tokenizers-0.21.4-cp39-abi3-win32.whl", hash = "sha256:6c42a930bc5f4c47f4ea775c91de47d27910881902b0f20e4990ebe045a415d0", size = 2329871, upload-time = "2025-07-28T15:48:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f2/fd673d979185f5dcbac4be7d09461cbb99751554ffb6718d0013af8604cb/tokenizers-0.21.4-cp39-abi3-win_amd64.whl", hash = "sha256:475d807a5c3eb72c59ad9b5fcdb254f6e17f53dfcbb9903233b0dfa9c943b597", size = 2507568, upload-time = "2025-07-28T15:48:55.456Z" },
 ]
 
 [[package]]
@@ -2575,6 +3264,53 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/c4/3e7a3887eba14e815e614db70b3b529112d1513d9dae6f4d43e373360b7f/torch-2.8.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:220a06fd7af8b653c35d359dfe1aaf32f65aa85befa342629f716acb134b9710", size = 102073391, upload-time = "2025-08-06T14:53:20.937Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/63/4fdc45a0304536e75a5e1b1bbfb1b56dd0e2743c48ee83ca729f7ce44162/torch-2.8.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c12fa219f51a933d5f80eeb3a7a5d0cbe9168c0a14bbb4055f1979431660879b", size = 888063640, upload-time = "2025-08-06T14:55:05.325Z" },
+    { url = "https://files.pythonhosted.org/packages/84/57/2f64161769610cf6b1c5ed782bd8a780e18a3c9d48931319f2887fa9d0b1/torch-2.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:8c7ef765e27551b2fbfc0f41bcf270e1292d9bf79f8e0724848b1682be6e80aa", size = 241366752, upload-time = "2025-08-06T14:53:38.692Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5e/05a5c46085d9b97e928f3f037081d3d2b87fb4b4195030fc099aaec5effc/torch-2.8.0-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:5ae0524688fb6707c57a530c2325e13bb0090b745ba7b4a2cd6a3ce262572916", size = 73621174, upload-time = "2025-08-06T14:53:25.44Z" },
+    { url = "https://files.pythonhosted.org/packages/49/0c/2fd4df0d83a495bb5e54dca4474c4ec5f9c62db185421563deeb5dabf609/torch-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e2fab4153768d433f8ed9279c8133a114a034a61e77a3a104dcdf54388838705", size = 101906089, upload-time = "2025-08-06T14:53:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a8/6acf48d48838fb8fe480597d98a0668c2beb02ee4755cc136de92a0a956f/torch-2.8.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b2aca0939fb7e4d842561febbd4ffda67a8e958ff725c1c27e244e85e982173c", size = 887913624, upload-time = "2025-08-06T14:56:44.33Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8a/5c87f08e3abd825c7dfecef5a0f1d9aa5df5dd0e3fd1fa2f490a8e512402/torch-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:2f4ac52f0130275d7517b03a33d2493bab3693c83dcfadf4f81688ea82147d2e", size = 241326087, upload-time = "2025-08-06T14:53:46.503Z" },
+    { url = "https://files.pythonhosted.org/packages/be/66/5c9a321b325aaecb92d4d1855421e3a055abd77903b7dab6575ca07796db/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:619c2869db3ada2c0105487ba21b5008defcc472d23f8b80ed91ac4a380283b0", size = 73630478, upload-time = "2025-08-06T14:53:57.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4e/469ced5a0603245d6a19a556e9053300033f9c5baccf43a3d25ba73e189e/torch-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2b2f96814e0345f5a5aed9bf9734efa913678ed19caf6dc2cddb7930672d6128", size = 101936856, upload-time = "2025-08-06T14:54:01.526Z" },
+    { url = "https://files.pythonhosted.org/packages/16/82/3948e54c01b2109238357c6f86242e6ecbf0c63a1af46906772902f82057/torch-2.8.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:65616ca8ec6f43245e1f5f296603e33923f4c30f93d65e103d9e50c25b35150b", size = 887922844, upload-time = "2025-08-06T14:55:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/54/941ea0a860f2717d86a811adf0c2cd01b3983bdd460d0803053c4e0b8649/torch-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:659df54119ae03e83a800addc125856effda88b016dfc54d9f65215c3975be16", size = 241330968, upload-time = "2025-08-06T14:54:45.293Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/8b7b13bba430f5e21d77708b616f767683629fc4f8037564a177d20f90ed/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:1a62a1ec4b0498930e2543535cf70b1bef8c777713de7ceb84cd79115f553767", size = 73915128, upload-time = "2025-08-06T14:54:34.769Z" },
+    { url = "https://files.pythonhosted.org/packages/15/0e/8a800e093b7f7430dbaefa80075aee9158ec22e4c4fc3c1a66e4fb96cb4f/torch-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:83c13411a26fac3d101fe8035a6b0476ae606deb8688e904e796a3534c197def", size = 102020139, upload-time = "2025-08-06T14:54:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/15/5e488ca0bc6162c86a33b58642bc577c84ded17c7b72d97e49b5833e2d73/torch-2.8.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8f0a9d617a66509ded240add3754e462430a6c1fc5589f86c17b433dd808f97a", size = 887990692, upload-time = "2025-08-06T14:56:18.286Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a8/6a04e4b54472fc5dba7ca2341ab219e529f3c07b6941059fbf18dccac31f/torch-2.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a7242b86f42be98ac674b88a4988643b9bc6145437ec8f048fea23f72feb5eca", size = 241603453, upload-time = "2025-08-06T14:55:22.945Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6e/650bb7f28f771af0cb791b02348db8b7f5f64f40f6829ee82aa6ce99aabe/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:7b677e17f5a3e69fdef7eb3b9da72622f8d322692930297e4ccb52fefc6c8211", size = 73632395, upload-time = "2025-08-06T14:55:28.645Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2584,6 +3320,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "4.55.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/a5/d8b8a1f3a051daeb5f11253bb69fc241f193d1c0566e299210ed9220ff4e/transformers-4.55.2.tar.gz", hash = "sha256:a45ec60c03474fd67adbce5c434685051b7608b3f4f167c25aa6aeb1cad16d4f", size = 9571466, upload-time = "2025-08-13T18:25:43.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/5a/022ac010bedfb5119734cf9d743cf1d830cb4c604f53bb1552216f4344dc/transformers-4.55.2-py3-none-any.whl", hash = "sha256:097e3c2e2c0c9681db3da9d748d8f9d6a724c644514673d0030e8c5a1109f1f1", size = 11269748, upload-time = "2025-08-13T18:25:40.394Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/39/43325b3b651d50187e591eefa22e236b2981afcebaefd4f2fc0ea99df191/triton-3.4.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b70f5e6a41e52e48cfc087436c8a28c17ff98db369447bcaff3b887a3ab4467", size = 155531138, upload-time = "2025-07-30T19:58:29.908Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
+    { url = "https://files.pythonhosted.org/packages/20/63/8cb444ad5cdb25d999b7d647abac25af0ee37d292afc009940c05b82dda0/triton-3.4.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7936b18a3499ed62059414d7df563e6c163c5e16c3773678a3ee3d417865035d", size = 155659780, upload-time = "2025-07-30T19:58:51.171Z" },
 ]
 
 [[package]]
@@ -2681,6 +3452,165 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/d4/cc2f0400e9154df4b9964249da78ebd72f318e35ccc425e9f403c392f22a/xxhash-3.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b47bbd8cf2d72797f3c2772eaaac0ded3d3af26481a26d7d7d41dc2d3c46b04a", size = 32844, upload-time = "2025-10-02T14:34:14.037Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ec/1cc11cd13e26ea8bc3cb4af4eaadd8d46d5014aebb67be3f71fb0b68802a/xxhash-3.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2b6821e94346f96db75abaa6e255706fb06ebd530899ed76d32cd99f20dc52fa", size = 30809, upload-time = "2025-10-02T14:34:15.484Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/19fe357ea348d98ca22f456f75a30ac0916b51c753e1f8b2e0e6fb884cce/xxhash-3.6.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d0a9751f71a1a65ce3584e9cae4467651c7e70c9d31017fa57574583a4540248", size = 194665, upload-time = "2025-10-02T14:34:16.541Z" },
+    { url = "https://files.pythonhosted.org/packages/90/3b/d1f1a8f5442a5fd8beedae110c5af7604dc37349a8e16519c13c19a9a2de/xxhash-3.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b29ee68625ab37b04c0b40c3fafdf24d2f75ccd778333cfb698f65f6c463f62", size = 213550, upload-time = "2025-10-02T14:34:17.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ef/3a9b05eb527457d5db13a135a2ae1a26c80fecd624d20f3e8dcc4cb170f3/xxhash-3.6.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6812c25fe0d6c36a46ccb002f40f27ac903bf18af9f6dd8f9669cb4d176ab18f", size = 212384, upload-time = "2025-10-02T14:34:19.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/18/ccc194ee698c6c623acbf0f8c2969811a8a4b6185af5e824cd27b9e4fd3e/xxhash-3.6.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4ccbff013972390b51a18ef1255ef5ac125c92dc9143b2d1909f59abc765540e", size = 445749, upload-time = "2025-10-02T14:34:20.659Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/86/cf2c0321dc3940a7aa73076f4fd677a0fb3e405cb297ead7d864fd90847e/xxhash-3.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:297b7fbf86c82c550e12e8fb71968b3f033d27b874276ba3624ea868c11165a8", size = 193880, upload-time = "2025-10-02T14:34:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fb/96213c8560e6f948a1ecc9a7613f8032b19ee45f747f4fca4eb31bb6d6ed/xxhash-3.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dea26ae1eb293db089798d3973a5fc928a18fdd97cc8801226fae705b02b14b0", size = 210912, upload-time = "2025-10-02T14:34:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/40/aa/4395e669b0606a096d6788f40dbdf2b819d6773aa290c19e6e83cbfc312f/xxhash-3.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7a0b169aafb98f4284f73635a8e93f0735f9cbde17bd5ec332480484241aaa77", size = 198654, upload-time = "2025-10-02T14:34:25.644Z" },
+    { url = "https://files.pythonhosted.org/packages/67/74/b044fcd6b3d89e9b1b665924d85d3f400636c23590226feb1eb09e1176ce/xxhash-3.6.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:08d45aef063a4531b785cd72de4887766d01dc8f362a515693df349fdb825e0c", size = 210867, upload-time = "2025-10-02T14:34:27.203Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fd/3ce73bf753b08cb19daee1eb14aa0d7fe331f8da9c02dd95316ddfe5275e/xxhash-3.6.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:929142361a48ee07f09121fe9e96a84950e8d4df3bb298ca5d88061969f34d7b", size = 414012, upload-time = "2025-10-02T14:34:28.409Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b3/5a4241309217c5c876f156b10778f3ab3af7ba7e3259e6d5f5c7d0129eb2/xxhash-3.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:51312c768403d8540487dbbfb557454cfc55589bbde6424456951f7fcd4facb3", size = 191409, upload-time = "2025-10-02T14:34:29.696Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/99bfbc15fb9abb9a72b088c1d95219fc4782b7d01fc835bd5744d66dd0b8/xxhash-3.6.0-cp311-cp311-win32.whl", hash = "sha256:d1927a69feddc24c987b337ce81ac15c4720955b667fe9b588e02254b80446fd", size = 30574, upload-time = "2025-10-02T14:34:31.028Z" },
+    { url = "https://files.pythonhosted.org/packages/65/79/9d24d7f53819fe301b231044ea362ce64e86c74f6e8c8e51320de248b3e5/xxhash-3.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:26734cdc2d4ffe449b41d186bbeac416f704a482ed835d375a5c0cb02bc63fef", size = 31481, upload-time = "2025-10-02T14:34:32.062Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4e/15cd0e3e8772071344eab2961ce83f6e485111fed8beb491a3f1ce100270/xxhash-3.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:d72f67ef8bf36e05f5b6c65e8524f265bd61071471cd4cf1d36743ebeeeb06b7", size = 27861, upload-time = "2025-10-02T14:34:33.555Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/d9412f3d7d462347e4511181dea65e47e0d0e16e26fbee2ea86a2aefb657/xxhash-3.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:01362c4331775398e7bb34e3ab403bc9ee9f7c497bc7dee6272114055277dd3c", size = 32744, upload-time = "2025-10-02T14:34:34.622Z" },
+    { url = "https://files.pythonhosted.org/packages/79/35/0429ee11d035fc33abe32dca1b2b69e8c18d236547b9a9b72c1929189b9a/xxhash-3.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b7b2df81a23f8cb99656378e72501b2cb41b1827c0f5a86f87d6b06b69f9f204", size = 30816, upload-time = "2025-10-02T14:34:36.043Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f2/57eb99aa0f7d98624c0932c5b9a170e1806406cdbcdb510546634a1359e0/xxhash-3.6.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:dc94790144e66b14f67b10ac8ed75b39ca47536bf8800eb7c24b50271ea0c490", size = 194035, upload-time = "2025-10-02T14:34:37.354Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ed/6224ba353690d73af7a3f1c7cdb1fc1b002e38f783cb991ae338e1eb3d79/xxhash-3.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93f107c673bccf0d592cdba077dedaf52fe7f42dcd7676eba1f6d6f0c3efffd2", size = 212914, upload-time = "2025-10-02T14:34:38.6Z" },
+    { url = "https://files.pythonhosted.org/packages/38/86/fb6b6130d8dd6b8942cc17ab4d90e223653a89aa32ad2776f8af7064ed13/xxhash-3.6.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2aa5ee3444c25b69813663c9f8067dcfaa2e126dc55e8dddf40f4d1c25d7effa", size = 212163, upload-time = "2025-10-02T14:34:39.872Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/e84875682b0593e884ad73b2d40767b5790d417bde603cceb6878901d647/xxhash-3.6.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7f99123f0e1194fa59cc69ad46dbae2e07becec5df50a0509a808f90a0f03f0", size = 445411, upload-time = "2025-10-02T14:34:41.569Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4f/426f91b96701ec2f37bb2b8cec664eff4f658a11f3fa9d94f0a887ea6d2b/xxhash-3.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49e03e6fe2cac4a1bc64952dd250cf0dbc5ef4ebb7b8d96bce82e2de163c82a2", size = 193883, upload-time = "2025-10-02T14:34:43.249Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5a/ddbb83eee8e28b778eacfc5a85c969673e4023cdeedcfcef61f36731610b/xxhash-3.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bd17fede52a17a4f9a7bc4472a5867cb0b160deeb431795c0e4abe158bc784e9", size = 210392, upload-time = "2025-10-02T14:34:45.042Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c2/ff69efd07c8c074ccdf0a4f36fcdd3d27363665bcdf4ba399abebe643465/xxhash-3.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6fb5f5476bef678f69db04f2bd1efbed3030d2aba305b0fc1773645f187d6a4e", size = 197898, upload-time = "2025-10-02T14:34:46.302Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ca/faa05ac19b3b622c7c9317ac3e23954187516298a091eb02c976d0d3dd45/xxhash-3.6.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:843b52f6d88071f87eba1631b684fcb4b2068cd2180a0224122fe4ef011a9374", size = 210655, upload-time = "2025-10-02T14:34:47.571Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/7a/06aa7482345480cc0cb597f5c875b11a82c3953f534394f620b0be2f700c/xxhash-3.6.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7d14a6cfaf03b1b6f5f9790f76880601ccc7896aff7ab9cd8978a939c1eb7e0d", size = 414001, upload-time = "2025-10-02T14:34:49.273Z" },
+    { url = "https://files.pythonhosted.org/packages/23/07/63ffb386cd47029aa2916b3d2f454e6cc5b9f5c5ada3790377d5430084e7/xxhash-3.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:418daf3db71e1413cfe211c2f9a528456936645c17f46b5204705581a45390ae", size = 191431, upload-time = "2025-10-02T14:34:50.798Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/93/14fde614cadb4ddf5e7cebf8918b7e8fac5ae7861c1875964f17e678205c/xxhash-3.6.0-cp312-cp312-win32.whl", hash = "sha256:50fc255f39428a27299c20e280d6193d8b63b8ef8028995323bf834a026b4fbb", size = 30617, upload-time = "2025-10-02T14:34:51.954Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5d/0d125536cbe7565a83d06e43783389ecae0c0f2ed037b48ede185de477c0/xxhash-3.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c0f2ab8c715630565ab8991b536ecded9416d615538be8ecddce43ccf26cbc7c", size = 31534, upload-time = "2025-10-02T14:34:53.276Z" },
+    { url = "https://files.pythonhosted.org/packages/54/85/6ec269b0952ec7e36ba019125982cf11d91256a778c7c3f98a4c5043d283/xxhash-3.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:eae5c13f3bc455a3bbb68bdc513912dc7356de7e2280363ea235f71f54064829", size = 27876, upload-time = "2025-10-02T14:34:54.371Z" },
+    { url = "https://files.pythonhosted.org/packages/33/76/35d05267ac82f53ae9b0e554da7c5e281ee61f3cad44c743f0fcd354f211/xxhash-3.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:599e64ba7f67472481ceb6ee80fa3bd828fd61ba59fb11475572cc5ee52b89ec", size = 32738, upload-time = "2025-10-02T14:34:55.839Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/3fbce1cd96534a95e35d5120637bf29b0d7f5d8fa2f6374e31b4156dd419/xxhash-3.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d8b8aaa30fca4f16f0c84a5c8d7ddee0e25250ec2796c973775373257dde8f1", size = 30821, upload-time = "2025-10-02T14:34:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ea/d387530ca7ecfa183cb358027f1833297c6ac6098223fd14f9782cd0015c/xxhash-3.6.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d597acf8506d6e7101a4a44a5e428977a51c0fadbbfd3c39650cca9253f6e5a6", size = 194127, upload-time = "2025-10-02T14:34:59.21Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/0c/71435dcb99874b09a43b8d7c54071e600a7481e42b3e3ce1eb5226a5711a/xxhash-3.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:858dc935963a33bc33490128edc1c12b0c14d9c7ebaa4e387a7869ecc4f3e263", size = 212975, upload-time = "2025-10-02T14:35:00.816Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7a/c2b3d071e4bb4a90b7057228a99b10d51744878f4a8a6dd643c8bd897620/xxhash-3.6.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba284920194615cb8edf73bf52236ce2e1664ccd4a38fdb543506413529cc546", size = 212241, upload-time = "2025-10-02T14:35:02.207Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/640b6eac0128e215f177df99eadcd0f1b7c42c274ab6a394a05059694c5a/xxhash-3.6.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b54219177f6c6674d5378bd862c6aedf64725f70dd29c472eaae154df1a2e89", size = 445471, upload-time = "2025-10-02T14:35:03.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1e/3c3d3ef071b051cc3abbe3721ffb8365033a172613c04af2da89d5548a87/xxhash-3.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42c36dd7dbad2f5238950c377fcbf6811b1cdb1c444fab447960030cea60504d", size = 193936, upload-time = "2025-10-02T14:35:05.013Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/bd/4a5f68381939219abfe1c22a9e3a5854a4f6f6f3c4983a87d255f21f2e5d/xxhash-3.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f22927652cba98c44639ffdc7aaf35828dccf679b10b31c4ad72a5b530a18eb7", size = 210440, upload-time = "2025-10-02T14:35:06.239Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/37/b80fe3d5cfb9faff01a02121a0f4d565eb7237e9e5fc66e73017e74dcd36/xxhash-3.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b45fad44d9c5c119e9c6fbf2e1c656a46dc68e280275007bbfd3d572b21426db", size = 197990, upload-time = "2025-10-02T14:35:07.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fd/2c0a00c97b9e18f72e1f240ad4e8f8a90fd9d408289ba9c7c495ed7dc05c/xxhash-3.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6f2580ffab1a8b68ef2b901cde7e55fa8da5e4be0977c68f78fc80f3c143de42", size = 210689, upload-time = "2025-10-02T14:35:09.438Z" },
+    { url = "https://files.pythonhosted.org/packages/93/86/5dd8076a926b9a95db3206aba20d89a7fc14dd5aac16e5c4de4b56033140/xxhash-3.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40c391dd3cd041ebc3ffe6f2c862f402e306eb571422e0aa918d8070ba31da11", size = 414068, upload-time = "2025-10-02T14:35:11.162Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3c/0bb129170ee8f3650f08e993baee550a09593462a5cddd8e44d0011102b1/xxhash-3.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f205badabde7aafd1a31e8ca2a3e5a763107a71c397c4481d6a804eb5063d8bd", size = 191495, upload-time = "2025-10-02T14:35:12.971Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3a/6797e0114c21d1725e2577508e24006fd7ff1d8c0c502d3b52e45c1771d8/xxhash-3.6.0-cp313-cp313-win32.whl", hash = "sha256:2577b276e060b73b73a53042ea5bd5203d3e6347ce0d09f98500f418a9fcf799", size = 30620, upload-time = "2025-10-02T14:35:14.129Z" },
+    { url = "https://files.pythonhosted.org/packages/86/15/9bc32671e9a38b413a76d24722a2bf8784a132c043063a8f5152d390b0f9/xxhash-3.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:757320d45d2fbcce8f30c42a6b2f47862967aea7bf458b9625b4bbe7ee390392", size = 31542, upload-time = "2025-10-02T14:35:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c5/cc01e4f6188656e56112d6a8e0dfe298a16934b8c47a247236549a3f7695/xxhash-3.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:457b8f85dec5825eed7b69c11ae86834a018b8e3df5e77783c999663da2f96d6", size = 27880, upload-time = "2025-10-02T14:35:16.315Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/30/25e5321c8732759e930c555176d37e24ab84365482d257c3b16362235212/xxhash-3.6.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a42e633d75cdad6d625434e3468126c73f13f7584545a9cf34e883aa1710e702", size = 32956, upload-time = "2025-10-02T14:35:17.413Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3c/0573299560d7d9f8ab1838f1efc021a280b5ae5ae2e849034ef3dee18810/xxhash-3.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:568a6d743219e717b07b4e03b0a828ce593833e498c3b64752e0f5df6bfe84db", size = 31072, upload-time = "2025-10-02T14:35:18.844Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1c/52d83a06e417cd9d4137722693424885cc9878249beb3a7c829e74bf7ce9/xxhash-3.6.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bec91b562d8012dae276af8025a55811b875baace6af510412a5e58e3121bc54", size = 196409, upload-time = "2025-10-02T14:35:20.31Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/8e/c6d158d12a79bbd0b878f8355432075fc82759e356ab5a111463422a239b/xxhash-3.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78e7f2f4c521c30ad5e786fdd6bae89d47a32672a80195467b5de0480aa97b1f", size = 215736, upload-time = "2025-10-02T14:35:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/68/c4c80614716345d55071a396cf03d06e34b5f4917a467faf43083c995155/xxhash-3.6.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ed0df1b11a79856df5ffcab572cbd6b9627034c1c748c5566fa79df9048a7c5", size = 214833, upload-time = "2025-10-02T14:35:23.32Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e9/ae27c8ffec8b953efa84c7c4a6c6802c263d587b9fc0d6e7cea64e08c3af/xxhash-3.6.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0e4edbfc7d420925b0dd5e792478ed393d6e75ff8fc219a6546fb446b6a417b1", size = 448348, upload-time = "2025-10-02T14:35:25.111Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6b/33e21afb1b5b3f46b74b6bd1913639066af218d704cc0941404ca717fc57/xxhash-3.6.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fba27a198363a7ef87f8c0f6b171ec36b674fe9053742c58dd7e3201c1ab30ee", size = 196070, upload-time = "2025-10-02T14:35:26.586Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b6/fcabd337bc5fa624e7203aa0fa7d0c49eed22f72e93229431752bddc83d9/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:794fe9145fe60191c6532fa95063765529770edcdd67b3d537793e8004cabbfd", size = 212907, upload-time = "2025-10-02T14:35:28.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d3/9ee6160e644d660fcf176c5825e61411c7f62648728f69c79ba237250143/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:6105ef7e62b5ac73a837778efc331a591d8442f8ef5c7e102376506cb4ae2729", size = 200839, upload-time = "2025-10-02T14:35:29.857Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/98/e8de5baa5109394baf5118f5e72ab21a86387c4f89b0e77ef3e2f6b0327b/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f01375c0e55395b814a679b3eea205db7919ac2af213f4a6682e01220e5fe292", size = 213304, upload-time = "2025-10-02T14:35:31.222Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1d/71056535dec5c3177eeb53e38e3d367dd1d16e024e63b1cee208d572a033/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d706dca2d24d834a4661619dcacf51a75c16d65985718d6a7d73c1eeeb903ddf", size = 416930, upload-time = "2025-10-02T14:35:32.517Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6c/5cbde9de2cd967c322e651c65c543700b19e7ae3e0aae8ece3469bf9683d/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5f059d9faeacd49c0215d66f4056e1326c80503f51a1532ca336a385edadd033", size = 193787, upload-time = "2025-10-02T14:35:33.827Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fa/0172e350361d61febcea941b0cc541d6e6c8d65d153e85f850a7b256ff8a/xxhash-3.6.0-cp313-cp313t-win32.whl", hash = "sha256:1244460adc3a9be84731d72b8e80625788e5815b68da3da8b83f78115a40a7ec", size = 30916, upload-time = "2025-10-02T14:35:35.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e6/e8cf858a2b19d6d45820f072eff1bea413910592ff17157cabc5f1227a16/xxhash-3.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b1e420ef35c503869c4064f4a2f2b08ad6431ab7b229a05cce39d74268bca6b8", size = 31799, upload-time = "2025-10-02T14:35:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/064b197e855bfb7b343210e82490ae672f8bc7cdf3ddb02e92f64304ee8a/xxhash-3.6.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ec44b73a4220623235f67a996c862049f375df3b1052d9899f40a6382c32d746", size = 28044, upload-time = "2025-10-02T14:35:37.195Z" },
+    { url = "https://files.pythonhosted.org/packages/93/1e/8aec23647a34a249f62e2398c42955acd9b4c6ed5cf08cbea94dc46f78d2/xxhash-3.6.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0f7b7e2ec26c1666ad5fc9dbfa426a6a3367ceaf79db5dd76264659d509d73b0", size = 30662, upload-time = "2025-10-02T14:37:01.743Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/b14510b38ba91caf43006209db846a696ceea6a847a0c9ba0a5b1adc53d6/xxhash-3.6.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5dc1e14d14fa0f5789ec29a7062004b5933964bb9b02aae6622b8f530dc40296", size = 41056, upload-time = "2025-10-02T14:37:02.879Z" },
+    { url = "https://files.pythonhosted.org/packages/50/55/15a7b8a56590e66ccd374bbfa3f9ffc45b810886c8c3b614e3f90bd2367c/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:881b47fc47e051b37d94d13e7455131054b56749b91b508b0907eb07900d1c13", size = 36251, upload-time = "2025-10-02T14:37:04.44Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/5ac99a041a29e58e95f907876b04f7067a0242cb85b5f39e726153981503/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6dc31591899f5e5666f04cc2e529e69b4072827085c1ef15294d91a004bc1bd", size = 32481, upload-time = "2025-10-02T14:37:05.869Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/8d95e906764a386a3d3b596f3c68bb63687dfca806373509f51ce8eea81f/xxhash-3.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d", size = 31565, upload-time = "2025-10-02T14:37:06.966Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/aa/60da938b8f0997ba3a911263c40d82b6f645a67902a490b46f3355e10fae/yarl-1.23.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b35d13d549077713e4414f927cdc388d62e543987c572baee613bf82f11a4b99", size = 123641, upload-time = "2026-03-01T22:04:42.841Z" },
+    { url = "https://files.pythonhosted.org/packages/24/84/e237607faf4e099dbb8a4f511cfd5efcb5f75918baad200ff7380635631b/yarl-1.23.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cbb0fef01f0c6b38cb0f39b1f78fc90b807e0e3c86a7ff3ce74ad77ce5c7880c", size = 86248, upload-time = "2026-03-01T22:04:44.757Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0d/71ceabc14c146ba8ee3804ca7b3d42b1664c8440439de5214d366fec7d3a/yarl-1.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc52310451fc7c629e13c4e061cbe2dd01684d91f2f8ee2821b083c58bd72432", size = 85988, upload-time = "2026-03-01T22:04:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/4a90d59c572e46b270ca132aca66954f1175abd691f74c1ef4c6711828e2/yarl-1.23.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2c6b50c7b0464165472b56b42d4c76a7b864597007d9c085e8b63e185cf4a7a", size = 100566, upload-time = "2026-03-01T22:04:47.639Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fb/c438fb5108047e629f6282a371e6e91cf3f97ee087c4fb748a1f32ceef55/yarl-1.23.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:aafe5dcfda86c8af00386d7781d4c2181b5011b7be3f2add5e99899ea925df05", size = 92079, upload-time = "2026-03-01T22:04:48.925Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/13/d269aa1aed3e4f50a5a103f96327210cc5fa5dd2d50882778f13c7a14606/yarl-1.23.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9ee33b875f0b390564c1fb7bc528abf18c8ee6073b201c6ae8524aca778e2d83", size = 108741, upload-time = "2026-03-01T22:04:50.838Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/115b16f22c37ea4437d323e472945bea97301c8ec6089868fa560abab590/yarl-1.23.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4c41e021bc6d7affb3364dc1e1e5fa9582b470f283748784bd6ea0558f87f42c", size = 108099, upload-time = "2026-03-01T22:04:52.499Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/64/c53487d9f4968045b8afa51aed7ca44f58b2589e772f32745f3744476c82/yarl-1.23.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99c8a9ed30f4164bc4c14b37a90208836cbf50d4ce2a57c71d0f52c7fb4f7598", size = 102678, upload-time = "2026-03-01T22:04:55.176Z" },
+    { url = "https://files.pythonhosted.org/packages/85/59/cd98e556fbb2bf8fab29c1a722f67ad45c5f3447cac798ab85620d1e70af/yarl-1.23.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f2af5c81a1f124609d5f33507082fc3f739959d4719b56877ab1ee7e7b3d602b", size = 100803, upload-time = "2026-03-01T22:04:56.588Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c0/b39770b56d4a9f0bb5f77e2f1763cd2d75cc2f6c0131e3b4c360348fcd65/yarl-1.23.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6b41389c19b07c760c7e427a3462e8ab83c4bb087d127f0e854c706ce1b9215c", size = 100163, upload-time = "2026-03-01T22:04:58.492Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/64/6980f99ab00e1f0ff67cb84766c93d595b067eed07439cfccfc8fb28c1a6/yarl-1.23.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:1dc702e42d0684f42d6519c8d581e49c96cefaaab16691f03566d30658ee8788", size = 93859, upload-time = "2026-03-01T22:05:00.268Z" },
+    { url = "https://files.pythonhosted.org/packages/38/69/912e6c5e146793e5d4b5fe39ff5b00f4d22463dfd5a162bec565ac757673/yarl-1.23.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:0e40111274f340d32ebcc0a5668d54d2b552a6cca84c9475859d364b380e3222", size = 108202, upload-time = "2026-03-01T22:05:02.273Z" },
+    { url = "https://files.pythonhosted.org/packages/59/97/35ca6767524687ad64e5f5c31ad54bc76d585585a9fcb40f649e7e82ffed/yarl-1.23.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:4764a6a7588561a9aef92f65bda2c4fb58fe7c675c0883862e6df97559de0bfb", size = 99866, upload-time = "2026-03-01T22:05:03.597Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/1c/1a3387ee6d73589f6f2a220ae06f2984f6c20b40c734989b0a44f5987308/yarl-1.23.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:03214408cfa590df47728b84c679ae4ef00be2428e11630277be0727eba2d7cc", size = 107852, upload-time = "2026-03-01T22:05:04.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b8/35c0750fcd5a3f781058bfd954515dd4b1eab45e218cbb85cf11132215f1/yarl-1.23.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:170e26584b060879e29fac213e4228ef063f39128723807a312e5c7fec28eff2", size = 102919, upload-time = "2026-03-01T22:05:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1c/9a1979aec4a81896d597bcb2177827f2dbee3f5b7cc48b2d0dadb644b41d/yarl-1.23.0-cp311-cp311-win32.whl", hash = "sha256:51430653db848d258336cfa0244427b17d12db63d42603a55f0d4546f50f25b5", size = 82602, upload-time = "2026-03-01T22:05:08.444Z" },
+    { url = "https://files.pythonhosted.org/packages/93/22/b85eca6fa2ad9491af48c973e4c8cf6b103a73dbb271fe3346949449fca0/yarl-1.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:bf49a3ae946a87083ef3a34c8f677ae4243f5b824bfc4c69672e72b3d6719d46", size = 87461, upload-time = "2026-03-01T22:05:10.145Z" },
+    { url = "https://files.pythonhosted.org/packages/93/95/07e3553fe6f113e6864a20bdc53a78113cda3b9ced8784ee52a52c9f80d8/yarl-1.23.0-cp311-cp311-win_arm64.whl", hash = "sha256:b39cb32a6582750b6cc77bfb3c49c0f8760dc18dc96ec9fb55fbb0f04e08b928", size = 82336, upload-time = "2026-03-01T22:05:11.554Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8a/94615bc31022f711add374097ad4144d569e95ff3c38d39215d07ac153a0/yarl-1.23.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1932b6b8bba8d0160a9d1078aae5838a66039e8832d41d2992daa9a3a08f7860", size = 124737, upload-time = "2026-03-01T22:05:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6f/c6554045d59d64052698add01226bc867b52fe4a12373415d7991fdca95d/yarl-1.23.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:411225bae281f114067578891bc75534cfb3d92a3b4dfef7a6ca78ba354e6069", size = 87029, upload-time = "2026-03-01T22:05:14.376Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/725ecc166d53438bc88f76822ed4b1e3b10756e790bafd7b523fe97c322d/yarl-1.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:13a563739ae600a631c36ce096615fe307f131344588b0bc0daec108cdb47b25", size = 86310, upload-time = "2026-03-01T22:05:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cbf44c5cb4a7633d078788e1b56387e3d3cf2b8139a3be38040b22d6c3221c8", size = 97587, upload-time = "2026-03-01T22:05:17.384Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0a/8b08aac08b50682e65759f7f8dde98ae8168f72487e7357a5d684c581ef9/yarl-1.23.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53ad387048f6f09a8969631e4de3f1bf70c50e93545d64af4f751b2498755072", size = 92528, upload-time = "2026-03-01T22:05:18.804Z" },
+    { url = "https://files.pythonhosted.org/packages/52/07/0b7179101fe5f8385ec6c6bb5d0cb9f76bd9fb4a769591ab6fb5cdbfc69a/yarl-1.23.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4a59ba56f340334766f3a4442e0efd0af895fae9e2b204741ef885c446b3a1a8", size = 105339, upload-time = "2026-03-01T22:05:20.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8a/36d82869ab5ec829ca8574dfcb92b51286fcfb1e9c7a73659616362dc880/yarl-1.23.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:803a3c3ce4acc62eaf01eaca1208dcf0783025ef27572c3336502b9c232005e7", size = 105061, upload-time = "2026-03-01T22:05:22.268Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3d2bff8f37f8d0f96c7ec554d16945050d54462d6e95414babaa18bfafc7f51", size = 100132, upload-time = "2026-03-01T22:05:23.638Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/9c89acf82f08a52cb52d6d39454f8d18af15f9d386a23795389d1d423823/yarl-1.23.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c75eb09e8d55bceb4367e83496ff8ef2bc7ea6960efb38e978e8073ea59ecb67", size = 99289, upload-time = "2026-03-01T22:05:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/54/5b0db00d2cb056922356104468019c0a132e89c8d3ab67d8ede9f4483d2a/yarl-1.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877b0738624280e34c55680d6054a307aa94f7d52fa0e3034a9cc6e790871da7", size = 96950, upload-time = "2026-03-01T22:05:27.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/10fa93811fd439341fad7e0718a86aca0de9548023bbb403668d6555acab/yarl-1.23.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b5405bb8f0e783a988172993cfc627e4d9d00432d6bbac65a923041edacf997d", size = 93960, upload-time = "2026-03-01T22:05:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d2/8ae2e6cd77d0805f4526e30ec43b6f9a3dfc542d401ac4990d178e4bf0cf/yarl-1.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c3a3598a832590c5a3ce56ab5576361b5688c12cb1d39429cf5dba30b510760", size = 104703, upload-time = "2026-03-01T22:05:30.438Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0c/b3ceacf82c3fe21183ce35fa2acf5320af003d52bc1fcf5915077681142e/yarl-1.23.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8419ebd326430d1cbb7efb5292330a2cf39114e82df5cc3d83c9a0d5ebeaf2f2", size = 98325, upload-time = "2026-03-01T22:05:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e0/12900edd28bdab91a69bd2554b85ad7b151f64e8b521fe16f9ad2f56477a/yarl-1.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:be61f6fff406ca40e3b1d84716fde398fc08bc63dd96d15f3a14230a0973ed86", size = 105067, upload-time = "2026-03-01T22:05:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/15/61/74bb1182cf79c9bbe4eb6b1f14a57a22d7a0be5e9cedf8e2d5c2086474c3/yarl-1.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3ceb13c5c858d01321b5d9bb65e4cf37a92169ea470b70fec6f236b2c9dd7e34", size = 100285, upload-time = "2026-03-01T22:05:35.4Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/cd5ef733f2550de6241bd8bd8c3febc78158b9d75f197d9c7baa113436af/yarl-1.23.0-cp312-cp312-win32.whl", hash = "sha256:fffc45637bcd6538de8b85f51e3df3223e4ad89bccbfca0481c08c7fc8b7ed7d", size = 82359, upload-time = "2026-03-01T22:05:36.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/25216a49daeeb7af2bec0db22d5e7df08ed1d7c9f65d78b14f3b74fd72fc/yarl-1.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:f69f57305656a4852f2a7203efc661d8c042e6cc67f7acd97d8667fb448a426e", size = 87674, upload-time = "2026-03-01T22:05:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/35/aeab955d6c425b227d5b7247eafb24f2653fedc32f95373a001af5dfeb9e/yarl-1.23.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e87a6e8735b44816e7db0b2fbc9686932df473c826b0d9743148432e10bb9b9", size = 81879, upload-time = "2026-03-01T22:05:40.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4b/a0a6e5d0ee8a2f3a373ddef8a4097d74ac901ac363eea1440464ccbe0898/yarl-1.23.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:16c6994ac35c3e74fb0ae93323bf8b9c2a9088d55946109489667c510a7d010e", size = 123796, upload-time = "2026-03-01T22:05:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b6/8925d68af039b835ae876db5838e82e76ec87b9782ecc97e192b809c4831/yarl-1.23.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4a42e651629dafb64fd5b0286a3580613702b5809ad3f24934ea87595804f2c5", size = 86547, upload-time = "2026-03-01T22:05:42.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/50/06d511cc4b8e0360d3c94af051a768e84b755c5eb031b12adaaab6dec6e5/yarl-1.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c6b9461a2a8b47c65eef63bb1c76a4f1c119618ffa99ea79bc5bb1e46c5821b", size = 85854, upload-time = "2026-03-01T22:05:44.85Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f4/4e30b250927ffdab4db70da08b9b8d2194d7c7b400167b8fbeca1e4701ca/yarl-1.23.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2569b67d616eab450d262ca7cb9f9e19d2f718c70a8b88712859359d0ab17035", size = 98351, upload-time = "2026-03-01T22:05:46.836Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fc/4118c5671ea948208bdb1492d8b76bdf1453d3e73df051f939f563e7dcc5/yarl-1.23.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e9d9a4d06d3481eab79803beb4d9bd6f6a8e781ec078ac70d7ef2dcc29d1bea5", size = 92711, upload-time = "2026-03-01T22:05:48.316Z" },
+    { url = "https://files.pythonhosted.org/packages/56/11/1ed91d42bd9e73c13dc9e7eb0dd92298d75e7ac4dd7f046ad0c472e231cd/yarl-1.23.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f514f6474e04179d3d33175ed3f3e31434d3130d42ec153540d5b157deefd735", size = 106014, upload-time = "2026-03-01T22:05:50.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c9/74e44e056a23fbc33aca71779ef450ca648a5bc472bdad7a82339918f818/yarl-1.23.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fda207c815b253e34f7e1909840fd14299567b1c0eb4908f8c2ce01a41265401", size = 105557, upload-time = "2026-03-01T22:05:51.416Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fe/b1e10b08d287f518994f1e2ff9b6d26f0adeecd8dd7d533b01bab29a3eda/yarl-1.23.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34b6cf500e61c90f305094911f9acc9c86da1a05a7a3f5be9f68817043f486e4", size = 101559, upload-time = "2026-03-01T22:05:52.872Z" },
+    { url = "https://files.pythonhosted.org/packages/72/59/c5b8d94b14e3d3c2a9c20cb100119fd534ab5a14b93673ab4cc4a4141ea5/yarl-1.23.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7504f2b476d21653e4d143f44a175f7f751cd41233525312696c76aa3dbb23f", size = 100502, upload-time = "2026-03-01T22:05:54.954Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4f/96976cb54cbfc5c9fd73ed4c51804f92f209481d1fb190981c0f8a07a1d7/yarl-1.23.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:578110dd426f0d209d1509244e6d4a3f1a3e9077655d98c5f22583d63252a08a", size = 98027, upload-time = "2026-03-01T22:05:56.409Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6e/904c4f476471afdbad6b7e5b70362fb5810e35cd7466529a97322b6f5556/yarl-1.23.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:609d3614d78d74ebe35f54953c5bbd2ac647a7ddb9c30a5d877580f5e86b22f2", size = 95369, upload-time = "2026-03-01T22:05:58.141Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/40/acfcdb3b5f9d68ef499e39e04d25e141fe90661f9d54114556cf83be8353/yarl-1.23.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4966242ec68afc74c122f8459abd597afd7d8a60dc93d695c1334c5fd25f762f", size = 105565, upload-time = "2026-03-01T22:06:00.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c6/31e28f3a6ba2869c43d124f37ea5260cac9c9281df803c354b31f4dd1f3c/yarl-1.23.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e0fd068364a6759bc794459f0a735ab151d11304346332489c7972bacbe9e72b", size = 99813, upload-time = "2026-03-01T22:06:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/08/1f/6f65f59e72d54aa467119b63fc0b0b1762eff0232db1f4720cd89e2f4a17/yarl-1.23.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:39004f0ad156da43e86aa71f44e033de68a44e5a31fc53507b36dd253970054a", size = 105632, upload-time = "2026-03-01T22:06:03.188Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c4/18b178a69935f9e7a338127d5b77d868fdc0f0e49becd286d51b3a18c61d/yarl-1.23.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e5723c01a56c5028c807c701aa66722916d2747ad737a046853f6c46f4875543", size = 101895, upload-time = "2026-03-01T22:06:04.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/54/f5b870b5505663911dba950a8e4776a0dbd51c9c54c0ae88e823e4b874a0/yarl-1.23.0-cp313-cp313-win32.whl", hash = "sha256:1b6b572edd95b4fa8df75de10b04bc81acc87c1c7d16bcdd2035b09d30acc957", size = 82356, upload-time = "2026-03-01T22:06:06.04Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/84/266e8da36879c6edcd37b02b547e2d9ecdfea776be49598e75696e3316e1/yarl-1.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:baaf55442359053c7d62f6f8413a62adba3205119bcb6f49594894d8be47e5e3", size = 87515, upload-time = "2026-03-01T22:06:08.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fd/7e1c66efad35e1649114fa13f17485f62881ad58edeeb7f49f8c5e748bf9/yarl-1.23.0-cp313-cp313-win_arm64.whl", hash = "sha256:fb4948814a2a98e3912505f09c9e7493b1506226afb1f881825368d6fb776ee3", size = 81785, upload-time = "2026-03-01T22:06:10.181Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fc/119dd07004f17ea43bb91e3ece6587759edd7519d6b086d16bfbd3319982/yarl-1.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:aecfed0b41aa72b7881712c65cf764e39ce2ec352324f5e0837c7048d9e6daaa", size = 130719, upload-time = "2026-03-01T22:06:11.708Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/0d/9f2348502fbb3af409e8f47730282cd6bc80dec6630c1e06374d882d6eb2/yarl-1.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a41bcf68efd19073376eb8cf948b8d9be0af26256403e512bb18f3966f1f9120", size = 89690, upload-time = "2026-03-01T22:06:13.429Z" },
+    { url = "https://files.pythonhosted.org/packages/50/93/e88f3c80971b42cfc83f50a51b9d165a1dbf154b97005f2994a79f212a07/yarl-1.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cde9a2ecd91668bcb7f077c4966d8ceddb60af01b52e6e3e2680e4cf00ad1a59", size = 89851, upload-time = "2026-03-01T22:06:15.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/07/61c9dd8ba8f86473263b4036f70fb594c09e99c0d9737a799dfd8bc85651/yarl-1.23.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5023346c4ee7992febc0068e7593de5fa2bf611848c08404b35ebbb76b1b0512", size = 95874, upload-time = "2026-03-01T22:06:17.553Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/f9ff8ceefba599eac6abddcfb0b3bee9b9e636e96dbf54342a8577252379/yarl-1.23.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1009abedb49ae95b136a8904a3f71b342f849ffeced2d3747bf29caeda218c4", size = 88710, upload-time = "2026-03-01T22:06:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/78/0231bfcc5d4c8eec220bc2f9ef82cb4566192ea867a7c5b4148f44f6cbcd/yarl-1.23.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a8d00f29b42f534cc8aa3931cfe773b13b23e561e10d2b26f27a8d309b0e82a1", size = 101033, upload-time = "2026-03-01T22:06:21.203Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/9b/30ea5239a61786f18fd25797151a17fbb3be176977187a48d541b5447dd4/yarl-1.23.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:95451e6ce06c3e104556d73b559f5da6c34a069b6b62946d3ad66afcd51642ea", size = 100817, upload-time = "2026-03-01T22:06:22.738Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e2/a4980481071791bc83bce2b7a1a1f7adcabfa366007518b4b845e92eeee3/yarl-1.23.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531ef597132086b6cf96faa7c6c1dcd0361dd5f1694e5cc30375907b9b7d3ea9", size = 97482, upload-time = "2026-03-01T22:06:24.21Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1e/304a00cf5f6100414c4b5a01fc7ff9ee724b62158a08df2f8170dfc72a2d/yarl-1.23.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88f9fb0116fbfcefcab70f85cf4b74a2b6ce5d199c41345296f49d974ddb4123", size = 95949, upload-time = "2026-03-01T22:06:25.697Z" },
+    { url = "https://files.pythonhosted.org/packages/68/03/093f4055ed4cae649ac53bca3d180bd37102e9e11d048588e9ab0c0108d0/yarl-1.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e7b0460976dc75cb87ad9cc1f9899a4b97751e7d4e77ab840fc9b6d377b8fd24", size = 95839, upload-time = "2026-03-01T22:06:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/28/4c75ebb108f322aa8f917ae10a8ffa4f07cae10a8a627b64e578617df6a0/yarl-1.23.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:115136c4a426f9da976187d238e84139ff6b51a20839aa6e3720cd1026d768de", size = 90696, upload-time = "2026-03-01T22:06:29.048Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9c/42c2e2dd91c1a570402f51bdf066bfdb1241c2240ba001967bad778e77b7/yarl-1.23.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:ead11956716a940c1abc816b7df3fa2b84d06eaed8832ca32f5c5e058c65506b", size = 100865, upload-time = "2026-03-01T22:06:30.525Z" },
+    { url = "https://files.pythonhosted.org/packages/74/05/1bcd60a8a0a914d462c305137246b6f9d167628d73568505fce3f1cb2e65/yarl-1.23.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:fe8f8f5e70e6dbdfca9882cd9deaac058729bcf323cf7a58660901e55c9c94f6", size = 96234, upload-time = "2026-03-01T22:06:32.692Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b2/f52381aac396d6778ce516b7bc149c79e65bfc068b5de2857ab69eeea3b7/yarl-1.23.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:a0e317df055958a0c1e79e5d2aa5a5eaa4a6d05a20d4b0c9c3f48918139c9fc6", size = 100295, upload-time = "2026-03-01T22:06:34.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/638bae5bbf1113a659b2435d8895474598afe38b4a837103764f603aba56/yarl-1.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f0fd84de0c957b2d280143522c4f91a73aada1923caee763e24a2b3fda9f8a5", size = 97784, upload-time = "2026-03-01T22:06:35.864Z" },
+    { url = "https://files.pythonhosted.org/packages/80/25/a3892b46182c586c202629fc2159aa13975d3741d52ebd7347fd501d48d5/yarl-1.23.0-cp313-cp313t-win32.whl", hash = "sha256:93a784271881035ab4406a172edb0faecb6e7d00f4b53dc2f55919d6c9688595", size = 88313, upload-time = "2026-03-01T22:06:37.39Z" },
+    { url = "https://files.pythonhosted.org/packages/43/68/8c5b36aa5178900b37387937bc2c2fe0e9505537f713495472dcf6f6fccc/yarl-1.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dd00607bffbf30250fe108065f07453ec124dbf223420f57f5e749b04295e090", size = 94932, upload-time = "2026-03-01T22:06:39.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cc/d79ba8292f51f81f4dc533a8ccfb9fc6992cabf0998ed3245de7589dc07c/yarl-1.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ac09d42f48f80c9ee1635b2fcaa819496a44502737660d3c0f2ade7526d29144", size = 84786, upload-time = "2026-03-01T22:06:41.988Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Close #433 

# Description

Refactors the extraction evaluation pipeline from batch-oriented to file-level processing, improving readability and maintainability.

# Changes

Introduces a new `Evaluator` class (`src/extraction/evaluation/evaluator.py`) as the main entry point for evaluation
* `Evaluator.evaluate(file)`: evaluates a single file, compute metrics, and mutates the `is_correct` flags on its entries (layers, depth intervals, material descriptions, groundwater, metadata).
* `Evaluator.aggregate(files)`: Aggregates results for all files.

# Output MLFlow

The logged output files were homogenized across geology and metadata. At the end of the script, we log each metric: F1, precision, and recall. Before that, only F1 was logged, and sometimes recall and precision, depending on the metrics. In addition, the way Dataframes are compute are unified across geology and metadata with `to_df()`