### PR TITLE
Remove gap_with_previous_affinity for DP matching

### DIFF
--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -912,9 +912,6 @@ def get_pairs_based_on_line_affinity(
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
     threshold = -0.3
 
-    for line, aff in zip(description_lines, affinities, strict=False):
-        print(aff.weighted_affinity(**weights), aff.vertical_spacing_affinity, line.text)
-
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0
         if affinity.weighted_affinity(**weights) <= threshold:

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -910,7 +910,10 @@ def get_pairs_based_on_line_affinity(
     pairs = []
     prev_block_idx = 0
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
-    threshold = -1
+    threshold = -0.3
+
+    for line, aff in zip(description_lines, affinities, strict=False):
+        print(aff.weighted_affinity(**weights), aff.vertical_spacing_affinity, line.text)
 
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -910,11 +910,11 @@ def get_pairs_based_on_line_affinity(
     pairs = []
     prev_block_idx = 0
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
-    # The presence of >=3 horiz. lines should tighten the vertical spacing constrain
-    threshold = -0.99 if sum(affinity.long_lines_affinity for affinity in affinities) <= -3.0 else 0.0
+    threshold = -1
+
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0
-        if affinity.weighted_affinity(**weights) < threshold:
+        if affinity.weighted_affinity(**weights) <= threshold:
             pairs.append(IntervalBlockPair(None, TextBlock(description_lines[prev_block_idx:line_idx])))
             prev_block_idx = line_idx
 

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -910,7 +910,16 @@ def get_pairs_based_on_line_affinity(
     pairs = []
     prev_block_idx = 0
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
-    threshold = -0.2
+
+    horizontal_lines_significance = sum(-affinity.long_lines_affinity for affinity in affinities)
+    vertical_spacing_significance = sum(max(0.0, -affinity.vertical_spacing_affinity) for affinity in affinities)
+    if horizontal_lines_significance > vertical_spacing_significance:
+        # if the precense of horizontal lines seems to be a stronger differentiator than the vertical spacing between
+        # lines, then we set the threshold at the level of the presence of such a horizontal line, making it less
+        # likely that descriptions are split in the absence of such a line.
+        threshold = -weights["line_weight"]
+    else:
+        threshold = -0.2 * weights["spacing_weight"]
 
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -914,7 +914,7 @@ def get_pairs_based_on_line_affinity(
     horizontal_lines_significance = sum(-affinity.long_lines_affinity for affinity in affinities)
     vertical_spacing_significance = sum(max(0.0, -affinity.vertical_spacing_affinity) for affinity in affinities)
     if horizontal_lines_significance > vertical_spacing_significance:
-        # if the precense of horizontal lines seems to be a stronger differentiator than the vertical spacing between
+        # if the presence of horizontal lines seems to be a stronger differentiator than the vertical spacing between
         # lines, then we set the threshold at the level of the presence of such a horizontal line, making it less
         # likely that descriptions are split in the absence of such a line.
         threshold = -weights["line_weight"]

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -910,7 +910,7 @@ def get_pairs_based_on_line_affinity(
     pairs = []
     prev_block_idx = 0
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
-    threshold = -0.3
+    threshold = -0.2
 
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -49,7 +49,7 @@ affinity_params:
     weights:
       line_weight: 1.0
       left_line_weight: 1.0
-      spacing_weight: 1.2
+      spacing_weight: 1.0
       right_end_weight: 1.0
       diagonal_weight: 1.0
       indentation_weight: 0.0
@@ -67,7 +67,7 @@ affinity_params:
       weights:
         line_weight: 1.0
         left_line_weight: 1.0
-        spacing_weight: 1.2
+        spacing_weight: 1.0
         right_end_weight: 1.0
         diagonal_weight: 1.0
         indentation_weight: 0.0

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -17,7 +17,6 @@ affinity_params:
       spacing_weight: 1.25
       right_end_weight: 1.0
       diagonal_weight: 1.25
-      gap_weight: 0.0
       indentation_weight: 0.6
   a_to_b:
     importance: 2.0
@@ -27,7 +26,6 @@ affinity_params:
       spacing_weight: 1.0
       right_end_weight: 1.0
       diagonal_weight: 0.0
-      gap_weight: 0.0
       indentation_weight: 0.0
   layer_identifier:
     importance: 0.66
@@ -37,7 +35,6 @@ affinity_params:
       spacing_weight: 1.0
       right_end_weight: 0.6
       diagonal_weight: 0.0
-      gap_weight: 0.0
       indentation_weight: 0.0
   spulprobe:
     importance: 2.0
@@ -47,16 +44,14 @@ affinity_params:
       spacing_weight: 1.0
       right_end_weight: 1.0
       diagonal_weight: 0.0
-      gap_weight: 0.0
       indentation_weight: 0.0
   no_sidebar:
     weights:
       line_weight: 1.0
       left_line_weight: 1.0
-      spacing_weight: 1.0
+      spacing_weight: 1.2
       right_end_weight: 1.0
       diagonal_weight: 1.0
-      gap_weight: 0.2
       indentation_weight: 0.0
   protocol:
       importance: 1.0
@@ -72,10 +67,9 @@ affinity_params:
       weights:
         line_weight: 1.0
         left_line_weight: 1.0
-        spacing_weight: 1.0
+        spacing_weight: 1.2
         right_end_weight: 1.0
         diagonal_weight: 1.0
-        gap_weight: 0.2
         indentation_weight: 0.0
 empty_interval_penalty: 0.2
 

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -50,7 +50,7 @@ affinity_params:
       line_weight: 1.0
       left_line_weight: 1.0
       spacing_weight: 1.0
-      right_end_weight: 1.0
+      right_end_weight: 0.5
       diagonal_weight: 1.0
       indentation_weight: 0.0
   protocol:

--- a/src/swissgeol_doc_processing/text/textline_affinity.py
+++ b/src/swissgeol_doc_processing/text/textline_affinity.py
@@ -13,7 +13,7 @@ from swissgeol_doc_processing.text.textline import TextLine
 
 @dataclass
 class Affinity:
-    """class holding the 4 types of affinities.
+    """Class holding the 6 types of affinities.
 
     Each affinity is a float between -1.0 and 1.0 and measures how likely two lines belong together.
 
@@ -21,6 +21,8 @@ class Affinity:
     lines_on_the_left_affinity: affinity based on the presence of lines cutting the left side of the text lines.
     vertical_spacing_affinity: affinity based on the vertical spacing between the two text lines.
     right_end_affinity: affinity based on the alignment of the right end of the two text lines.
+    diagonal_line_affinity: affinity based on the presence of diagonal lines inbetween the two text lines.
+    indentation_affinity: affinity based on the indentation difference between the two text lines.
     """
 
     long_lines_affinity: float

--- a/src/swissgeol_doc_processing/text/textline_affinity.py
+++ b/src/swissgeol_doc_processing/text/textline_affinity.py
@@ -28,13 +28,12 @@ class Affinity:
     vertical_spacing_affinity: float
     right_end_affinity: float
     diagonal_line_affinity: float
-    gap_with_previous_affinity: float
     indentation_affinity: float
 
     @classmethod
     def get_zero_affinity(cls) -> Affinity:
         """Get an affinity with all zero values."""
-        return cls(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        return cls(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
     def weighted_affinity(
         self,
@@ -43,7 +42,6 @@ class Affinity:
         spacing_weight: float,
         right_end_weight: float,
         diagonal_weight: float,
-        gap_weight: float,
         indentation_weight: float,
     ) -> float:
         """Compute the weighted affinity using the provided weights."""
@@ -53,13 +51,12 @@ class Affinity:
             + spacing_weight * self.vertical_spacing_affinity
             + right_end_weight * self.right_end_affinity
             + diagonal_weight * self.diagonal_line_affinity
-            + gap_weight * self.gap_with_previous_affinity
             + indentation_weight * self.indentation_affinity
         )
 
     def total_affinity(self) -> float:
         """Compute the total affinity with equal weights."""
-        return self.weighted_affinity(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+        return self.weighted_affinity(1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
 
     def weighted_mean_affinity(
         self,
@@ -68,7 +65,6 @@ class Affinity:
         spacing_weight: float,
         right_end_weight: float,
         diagonal_weight: float,
-        gap_weight: float,
         indentation_weight: float,
     ) -> float:
         """Compute the weighted affinity using the provided weights."""
@@ -78,14 +74,13 @@ class Affinity:
             spacing_weight,
             right_end_weight,
             diagonal_weight,
-            gap_weight,
             indentation_weight,
         ]
         return self.weighted_affinity(*weights) / sum(weights)
 
     def mean_affinity(self) -> float:
         """Compute the mean affinity."""
-        return self.weighted_mean_affinity(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+        return self.weighted_mean_affinity(1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
 
 
 class LineAffinityCalculator:
@@ -141,12 +136,6 @@ class LineAffinityCalculator:
 
         # diagonals separator
         self.diagonals = diagonals
-
-        # overlap affinity
-        self.overlapping_distances = [None] + [
-            line.rect.y0 - prev_line.rect.y1
-            for prev_line, line in zip(description_lines, description_lines[1:], strict=False)
-        ]
 
     def _is_spanning_description(self, line: Line) -> bool:
         """Check if a line spans the material description rectangle.
@@ -246,30 +235,6 @@ class LineAffinityCalculator:
         h_reference = current_rect.height if self.at_least_one_overlap else self.spacing_threshold
         score = max(-1.0, 1.0 - (current_rect.y1 - previous_rect.y1) / h_reference)  # not capped at 0
         return score
-
-    def compute_gap_affinity(self, previous_line: TextLine, prev_line_idx: int) -> float:
-        """Check the gap between the two lines.
-
-        If the gap is significantly larger than the previous gap, it is unlikely that the current line is the
-        continuation of the description.
-
-        Args:
-            previous_line (TextLine): The previous line.
-            prev_line_idx (int): The index of the previous line, to acess the gaps lookup.
-
-        Returns:
-            float: The affinity: 0.0 if lines are not compatible, 1.0 otherwise.
-        """
-        previous_gap = self.overlapping_distances[prev_line_idx]
-        current_gap = self.overlapping_distances[prev_line_idx + 1]
-        previous_line_height = previous_line.rect.height  # involved in both gaps
-        if current_gap > 0.6 * previous_line_height:
-            # gap is too big
-            return 0.0
-        if previous_gap is None or current_gap <= previous_gap + previous_line_height * 0.2:
-            # current gap is roughly the same as the previous, or smaller
-            return 1.0
-        return 0.0
 
     def compute_right_end_affinity(self, previous_line: TextLine, current_line: TextLine) -> float:
         """Check the alignment of the right end of the lines.
@@ -378,7 +343,7 @@ def get_line_affinity(
         diagonals,
     )
     affinities = [Affinity.get_zero_affinity()]  # first line has no previous
-    for prev_line_idx, (previous_line, line) in enumerate(zip(description_lines, description_lines[1:], strict=False)):
+    for previous_line, line in zip(description_lines, description_lines[1:], strict=False):
         affinities.append(
             Affinity(
                 calculator.compute_long_lines_affinity(previous_line, line),
@@ -386,7 +351,6 @@ def get_line_affinity(
                 calculator.compute_vertical_spacing_affinity(previous_line, line),
                 calculator.compute_right_end_affinity(previous_line, line),
                 calculator.compute_diagonal_affinity(previous_line, line),
-                calculator.compute_gap_affinity(previous_line, prev_line_idx),
                 calculator.compute_indentation_affinity(previous_line, line),
             )
         )

--- a/tests/test_line_affinity.py
+++ b/tests/test_line_affinity.py
@@ -35,7 +35,7 @@ matching_params = read_params("matching_params.yml")
         pytest.param([], [], 2, id="no_geom_lines"),
         pytest.param(geometric_lines_cut, [], 3, id="span_line"),
         pytest.param(geometric_lines_lefthandside, [], 3, id="left_line"),
-        pytest.param([], diagonal_line, 3, id="diag_line"),
+        pytest.param([], diagonal_line, 2, id="diag_line"),
     ],
 )
 def test_get_description_blocks(geometrical_lines, diagonals, expected_num_block):
@@ -45,7 +45,7 @@ def test_get_description_blocks(geometrical_lines, diagonals, expected_num_block
         1. no geometrical lines: expect 2 blocks (first two lines together as they slightly overlap, third separate)
         2. span line cutting through first two lines: expect 3 blocks (all separate)
         3. left-hand side line cutting through first two lines: expect 3 blocks (all separate)
-        4. diagonal line cutting through first two lines: expect 3 blocks (all separate)
+        4. diagonal line cutting through first two lines: expect 2 blocks
     """
     line_affinities = get_line_affinity(
         description_lines,

--- a/tests/test_line_affinity.py
+++ b/tests/test_line_affinity.py
@@ -45,7 +45,7 @@ def test_get_description_blocks(geometrical_lines, diagonals, expected_num_block
         1. no geometrical lines: expect 2 blocks (first two lines together as they slightly overlap, third separate)
         2. span line cutting through first two lines: expect 3 blocks (all separate)
         3. left-hand side line cutting through first two lines: expect 3 blocks (all separate)
-        4. diagonal line cutting through first two lines: expect 2 blocks
+        4. diagonal line cutting through first two lines: expect 3 blocks (all separate)
     """
     line_affinities = get_line_affinity(
         description_lines,

--- a/tests/test_line_affinity.py
+++ b/tests/test_line_affinity.py
@@ -35,7 +35,7 @@ matching_params = read_params("matching_params.yml")
         pytest.param([], [], 2, id="no_geom_lines"),
         pytest.param(geometric_lines_cut, [], 3, id="span_line"),
         pytest.param(geometric_lines_lefthandside, [], 3, id="left_line"),
-        pytest.param([], diagonal_line, 2, id="diag_line"),
+        pytest.param([], diagonal_line, 3, id="diag_line"),
     ],
 )
 def test_get_description_blocks(geometrical_lines, diagonals, expected_num_block):


### PR DESCRIPTION
While investigating #442 / #456, I made the following observations:
- `gap_with_previous_affinity` and `vertical_spacing_affinity` serve very similar purposes: making a split between layers more likely when the vertical distance between the descriptions is bigger.
- `gap_with_previous_affinity` was only used by default for a small number of sidebars (no sidebar and ProtocolSidebar).
- `gap_with_previous_affinity` did not behave in a reasonable way for many other inputs. In particular, there were issues with negative distance values. Also, because the computation only compared the current gap with the previous gap, it gave inconsistent results when the previous layer's description consisted of a single line vs. multiple lines.
- For #442, @AgathaSchmidt discovered that it could be beneficial to give more weight to the vertical gap between description lines. However, giving more weight to `gap_with_previous_affinity` does not work well in many cases because of the behaviour described in the previous point.
- For this reason, I wanted to check if we could completely remove `gap_with_previous_affinity` and instead only use `vertical_spacing_affinity` as a measure for the vertical gaps. This seems to be possible and gives good results on the Zurich and GeoQuat datasets.

(Note: although these changes are related to / inspired by #422, they don't provide a solution for the issue itself.)

**Zurich**:
- Layer F1 goes up by 0.1%
- Material description F1 goes up by 0.1%
- Improved: 267123120-bp

**Geoquat**
- Layer F1 goes up by 0.01%
- Material description F1 goes down by 0.1%
- Improved: A135
- Worse: A437
- Other changes: 10088, A11406, A1220, A185, B140, B366, V69

I don't think that we will ever get a perfect solution for splitting material descriptions for "no sidebar" borehole profiles by looking at vertical gaps between description lines alone. A more robust solution for splitting material descriptions in the "no sidebar" case might be to take into account the dividing lines in the corresponding strip log (assuming a strip log was detected). But that would be something for a future ticket.