### PR TITLE
Incorrect overlap between successive boreholes

### DIFF
--- a/src/extraction/features/stratigraphy/layer/continuation_detection.py
+++ b/src/extraction/features/stratigraphy/layer/continuation_detection.py
@@ -72,11 +72,11 @@ def _prepare_merge_candidates(
             * Unaffected boreholes from the current page.
     """
     # 1) Overlap-based (returns a triple)
-    borehole_to_extend, borehole_continuation, last_duplicated_layer_index = select_boreholes_with_overlap(
+    borehole_to_extend, borehole_continuation, overlap_result = select_boreholes_with_overlap(
         previous_page_boreholes, current_page_boreholes, matching_params
     )
 
-    if borehole_to_extend is None or borehole_continuation is None or last_duplicated_layer_index is None:
+    if borehole_to_extend is None or borehole_continuation is None or overlap_result is None:
         # 2) Depth/position-based (returns a pair) → normalize to triple
         borehole_to_extend, borehole_continuation = _select_boreholes_for_concatenation(
             previous_page_boreholes, current_page_boreholes, page_number
@@ -89,8 +89,8 @@ def _prepare_merge_candidates(
         borehole for borehole in current_page_boreholes if borehole is not borehole_continuation
     ]
 
-    if last_duplicated_layer_index:
-        upper_id, lower_id = last_duplicated_layer_index
+    if overlap_result:
+        upper_id, lower_id = overlap_result.upper_id, overlap_result.lower_id
 
         if upper_id > 0 and lower_id > 0:
             upper_layer = borehole_to_extend.predictions[upper_id - 1]

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -121,7 +121,7 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
 
     for i in list(range(1, min(len(layers_prev), len(layers_curr)) + 1)):
         # All layers should match to enforce overlap
-        convoluted_layers_match = [
+        if all(
             _are_layers_similar(
                 layer_prev=layer_prev,
                 layer_curr=layer_curr,
@@ -130,9 +130,7 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
                 is_extremity=(j == 0 or j == i - 1),  # Indicate to function that one layer might be cut (extremities)
             )
             for j, (layer_prev, layer_curr) in enumerate(zip(layers_prev[-i:], layers_curr[:i], strict=True))
-        ]
-        print(convoluted_layers_match)
-        if all(convoluted_layers_match):
+        ):
             idx_next = i
 
     return idx_next

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -83,10 +83,18 @@ def _are_layers_similar(
     # Rule 3: If depth exists, should match
     if force_depth_matching and layer_curr.depths and layer_prev.depths:
         # Rule 3.1 Strating depth should match
-        if layer_curr.depths.start and layer_prev.depths.start and layer_curr.depths.start != layer_prev.depths.start:
+        if (
+            layer_curr.depths.start
+            and layer_prev.depths.start
+            and layer_curr.depths.start.value != layer_prev.depths.start.value
+        ):
             return False
         # Rule 3.2 Ending depth should match
-        if layer_curr.depths.end and layer_prev.depths.end and layer_curr.depths.end != layer_prev.depths.end:
+        if (
+            layer_curr.depths.end
+            and layer_prev.depths.end
+            and layer_curr.depths.end.value != layer_prev.depths.end.value
+        ):
             return False
 
     # All rules validated
@@ -113,7 +121,7 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
 
     for i in list(range(1, min(len(layers_prev), len(layers_curr)) + 1)):
         # All layers should match to enforce overlap
-        if all(
+        convoluted_layers_match = [
             _are_layers_similar(
                 layer_prev=layer_prev,
                 layer_curr=layer_curr,
@@ -122,7 +130,9 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
                 is_extremity=(j == 0 or j == i - 1),  # Indicate to function that one layer might be cut (extremities)
             )
             for j, (layer_prev, layer_curr) in enumerate(zip(layers_prev[-i:], layers_curr[:i], strict=True))
-        ):
+        ]
+        print(convoluted_layers_match)
+        if all(convoluted_layers_match):
             idx_next = i
 
     return idx_next

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+from dataclasses import dataclass
 
 import Levenshtein
 
@@ -10,11 +11,23 @@ from extraction.features.stratigraphy.layer.layer import ExtractedBorehole, Laye
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class OverlapResult:
+    """Data class that contains all information regaring overlapping layers on consecutive pages.
+
+    `upper_id` is the number of layers to keep from the previous borehole and `lower_id` is the index of the
+    first non-overlapping layer in the continuing borehole.
+    """
+
+    upper_id: int
+    lower_id: int
+
+
 def select_boreholes_with_overlap(
     previous_page_boreholes: list[ExtractedBorehole],
     current_page_boreholes: list[ExtractedBorehole],
     matching_params: dict,
-) -> tuple[ExtractedBorehole | None, ExtractedBorehole | None, tuple[int, int] | None]:
+) -> tuple[ExtractedBorehole | None, ExtractedBorehole | None, OverlapResult | None]:
     """Remove duplicate layers caused by overlapping scanned pages.
 
     Compare layers from current page with those from previous page using a sliding-window
@@ -26,22 +39,16 @@ def select_boreholes_with_overlap(
         matching_params (dict): The parameters for matching boreholes.
 
     Returns:
-        (ExtractedBorehole | None, ExtractedBorehole | None, tuple[int, int] | None):
-            The borehole to be extended, the continuing borehole, and the cut indices
-            ``(upper_id, lower_id)`` where ``upper_id`` is the number of layers to keep
-            from the previous borehole and ``lower_id`` is the index of the first
-            non-overlapping layer in the continuing borehole.
+        (ExtractedBorehole | None, ExtractedBorehole | None, OverlapResult | None):
+            The borehole to be extended, the continuing borehole, and the precise location of the overlap.
     """
     for current_borehole in current_page_boreholes:
         for previous_page_borehole in previous_page_boreholes:
             # Check overlap between layers
-            if id_best := find_split_by_convolution(
+            if overlap := find_split_by_convolution(
                 previous_page_borehole.predictions, current_borehole.predictions, matching_params
             ):
-                upper_id = len(previous_page_borehole.predictions)
-                lower_id = id_best
-
-                return previous_page_borehole, current_borehole, (upper_id, lower_id)
+                return previous_page_borehole, current_borehole, overlap
 
     return None, None, None
 
@@ -106,7 +113,9 @@ def are_layers_similar(
     return True
 
 
-def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer], matching_params: dict) -> int | None:
+def find_split_by_convolution(
+    layers_prev: list[Layer], layers_curr: list[Layer], matching_params: dict
+) -> OverlapResult | None:
     """Find the extent of overlap between consecutive page layers.
 
     Determines the maximum number of consecutive layers from the bottom of the previous
@@ -118,7 +127,7 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
         matching_params (dict): Configuration dict with keys.
 
     Returns:
-        int | None: Index of first non-overlapping layer in current page, or None if no overlap.
+        OverlapResult | None: indices that define the overlapping layers, or None if no overlap.
     """
     material_threshold = matching_params["duplicate_layer_threshold"]
 
@@ -141,14 +150,14 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
             else:
                 if match_with_depths_count >= 2:
                     # allow the overlap, even though not all layers match
-                    return i
+                    return OverlapResult(upper_id=len(layers_prev) - i + j, lower_id=j)
                 # no valid overlap; break inner loop and go to next value for i
                 match_ok = False
                 break
 
         # all layers matched
         if match_ok:
-            return i
+            return OverlapResult(upper_id=len(layers_prev), lower_id=i)
 
 
 def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool) -> bool:

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -1,6 +1,7 @@
 """This module contains functionality for detecting duplicate layers across pdf pages."""
 
 import logging
+import math
 
 import Levenshtein
 
@@ -43,10 +44,10 @@ def select_boreholes_with_overlap(
     return None, None, None
 
 
-def _are_layers_similar(
+def are_layers_similar(
     layer_prev: Layer,
     layer_curr: Layer,
-    material_threshold: float,
+    material_threshold: float = 0.95,
     force_depth_matching: bool = False,
     is_extremity: bool = False,
 ) -> bool:
@@ -60,7 +61,7 @@ def _are_layers_similar(
     Args:
         layer_prev (Layer): The layer from the previous page.
         layer_curr (Layer): The layer from the current page.
-        material_threshold (float): Minimum similarity threshold for material descriptions.
+        material_threshold (float): Minimum similarity threshold for material descriptions. Defaults to 0.95.
         force_depth_matching (bool, optional): Whether to enforce matching depths. Defaults to False.
         is_extremity (bool, optional): Whether this layer is at the boundary of the overlap. Defaults to False.
 
@@ -82,18 +83,22 @@ def _are_layers_similar(
 
     # Rule 3: If depth exists, should match
     if force_depth_matching and layer_curr.depths and layer_prev.depths:
-        # Rule 3.1 Strating depth should match
+        # Rule 3.1 Strating depth should match within tolerence
         if (
             layer_curr.depths.start
+            and layer_curr.depths.start.value
             and layer_prev.depths.start
-            and layer_curr.depths.start.value != layer_prev.depths.start.value
+            and layer_prev.depths.start.value
+            and not math.isclose(layer_curr.depths.start.value, layer_prev.depths.start.value, abs_tol=1e-2)
         ):
             return False
-        # Rule 3.2 Ending depth should match
+        # Rule 3.2 Ending depth should match within tolerence
         if (
             layer_curr.depths.end
+            and layer_curr.depths.end.value
             and layer_prev.depths.end
-            and layer_curr.depths.end.value != layer_prev.depths.end.value
+            and layer_prev.depths.end.value
+            and not math.isclose(layer_curr.depths.end.value, layer_prev.depths.end.value, abs_tol=1e-2)
         ):
             return False
 
@@ -122,7 +127,7 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
     for i in list(range(1, min(len(layers_prev), len(layers_curr)) + 1)):
         # All layers should match to enforce overlap
         if all(
-            _are_layers_similar(
+            are_layers_similar(
                 layer_prev=layer_prev,
                 layer_curr=layer_curr,
                 material_threshold=material_threshold,

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -50,7 +50,6 @@ def are_layers_similar(
     layer_prev: Layer,
     layer_curr: Layer,
     material_threshold: float = 0.95,
-    force_depth_matching: bool = False,
     is_extremity: bool = False,
 ) -> bool:
     """Check if two layers are similar based on material description and optional depth matching.
@@ -64,7 +63,6 @@ def are_layers_similar(
         layer_prev (Layer): The layer from the previous page.
         layer_curr (Layer): The layer from the current page.
         material_threshold (float): Minimum similarity threshold for material descriptions. Defaults to 0.95.
-        force_depth_matching (bool, optional): Whether to enforce matching depths. Defaults to False.
         is_extremity (bool, optional): Whether this layer is at the boundary of the overlap. Defaults to False.
 
     Returns:
@@ -84,7 +82,7 @@ def are_layers_similar(
         return False
 
     # Rule 3: If depth exists, should match
-    if force_depth_matching and layer_curr.depths and layer_prev.depths:
+    if layer_curr.depths and layer_prev.depths:
         # Rule 3.1 Starting depth should match within tolerance
         if (
             layer_curr.depths.start
@@ -123,24 +121,34 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
         int | None: Index of first non-overlapping layer in current page, or None if no overlap.
     """
     material_threshold = matching_params["duplicate_layer_threshold"]
-    force_depth = matching_params["duplicate_layer_force_depth"]
-    idx_next = None
 
-    for i in list(range(1, min(len(layers_prev), len(layers_curr)) + 1)):
-        # All layers should match to enforce overlap
-        if all(
-            are_layers_similar(
+    # check the longest possible overlap first
+    for i in range(min(len(layers_prev), len(layers_curr)), 0, -1):
+        match_with_depths_count = 0
+        match_ok = True
+
+        for j, (layer_prev, layer_curr) in enumerate(zip(layers_prev[-i:], layers_curr[:i], strict=True)):
+            if are_layers_similar(
                 layer_prev=layer_prev,
                 layer_curr=layer_curr,
                 material_threshold=material_threshold,
-                force_depth_matching=force_depth,
                 is_extremity=(j == 0 or j == i - 1),  # Indicate to function that one layer might be cut (extremities)
-            )
-            for j, (layer_prev, layer_curr) in enumerate(zip(layers_prev[-i:], layers_curr[:i], strict=True))
-        ):
-            idx_next = i
+            ):
+                if layer_prev.depths and layer_prev.depths.start and layer_prev.depths.end:
+                    match_with_depths_count += 1
+                else:
+                    match_with_depths_count = 0
+            else:
+                if match_with_depths_count >= 2:
+                    # allow the overlap, even though not all layers match
+                    return i
+                # no valid overlap; break inner loop and go to next value for i
+                match_ok = False
+                break
 
-    return idx_next
+        # all layers matched
+        if match_ok:
+            return i
 
 
 def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool) -> bool:

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -40,64 +40,15 @@ def select_boreholes_with_overlap(
 
                 return previous_page_borehole, current_borehole, (upper_id, lower_id)
 
-            # TODO remove old methods
-            # bottom_duplicate_idx = find_last_duplicate_layer_index(
-            #     previous_page_borehole.predictions, current_borehole.predictions, matching_params
-            # )
-
-            # # Potential overlap detected
-            # if bottom_duplicate_idx is not None:
-            #     # Compute indices to cut duplicate layers at the overlap
-            #   upper_id, lower_id = find_optimal_split(previous_page_borehole, current_borehole, bottom_duplicate_idx)
-
-            # return previous_page_borehole, current_borehole, (upper_id, lower_id)
-
     return None, None, None
 
 
-def find_optimal_split(
-    borehole_to_extend: ExtractedBorehole, borehole_continuation: ExtractedBorehole, last_duplicate_layer_index: int
-) -> tuple[int, int]:
-    """Find cut indices to remove duplicated layers when merging two boreholes.
-
-    When a borehole continues on the next page, some top layers of the new page
-    may duplicate the bottom layers of the previous page. This function walks the
-    overlap (from the bottom up) and shifts the split upward if the upper
-    layer lacks depth information while the corresponding lower layer has it.
-    This preserves the most complete layer data across the boundary.
-
-    Args:
-        borehole_to_extend (ExtractedBorehole): The borehole from the previous page.
-        borehole_continuation (ExtractedBorehole): The borehole from the current page.
-        last_duplicate_layer_index (int): The index of the last duplicated layer in the continuing borehole.
-
-    Returns:
-        tuple[int, int]: `(id_upper_end, id_lower_start)` such that concatenating these two slices removes
-        duplicates while keeping the most informative depth entries.
-    """
-    # Check the number of layer that overlaps
-    n_overlap = min(len(borehole_to_extend.predictions), last_duplicate_layer_index + 1)
-    offset = 0
-
-    # Check if threshold should be moved
-    for i in range(n_overlap):
-        upper_layer = borehole_to_extend.predictions[-(i + 1)]
-        lower_layer = borehole_continuation.predictions[last_duplicate_layer_index - i]
-        # It is possible that the information of the upper layers is cut (), check if we can retrieve information from
-        # the lower layers
-        if not upper_layer.depth_nonempty() and lower_layer.depth_nonempty():
-            offset += 1
-        else:
-            # As soon as information is missing in the lower layer, stop iteration
-            break
-    # Define cut ids
-    id_upper_end = len(borehole_to_extend.predictions) - offset
-    id_lower_start = 1 + last_duplicate_layer_index - offset
-    return id_upper_end, id_lower_start
-
-
 def _are_layers_similar(
-    layer_prev: Layer, layer_curr: Layer, material_threshold: float, force_depth_matching: bool = False
+    layer_prev: Layer,
+    layer_curr: Layer,
+    material_threshold: float,
+    force_depth_matching: bool = False,
+    is_extremity: bool = False,
 ) -> bool:
     """_summary_.
 
@@ -106,6 +57,7 @@ def _are_layers_similar(
         layer_curr (Layer): _description_
         material_threshold (float): _description_
         force_depth_matching (bool, optional): _description_. Defaults to False.
+        is_extremity (bool, optional): _description_. Defaults to False.
 
     Returns:
         bool: _description_
@@ -120,6 +72,7 @@ def _are_layers_similar(
         cur_text=layer_curr.material_description.text,
         prev_text=layer_prev.material_description.text,
         t=material_threshold,
+        is_extremity=is_extremity,
     ):
         return False
 
@@ -137,7 +90,7 @@ def _are_layers_similar(
 
 
 def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer], matching_params: dict) -> int | None:
-    """_summary_.
+    """_summary_. Find first layer in current that does not overlap with previous. If none, no overlap.
 
     Args:
         layers_prev (list[Layer]): _description_
@@ -148,90 +101,27 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
         int | None: _description_
     """
     material_threshold = matching_params["duplicate_layer_threshold"]
+    force_depth = matching_params["duplicate_layer_force_depth"]
     idx_best = None
 
     for i in list(range(1, min(len(layers_prev), len(layers_curr)) + 1)):
         # All layers should match to enforce overlap
         if all(
-            _are_layers_similar(layers_prev, layers_curr, material_threshold)
-            for layers_prev, layers_curr in zip(layers_prev[-i:], layers_curr[:i], strict=True)
+            _are_layers_similar(
+                layer_prev=layer_prev,
+                layer_curr=layer_curr,
+                material_threshold=material_threshold,
+                force_depth_matching=force_depth,
+                is_extremity=(j == 0 or j == i - 1),  # Indicate to function that one layer might be cut (extremities)
+            )
+            for j, (layer_prev, layer_curr) in enumerate(zip(layers_prev[-i:], layers_curr[:i], strict=True))
         ):
             idx_best = i
 
     return idx_best
 
 
-def find_last_duplicate_layer_index(
-    previous_page_layers: list[Layer], sorted_layers: list[Layer], matching_params: dict
-) -> int | None:
-    """Find the index of the last duplicate layer in the current page compared to the previous page.
-
-    The last duplicated layer is the deepest one that is duplicated, starting from the top.
-
-    Args:
-        previous_page_layers (list[Layer]): Layers from a borehole on the previous page sorted from top to bottom
-        sorted_layers (list[Layer]): Layers from a borehole on the current page sorted from top to bottom
-        matching_params (dict): The parameters for matching boreholes.
-
-    Returns:
-        int | None: Index of the last duplicate layer or None if not found
-    """
-    compare_against_idx = len(previous_page_layers) - 1  # begin comparison against the last of previous page
-    layer_idx = len(sorted_layers) - 1  # begin from the bottom of the current page, then validate upwards
-
-    bottom_duplicate_idx = None
-    duplicate_layer_threshold = matching_params["duplicate_layer_threshold"]
-
-    while layer_idx >= 0:
-        current_layer = sorted_layers[layer_idx]
-        if not current_layer.material_description:
-            layer_idx -= 1
-            continue
-        if compare_against_idx < 0:
-            break  # we've run out of previous layers to compare against
-
-        previous_page_layer = previous_page_layers[compare_against_idx]
-
-        # 1. check of the current layer with the compare_against_idx'th layer of previous page.
-        if _is_duplicate(
-            current_layer.material_description.text,
-            previous_page_layer.material_description.text,
-            duplicate_layer_threshold,
-        ):
-            # 2. check in case of wrong lines split of the merged layer with the compare_against_idx'th layer of
-            # previous page.
-            layer_idx_delta = 1
-            if layer_idx >= 1 and sorted_layers[layer_idx - 1].material_description:
-                text_merged = " ".join(
-                    [sorted_layers[layer_idx - 1].material_description.text, current_layer.material_description.text]
-                )
-                if _is_duplicate(
-                    text_merged, previous_page_layer.material_description.text, duplicate_layer_threshold
-                ):
-                    # If the merged is also a duplicate, we should skip both layers.
-                    layer_idx_delta = 2
-
-            if bottom_duplicate_idx is None:
-                # record the lowest layer that is duplicated (i.e. the first encountered, as we iterate backwards).
-                bottom_duplicate_idx = layer_idx
-            layer_idx -= layer_idx_delta  # skip the wrongly split layer(s)
-            compare_against_idx -= 1
-            continue
-
-        # 3. No duplicate was found, we just continue with the above layer
-        if bottom_duplicate_idx is None:
-            layer_idx -= 1
-            continue
-        # 4. No duplicate was found, but we previously found a duplicate (bottom_duplicate_idx was set), it likely
-        # was a false positive and we reset the search
-        layer_idx = bottom_duplicate_idx - 1  # just above the false positive
-        bottom_duplicate_idx = None
-        compare_against_idx = len(previous_page_layers) - 1  # reset with the last layer of the previous page
-
-    return bottom_duplicate_idx
-
-
-def _is_duplicate(cur_text: str, prev_text: str, t: float):
+def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool):
     """Detect if layer and prev_layer are duplicates across a page break.
 
     Strategy:
@@ -243,14 +133,21 @@ def _is_duplicate(cur_text: str, prev_text: str, t: float):
         cur_text (str): The text of the current layer to compare.
         prev_text (str): The text of the previous layer to compare against.
         t (float): The similarity threshold.
+        is_extremity (bool): TODO
 
     Returns:
         bool: True if the layers are considered duplicates, False otherwise.
     """
     cur_text = cur_text.lower()
     prev_text = prev_text.lower()
-    min_length = min(len(cur_text), len(prev_text))
-    return (
-        Levenshtein.ratio(cur_text, prev_text[-min_length:]) > t
-        or Levenshtein.ratio(cur_text[:min_length], prev_text) > t
-    )
+
+    if is_extremity:
+        min_length = min(len(cur_text), len(prev_text))
+        score = max(
+            Levenshtein.ratio(cur_text, prev_text[-min_length:]),
+            Levenshtein.ratio(cur_text[:min_length], prev_text),
+        )
+    else:
+        score = Levenshtein.ratio(cur_text, prev_text)
+
+    return score > t

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -50,19 +50,23 @@ def _are_layers_similar(
     force_depth_matching: bool = False,
     is_extremity: bool = False,
 ) -> bool:
-    """_summary_.
+    """Check if two layers are similar based on material description and optional depth matching.
+
+    Validates layers through three rules:
+    1. Both layers must have material descriptions
+    2. Material descriptions must exceed similarity threshold
+    3. If force_depth_matching is enabled, depths must match
 
     Args:
-        layer_prev (Layer): _description_
-        layer_curr (Layer): _description_
-        material_threshold (float): _description_
-        force_depth_matching (bool, optional): _description_. Defaults to False.
-        is_extremity (bool, optional): _description_. Defaults to False.
+        layer_prev (Layer): The layer from the previous page.
+        layer_curr (Layer): The layer from the current page.
+        material_threshold (float): Minimum similarity threshold for material descriptions.
+        force_depth_matching (bool, optional): Whether to enforce matching depths. Defaults to False.
+        is_extremity (bool, optional): Whether this layer is at the boundary of the overlap. Defaults to False.
 
     Returns:
-        bool: _description_
+        bool: True if layers are similar according to all active rules, False otherwise.
     """
-    # Check how close two layers are from each other based on depth and material description
     # Rule 1: Material description should exists
     if not layer_prev.material_description or not layer_curr.material_description:
         return False
@@ -90,19 +94,22 @@ def _are_layers_similar(
 
 
 def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer], matching_params: dict) -> int | None:
-    """_summary_. Find first layer in current that does not overlap with previous. If none, no overlap.
+    """Find the extent of overlap between consecutive page layers.
+
+    Determines the maximum number of consecutive layers from the bottom of the previous
+    page that match the top layers of the current page.
 
     Args:
-        layers_prev (list[Layer]): _description_
-        layers_curr (list[Layer]): _description_
-        matching_params (dict): _description_
+        layers_prev (list[Layer]): Layers from the previous page, ordered top to bottom.
+        layers_curr (list[Layer]): Layers from the current page, ordered top to bottom.
+        matching_params (dict): Configuration dict with keys.
 
     Returns:
-        int | None: _description_
+        int | None: Index of first non-overlapping layer in current page, or None if no overlap.
     """
     material_threshold = matching_params["duplicate_layer_threshold"]
     force_depth = matching_params["duplicate_layer_force_depth"]
-    idx_best = None
+    idx_next = None
 
     for i in list(range(1, min(len(layers_prev), len(layers_curr)) + 1)):
         # All layers should match to enforce overlap
@@ -116,9 +123,9 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
             )
             for j, (layer_prev, layer_curr) in enumerate(zip(layers_prev[-i:], layers_curr[:i], strict=True))
         ):
-            idx_best = i
+            idx_next = i
 
-    return idx_best
+    return idx_next
 
 
 def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool):
@@ -133,7 +140,8 @@ def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool):
         cur_text (str): The text of the current layer to compare.
         prev_text (str): The text of the previous layer to compare against.
         t (float): The similarity threshold.
-        is_extremity (bool): TODO
+        is_extremity (bool): If True, uses partial text matching to handle truncated boundary layers.
+            If False, compares full text content.
 
     Returns:
         bool: True if the layers are considered duplicates, False otherwise.

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -17,8 +17,8 @@ def select_boreholes_with_overlap(
 ) -> tuple[ExtractedBorehole | None, ExtractedBorehole | None, tuple[int, int] | None]:
     """Remove duplicate layers caused by overlapping scanned pages.
 
-    Compare layers from current page with those from previous page to identify and remove
-    duplicates. Layers are compared from bottom to top based on their material descriptions.
+    Compare layers from current page with those from previous page using a sliding-window
+    approach to find the longest contiguous overlap at the page boundary.
 
     Args:
         previous_page_boreholes (list[ExtractedBorehole]): Layers from previous page
@@ -27,12 +27,14 @@ def select_boreholes_with_overlap(
 
     Returns:
         (ExtractedBorehole | None, ExtractedBorehole | None, tuple[int, int] | None):
-                The boreholes to be extended, the continuing borehole, and the indexes of the first and last
-                duplicated layer in the previous and continuing borehole, if any.
+            The borehole to be extended, the continuing borehole, and the cut indices
+            ``(upper_id, lower_id)`` where ``upper_id`` is the number of layers to keep
+            from the previous borehole and ``lower_id`` is the index of the first
+            non-overlapping layer in the continuing borehole.
     """
     for current_borehole in current_page_boreholes:
         for previous_page_borehole in previous_page_boreholes:
-            # # Check overlap between layers
+            # Check overlap between layers
             if id_best := find_split_by_convolution(
                 previous_page_borehole.predictions, current_borehole.predictions, matching_params
             ):
@@ -68,7 +70,7 @@ def are_layers_similar(
     Returns:
         bool: True if layers are similar according to all active rules, False otherwise.
     """
-    # Rule 1: Material description should exists
+    # Rule 1: Material descriptions must exist
     if not layer_prev.material_description or not layer_curr.material_description:
         return False
 
@@ -83,7 +85,7 @@ def are_layers_similar(
 
     # Rule 3: If depth exists, should match
     if force_depth_matching and layer_curr.depths and layer_prev.depths:
-        # Rule 3.1 Strating depth should match within tolerence
+        # Rule 3.1 Starting depth should match within tolerance
         if (
             layer_curr.depths.start
             and layer_curr.depths.start.value
@@ -92,7 +94,7 @@ def are_layers_similar(
             and not math.isclose(layer_curr.depths.start.value, layer_prev.depths.start.value, abs_tol=1e-2)
         ):
             return False
-        # Rule 3.2 Ending depth should match within tolerence
+        # Rule 3.2 Ending depth should match within tolerance
         if (
             layer_curr.depths.end
             and layer_curr.depths.end.value
@@ -141,13 +143,14 @@ def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer]
     return idx_next
 
 
-def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool):
+def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool) -> bool:
     """Detect if layer and prev_layer are duplicates across a page break.
 
     Strategy:
-      - Check any suffix of prev_text words vs the full current text.
-      - Check any prefix of current words vs the full prev_text text.
-    This covers both split cases (the prev_text was cut off / the cur_text only repeats the tail).
+        - If `is_extremity` is True: uses partial matching to handle truncated boundary layers. Compares
+        any suffix of `prev_text` against full `cur_text`, and any prefix of `cur_text` against
+        full `prev_text`.
+        - If `is_extremity` is False: compares the full text of both layers directly.
 
     Args:
         cur_text (str): The text of the current layer to compare.

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -31,16 +31,26 @@ def select_boreholes_with_overlap(
     """
     for current_borehole in current_page_boreholes:
         for previous_page_borehole in previous_page_boreholes:
-            bottom_duplicate_idx = find_last_duplicate_layer_index(
+            # # Check overlap between layers
+            if id_best := find_split_by_convolution(
                 previous_page_borehole.predictions, current_borehole.predictions, matching_params
-            )
-
-            # Potential overlap detected
-            if bottom_duplicate_idx is not None:
-                # Compute indices to cut duplicate layers at the overlap
-                upper_id, lower_id = find_optimal_split(previous_page_borehole, current_borehole, bottom_duplicate_idx)
+            ):
+                upper_id = len(previous_page_borehole.predictions)
+                lower_id = id_best
 
                 return previous_page_borehole, current_borehole, (upper_id, lower_id)
+
+            # TODO remove old methods
+            # bottom_duplicate_idx = find_last_duplicate_layer_index(
+            #     previous_page_borehole.predictions, current_borehole.predictions, matching_params
+            # )
+
+            # # Potential overlap detected
+            # if bottom_duplicate_idx is not None:
+            #     # Compute indices to cut duplicate layers at the overlap
+            #   upper_id, lower_id = find_optimal_split(previous_page_borehole, current_borehole, bottom_duplicate_idx)
+
+            # return previous_page_borehole, current_borehole, (upper_id, lower_id)
 
     return None, None, None
 
@@ -84,6 +94,71 @@ def find_optimal_split(
     id_upper_end = len(borehole_to_extend.predictions) - offset
     id_lower_start = 1 + last_duplicate_layer_index - offset
     return id_upper_end, id_lower_start
+
+
+def _are_layers_similar(
+    layer_prev: Layer, layer_curr: Layer, material_threshold: float, force_depth_matching: bool = False
+) -> bool:
+    """_summary_.
+
+    Args:
+        layer_prev (Layer): _description_
+        layer_curr (Layer): _description_
+        material_threshold (float): _description_
+        force_depth_matching (bool, optional): _description_. Defaults to False.
+
+    Returns:
+        bool: _description_
+    """
+    # Check how close two layers are from each other based on depth and material description
+    # Rule 1: Material description should exists
+    if not layer_prev.material_description or not layer_curr.material_description:
+        return False
+
+    # Rule 2: Material description score should exceed threshold
+    if not _is_duplicate(
+        cur_text=layer_curr.material_description.text,
+        prev_text=layer_prev.material_description.text,
+        t=material_threshold,
+    ):
+        return False
+
+    # Rule 3: If depth exists, should match
+    if force_depth_matching and layer_curr.depths and layer_prev.depths:
+        # Rule 3.1 Strating depth should match
+        if layer_curr.depths.start and layer_prev.depths.start and layer_curr.depths.start != layer_prev.depths.start:
+            return False
+        # Rule 3.2 Ending depth should match
+        if layer_curr.depths.end and layer_prev.depths.end and layer_curr.depths.end != layer_prev.depths.end:
+            return False
+
+    # All rules validated
+    return True
+
+
+def find_split_by_convolution(layers_prev: list[Layer], layers_curr: list[Layer], matching_params: dict) -> int | None:
+    """_summary_.
+
+    Args:
+        layers_prev (list[Layer]): _description_
+        layers_curr (list[Layer]): _description_
+        matching_params (dict): _description_
+
+    Returns:
+        int | None: _description_
+    """
+    material_threshold = matching_params["duplicate_layer_threshold"]
+    idx_best = None
+
+    for i in list(range(1, min(len(layers_prev), len(layers_curr)) + 1)):
+        # All layers should match to enforce overlap
+        if all(
+            _are_layers_similar(layers_prev, layers_curr, material_threshold)
+            for layers_prev, layers_curr in zip(layers_prev[-i:], layers_curr[:i], strict=True)
+        ):
+            idx_best = i
+
+    return idx_best
 
 
 def find_last_duplicate_layer_index(

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class OverlapResult:
-    """Data class that contains all information regaring overlapping layers on consecutive pages.
+    """Data class that contains all information regarding overlapping layers on consecutive pages.
 
     `upper_id` is the number of layers to keep from the previous borehole and `lower_id` is the index of the
     first non-overlapping layer in the continuing borehole.
@@ -64,7 +64,7 @@ def are_layers_similar(
     Validates layers through three rules:
     1. Both layers must have material descriptions
     2. Material descriptions must exceed similarity threshold
-    3. If force_depth_matching is enabled, depths must match
+    3. It present, depths must match
 
     Args:
         layer_prev (Layer): The layer from the previous page.
@@ -83,7 +83,7 @@ def are_layers_similar(
     if not _is_duplicate(
         cur_text=layer_curr.material_description.text,
         prev_text=layer_prev.material_description.text,
-        t=material_threshold,
+        threshold=material_threshold,
         is_extremity=is_extremity,
     ):
         return False
@@ -160,7 +160,7 @@ def find_split_by_convolution(
             return OverlapResult(upper_id=len(layers_prev), lower_id=i)
 
 
-def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool) -> bool:
+def _is_duplicate(cur_text: str, prev_text: str, threshold: float, is_extremity: bool) -> bool:
     """Detect if layer and prev_layer are duplicates across a page break.
 
     Strategy:
@@ -172,7 +172,7 @@ def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool) -
     Args:
         cur_text (str): The text of the current layer to compare.
         prev_text (str): The text of the previous layer to compare against.
-        t (float): The similarity threshold.
+        threshold (float): The similarity threshold.
         is_extremity (bool): If True, uses partial text matching to handle truncated boundary layers.
             If False, compares full text content.
 
@@ -191,4 +191,4 @@ def _is_duplicate(cur_text: str, prev_text: str, t: float, is_extremity: bool) -
     else:
         score = Levenshtein.ratio(cur_text, prev_text)
 
-    return score > t
+    return score > threshold

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -5,7 +5,7 @@ block_line_ratio: 0.20
 min_block_clearance: 10
 left_line_length_threshold: 7
 duplicate_layer_threshold: 0.95
-duplicate_layer_force_depth: False
+duplicate_layer_force_depth: True
 min_num_layers: 2
 protocol_min_num_layers: 1
 fallback_min_table_height_ratio: 0.85

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -5,7 +5,6 @@ block_line_ratio: 0.20
 min_block_clearance: 10
 left_line_length_threshold: 7
 duplicate_layer_threshold: 0.95
-duplicate_layer_force_depth: True
 min_num_layers: 2
 protocol_min_num_layers: 1
 fallback_min_table_height_ratio: 0.85

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -5,6 +5,7 @@ block_line_ratio: 0.20
 min_block_clearance: 10
 left_line_length_threshold: 7
 duplicate_layer_threshold: 0.95
+duplicate_layer_force_depth: False
 min_num_layers: 2
 protocol_min_num_layers: 1
 fallback_min_table_height_ratio: 0.85
@@ -59,24 +60,24 @@ affinity_params:
       gap_weight: 0.2
       indentation_weight: 0.0
   protocol:
-      importance: 1.0
-      min_entries: 2
-      header_keywords:
-        - Tiefe
-        - Tiefe bis
-        - Tiefe bis m
-        - bis
-        - Depth
-      max_header_gap: 40
-      # those parameters were chosen randomly but they behave well so far.
-      weights:
-        line_weight: 1.0
-        left_line_weight: 1.0
-        spacing_weight: 1.0
-        right_end_weight: 1.0
-        diagonal_weight: 1.0
-        gap_weight: 0.2
-        indentation_weight: 0.0
+    importance: 1.0
+    min_entries: 2
+    header_keywords:
+      - Tiefe
+      - Tiefe bis
+      - Tiefe bis m
+      - bis
+      - Depth
+    max_header_gap: 40
+    # those parameters were chosen randomly but they behave well so far.
+    weights:
+      line_weight: 1.0
+      left_line_weight: 1.0
+      spacing_weight: 1.0
+      right_end_weight: 1.0
+      diagonal_weight: 1.0
+      gap_weight: 0.2
+      indentation_weight: 0.0
 empty_interval_penalty: 0.2
 
 material_description_column_width: 0.08

--- a/tests/test_continuation_detection.py
+++ b/tests/test_continuation_detection.py
@@ -7,6 +7,7 @@ from extraction.features.stratigraphy.layer.layer import (
     LayerDepths,
     LayerDepthsEntry,
 )
+from extraction.features.stratigraphy.layer.overlap_detection import OverlapResult
 from swissgeol_doc_processing.text.textblock import MaterialDescription
 
 
@@ -47,7 +48,7 @@ def test_merge_boreholes_reconciles_duplicated_boundary_layer(monkeypatch):
 
     def mock_select_boreholes_with_overlap(previous_page_boreholes, current_page_boreholes, matching_params):
         if previous_page_boreholes == [previous_borehole] and current_page_boreholes == [current_borehole]:
-            return previous_borehole, current_borehole, (2, 1)
+            return previous_borehole, current_borehole, OverlapResult(2, 1)
         return None, None, None
 
     monkeypatch.setattr(

--- a/tests/test_overlap_detection.py
+++ b/tests/test_overlap_detection.py
@@ -45,8 +45,8 @@ def test_find_last_duplicate_no_duplicates(create_layer):
     prev_layers = [create_layer("Layer A"), create_layer("Layer B")]
     current_layers = [create_layer("Layer C"), create_layer("Layer D")]
 
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx is None
+    overlap_result = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert overlap_result is None
 
 
 def test_find_last_duplicate_single_at_top(create_layer):
@@ -54,8 +54,9 @@ def test_find_last_duplicate_single_at_top(create_layer):
     prev_layers = [create_layer("Layer A"), create_layer("Layer B")]
     current_layers = [create_layer("Layer B"), create_layer("Layer C"), create_layer("Layer D")]
 
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 1
+    overlap_result = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert overlap_result.upper_id == 2
+    assert overlap_result.lower_id == 1
 
 
 def test_find_last_duplicate_multiple_consecutive(create_layer):
@@ -63,8 +64,9 @@ def test_find_last_duplicate_multiple_consecutive(create_layer):
     prev_layers = [create_layer("Layer A"), create_layer("Layer B"), create_layer("Layer C")]
     current_layers = [create_layer("Layer B"), create_layer("Layer C"), create_layer("Layer D")]
 
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 2
+    overlap_result = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert overlap_result.upper_id == 3
+    assert overlap_result.lower_id == 2
 
 
 def test_find_last_duplicate_false_positive(create_layer):
@@ -78,8 +80,9 @@ def test_find_last_duplicate_false_positive(create_layer):
         create_layer("Layer D"),  # false positive, same description but not a duplicate
         create_layer("Layer Z"),
     ]
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
-    assert bottom_duplicated_idx == 2
+    overlap_result = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
+    assert overlap_result.upper_id == 4
+    assert overlap_result.lower_id == 2
 
     current_layers_correct = [
         create_layer("Layer X"),
@@ -87,8 +90,8 @@ def test_find_last_duplicate_false_positive(create_layer):
         create_layer("Layer D"),  # false positive, same description but not a duplicate
         create_layer("Layer Z"),
     ]
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
-    assert bottom_duplicated_idx is None
+    overlap_result = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
+    assert overlap_result is None
 
 
 def test_find_last_duplicate_prev_bottom_cropped(create_layer):
@@ -102,8 +105,9 @@ def test_find_last_duplicate_prev_bottom_cropped(create_layer):
         create_layer("Bedrock"),
     ]
 
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 1
+    overlap_result = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert overlap_result.upper_id == 2
+    assert overlap_result.lower_id == 1
 
 
 def test_find_last_duplicate_current_top_cropped(create_layer):
@@ -117,8 +121,9 @@ def test_find_last_duplicate_current_top_cropped(create_layer):
         create_layer("Bedrock"),
     ]
 
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 1
+    overlap_result = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert overlap_result.upper_id == 2
+    assert overlap_result.lower_id == 1
 
 
 def test_find_last_duplicate_ocr_error(create_layer):
@@ -129,8 +134,9 @@ def test_find_last_duplicate_ocr_error(create_layer):
         create_layer("Clay with gravel"),
     ]
 
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 1
+    overlap_result = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert overlap_result.upper_id == 2
+    assert overlap_result.lower_id == 1
 
 
 def test_find_last_duplicate_full_duplicates(create_layer):
@@ -143,8 +149,8 @@ def test_find_last_duplicate_full_duplicates(create_layer):
         create_layer("Layer C"),
         create_layer("Layer D"),
     ]
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
-    assert bottom_duplicated_idx is None
+    overlap_result = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
+    assert overlap_result is None
 
 
 def test_are_layers_similar_text(create_layer):

--- a/tests/test_overlap_detection.py
+++ b/tests/test_overlap_detection.py
@@ -67,21 +67,6 @@ def test_find_last_duplicate_multiple_consecutive(create_layer):
     assert bottom_duplicated_idx == 2
 
 
-def test_find_last_duplicate_wrong_line_grouping(create_layer):
-    """Test when description lines are grouped differently on each page, due to different scan quality."""
-    # TODO: Test for extremities
-    prev_layers = [create_layer("Layer A"), create_layer("Layer B"), create_layer("Layer C")]
-    current_layers = [
-        create_layer("Layer B"),
-        create_layer("Layer"),  # description incorrectly split,
-        create_layer("C"),  # the algorithm will also pick up this layer
-        create_layer("Layer D"),
-    ]
-
-    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 2
-
-
 def test_find_last_duplicate_false_positive(create_layer):
     """Test when a layer has the same description, but is not a duplicate (above layer do not match)."""
     prev_layers = [create_layer("Layer A"), create_layer("Layer B"), create_layer("Layer C"), create_layer("Layer D")]

--- a/tests/test_overlap_detection.py
+++ b/tests/test_overlap_detection.py
@@ -160,9 +160,8 @@ def test_are_layers_similar_elevation(create_elevation_layer):
     layer_a = create_elevation_layer("Desc A", [0, 1])
     layer_b = create_elevation_layer("Desc A", [0, 2])
     layer_c = create_elevation_layer("Desc A", [0, None])
-    assert are_layers_similar(layer_a, layer_b, force_depth_matching=False)
-    assert not are_layers_similar(layer_a, layer_b, force_depth_matching=True)
-    assert are_layers_similar(layer_a, layer_c, force_depth_matching=True)
+    assert not are_layers_similar(layer_a, layer_b)
+    assert are_layers_similar(layer_a, layer_c)
 
 
 def test_are_layers_similar_extremities(create_layer):

--- a/tests/test_overlap_detection.py
+++ b/tests/test_overlap_detection.py
@@ -4,7 +4,7 @@ import pymupdf
 import pytest
 
 from extraction.features.stratigraphy.layer.layer import Layer
-from extraction.features.stratigraphy.layer.overlap_detection import find_last_duplicate_layer_index
+from extraction.features.stratigraphy.layer.overlap_detection import find_split_by_convolution
 from swissgeol_doc_processing.text.textblock import MaterialDescription, MaterialDescriptionLine
 from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 from swissgeol_doc_processing.utils.file_utils import read_params
@@ -29,7 +29,7 @@ def test_find_last_duplicate_no_duplicates(create_layer):
     prev_layers = [create_layer("Layer A"), create_layer("Layer B")]
     current_layers = [create_layer("Layer C"), create_layer("Layer D")]
 
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers, matching_params)
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
     assert bottom_duplicated_idx is None
 
 
@@ -38,8 +38,8 @@ def test_find_last_duplicate_single_at_top(create_layer):
     prev_layers = [create_layer("Layer A"), create_layer("Layer B")]
     current_layers = [create_layer("Layer B"), create_layer("Layer C"), create_layer("Layer D")]
 
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 0
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert bottom_duplicated_idx == 1
 
 
 def test_find_last_duplicate_multiple_consecutive(create_layer):
@@ -47,8 +47,8 @@ def test_find_last_duplicate_multiple_consecutive(create_layer):
     prev_layers = [create_layer("Layer A"), create_layer("Layer B"), create_layer("Layer C")]
     current_layers = [create_layer("Layer B"), create_layer("Layer C"), create_layer("Layer D")]
 
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 1
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert bottom_duplicated_idx == 2
 
 
 def test_find_last_duplicate_wrong_line_grouping(create_layer):
@@ -61,7 +61,7 @@ def test_find_last_duplicate_wrong_line_grouping(create_layer):
         create_layer("Layer D"),
     ]
 
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers, matching_params)
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
     assert bottom_duplicated_idx == 2
 
 
@@ -76,8 +76,8 @@ def test_find_last_duplicate_false_positive(create_layer):
         create_layer("Layer D"),  # false positive, same description but not a duplicate
         create_layer("Layer Z"),
     ]
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers_correct, matching_params)
-    assert bottom_duplicated_idx == 1
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
+    assert bottom_duplicated_idx == 2
 
     current_layers_correct = [
         create_layer("Layer X"),
@@ -85,7 +85,7 @@ def test_find_last_duplicate_false_positive(create_layer):
         create_layer("Layer D"),  # false positive, same description but not a duplicate
         create_layer("Layer Z"),
     ]
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers_correct, matching_params)
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
     assert bottom_duplicated_idx is None
 
 
@@ -100,8 +100,8 @@ def test_find_last_duplicate_prev_bottom_cropped(create_layer):
         create_layer("Bedrock"),
     ]
 
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 0
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert bottom_duplicated_idx == 1
 
 
 def test_find_last_duplicate_current_top_cropped(create_layer):
@@ -115,8 +115,8 @@ def test_find_last_duplicate_current_top_cropped(create_layer):
         create_layer("Bedrock"),
     ]
 
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 0
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert bottom_duplicated_idx == 1
 
 
 def test_find_last_duplicate_ocr_error(create_layer):
@@ -127,8 +127,8 @@ def test_find_last_duplicate_ocr_error(create_layer):
         create_layer("Clay with gravel"),
     ]
 
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers, matching_params)
-    assert bottom_duplicated_idx == 0
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert bottom_duplicated_idx == 1
 
 
 def test_find_last_duplicate_full_duplicates(create_layer):
@@ -141,5 +141,5 @@ def test_find_last_duplicate_full_duplicates(create_layer):
         create_layer("Layer C"),
         create_layer("Layer D"),
     ]
-    bottom_duplicated_idx = find_last_duplicate_layer_index(prev_layers, current_layers_correct, matching_params)
-    assert bottom_duplicated_idx == 3
+    bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
+    assert bottom_duplicated_idx == 4

--- a/tests/test_overlap_detection.py
+++ b/tests/test_overlap_detection.py
@@ -26,9 +26,9 @@ def create_layer():
 
 @pytest.fixture
 def create_elevation_layer():
-    """Create a Layer with given text."""
+    """Create a Layer with given text and depth interval."""
 
-    def _create_elevation_layer(text: str, elevation: tuple[int, int]) -> Layer:
+    def _create_elevation_layer(text: str, elevation: tuple[int | None, int | None]) -> Layer:
         line_feat = FeatureOnPage(MaterialDescriptionLine(text), rect=pymupdf.Rect, page=0)
         material_description = MaterialDescription(text, [line_feat])
         depths = LayerDepths(
@@ -134,7 +134,7 @@ def test_find_last_duplicate_ocr_error(create_layer):
 
 
 def test_find_last_duplicate_full_duplicates(create_layer):
-    """Test when the number of duplicated layer of the current page exeeds the number of layer in the previous."""
+    """Test when the number of duplicated layers of the current page exceeds the number of layer in the previous."""
     prev_layers = [create_layer("Layer B"), create_layer("Layer C"), create_layer("Layer D")]
 
     current_layers_correct = [
@@ -148,7 +148,7 @@ def test_find_last_duplicate_full_duplicates(create_layer):
 
 
 def test_are_layers_similar_text(create_layer):
-    """Test if two layer are matched based on small text difference."""
+    """Test if two layers are matched based on small text difference."""
     layer_a = create_layer("Desc A")
     layer_b = create_layer("Desc AB")
     assert are_layers_similar(layer_a, layer_b, material_threshold=0.80)
@@ -156,7 +156,7 @@ def test_are_layers_similar_text(create_layer):
 
 
 def test_are_layers_similar_elevation(create_elevation_layer):
-    """Test if two layer are matched based on elevation difference."""
+    """Test if two layers are matched based on elevation difference."""
     layer_a = create_elevation_layer("Desc A", [0, 1])
     layer_b = create_elevation_layer("Desc A", [0, 2])
     layer_c = create_elevation_layer("Desc A", [0, None])
@@ -166,7 +166,7 @@ def test_are_layers_similar_elevation(create_elevation_layer):
 
 
 def test_are_layers_similar_extremities(create_layer):
-    """Test if two layer are matched based on position in file."""
+    """Test if two layers are matched based on position in file."""
     layer_a = create_layer("Desc A Desc B")
     layer_b = create_layer("Desc A")
     layer_c = create_layer("Desc B")

--- a/tests/test_overlap_detection.py
+++ b/tests/test_overlap_detection.py
@@ -3,8 +3,8 @@
 import pymupdf
 import pytest
 
-from extraction.features.stratigraphy.layer.layer import Layer
-from extraction.features.stratigraphy.layer.overlap_detection import find_split_by_convolution
+from extraction.features.stratigraphy.layer.layer import Layer, LayerDepths, LayerDepthsEntry
+from extraction.features.stratigraphy.layer.overlap_detection import are_layers_similar, find_split_by_convolution
 from swissgeol_doc_processing.text.textblock import MaterialDescription, MaterialDescriptionLine
 from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 from swissgeol_doc_processing.utils.file_utils import read_params
@@ -22,6 +22,22 @@ def create_layer():
         return Layer(material_description=material_description, depths=None)
 
     return _create_layer
+
+
+@pytest.fixture
+def create_elevation_layer():
+    """Create a Layer with given text."""
+
+    def _create_elevation_layer(text: str, elevation: tuple[int, int]) -> Layer:
+        line_feat = FeatureOnPage(MaterialDescriptionLine(text), rect=pymupdf.Rect, page=0)
+        material_description = MaterialDescription(text, [line_feat])
+        depths = LayerDepths(
+            LayerDepthsEntry(elevation[0], rect=pymupdf.Rect, page_number=0),
+            LayerDepthsEntry(elevation[1], rect=pymupdf.Rect, page_number=0),
+        )
+        return Layer(material_description=material_description, depths=depths)
+
+    return _create_elevation_layer
 
 
 def test_find_last_duplicate_no_duplicates(create_layer):
@@ -53,6 +69,7 @@ def test_find_last_duplicate_multiple_consecutive(create_layer):
 
 def test_find_last_duplicate_wrong_line_grouping(create_layer):
     """Test when description lines are grouped differently on each page, due to different scan quality."""
+    # TODO: Test for extremities
     prev_layers = [create_layer("Layer A"), create_layer("Layer B"), create_layer("Layer C")]
     current_layers = [
         create_layer("Layer B"),
@@ -142,4 +159,33 @@ def test_find_last_duplicate_full_duplicates(create_layer):
         create_layer("Layer D"),
     ]
     bottom_duplicated_idx = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
-    assert bottom_duplicated_idx == 4
+    assert bottom_duplicated_idx is None
+
+
+def test_are_layers_similar_text(create_layer):
+    """Test if two layer are matched based on small text difference."""
+    layer_a = create_layer("Desc A")
+    layer_b = create_layer("Desc AB")
+    assert are_layers_similar(layer_a, layer_b, material_threshold=0.80)
+    assert not are_layers_similar(layer_a, layer_b, material_threshold=1.00)
+
+
+def test_are_layers_similar_elevation(create_elevation_layer):
+    """Test if two layer are matched based on elevation difference."""
+    layer_a = create_elevation_layer("Desc A", [0, 1])
+    layer_b = create_elevation_layer("Desc A", [0, 2])
+    layer_c = create_elevation_layer("Desc A", [0, None])
+    assert are_layers_similar(layer_a, layer_b, force_depth_matching=False)
+    assert not are_layers_similar(layer_a, layer_b, force_depth_matching=True)
+    assert are_layers_similar(layer_a, layer_c, force_depth_matching=True)
+
+
+def test_are_layers_similar_extremities(create_layer):
+    """Test if two layer are matched based on position in file."""
+    layer_a = create_layer("Desc A Desc B")
+    layer_b = create_layer("Desc A")
+    layer_c = create_layer("Desc B")
+    assert not are_layers_similar(layer_a, layer_b, is_extremity=False)
+    assert not are_layers_similar(layer_a, layer_b, is_extremity=True)
+    assert are_layers_similar(layer_a, layer_c, is_extremity=True)
+    assert not are_layers_similar(layer_c, layer_a, is_extremity=True)


### PR DESCRIPTION
Closes #454 and closes #330

# Description

Boreholes from different pages were being incorrectly merged when their material descriptions were similar. This PR addresses the root causes across three areas of the pipeline and simplifies the implementation.


# Changes

* **Partial matching**: The pipeline was designed to allow text cut off at page boundaries, supporting overlap between pages. However, the previous implementation permitted partial overlap for any layer, including those in the middle of a page. This caused a description like "Description A, Description B" to incorrectly match "Description B" even when it wasn't the last layer on the page. Partial matching is now restricted to boundary layers only.

* **Sliding window** (convolutional strategy): The previous approach iterated layer-by-layer through a while loop, checking compliance only for the last matched layer. If multiple layers overlapped, only the final one was evaluated. The new approach uses a convolutional strategy: it iterates over all candidate overlaps simultaneously and scores each one, then selects the best. Benefits: Shorter, more readable code, all overlap candidates are evaluated (not just the last one).

* **Elevation matching**: Added a depth-matching requirement: when depth information is available (start or end), it must match before layers can be merged.


# Performance

| Dataset | Layer F1 (before) | Layer F1 (after) | Notes |
|---------|-----------------|------------------|------|
| Geoquat | 47.7 | 47.6 | Negligible, see details below |
| Zurich  | 84.3 | 84.3 | — |
| Thurgau | — | Fixed |  TH:1780 now correctly separated |


* `GQ:A234`: Elevation bar mismatch. The previous approach accepted a non-monotonic depth sequence (23.35 → 0.6); the new logic requires a consistent span.
* `GQ:A525`: One layer is split into multiple entries due to inconsistent text grouping.

# Test

* Existing tests updated to reflect the convolutional overlap strategy
* New tests added for one-to-one layer similarity checks
* `test_find_last_duplicate_wrong_line_grouping` removed. It tested behaviour that is explicitly no longer coherent under the new sliding window logic


