### PR TITLE
New material description detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,6 @@ We use [uv](https://docs.astral.sh/uv/) to manage package dependencies. Install 
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-This repository uses [Git LFS](https://git-lfs.github.com) to store the BERT model files. Install and enable it before cloning so the model files are downloaded automatically:
-
-```bash
-brew install git-lfs   # macOS — see https://git-lfs.github.com for other platforms
-git lfs install        # one-time setup per machine
-```
-
-If you already cloned without LFS installed, fetch the model files afterwards:
-
-```bash
-git lfs pull
-```
-
 The below commands will install the package for you (assuming you have successfully cloned the repository):
 ```bash
 uv sync --all-extras
@@ -216,11 +203,9 @@ To execute the layer description classification, follow these steps:
 ### 1. Setup
 
 Repeat steps 1 and 2 of the [data extraction pipeline](#run-data-extraction) to set up the environment and download the data.
-
-The pre-trained BERT models (`backbone`, `lithology_head`, `en_main_head`) are stored in the repository via Git LFS and are fetched automatically when cloning with LFS installed. If the `models/` directory contains only small pointer files instead of the actual weights, run:
-
+Pre-trained models can be downloaded with
 ```bash
-git lfs pull
+aws s3 sync s3://stijnvermeeren-boreholes-models models/uscs/your_model_folder
 ```
 
 ### 2. Run the Classification Pipeline

--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ We use [uv](https://docs.astral.sh/uv/) to manage package dependencies. Install 
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
+This repository uses [Git LFS](https://git-lfs.github.com) to store the BERT model files. Install and enable it before cloning so the model files are downloaded automatically:
+
+```bash
+brew install git-lfs   # macOS — see https://git-lfs.github.com for other platforms
+git lfs install        # one-time setup per machine
+```
+
+If you already cloned without LFS installed, fetch the model files afterwards:
+
+```bash
+git lfs pull
+```
+
 The below commands will install the package for you (assuming you have successfully cloned the repository):
 ```bash
 uv sync --all-extras
@@ -203,9 +216,11 @@ To execute the layer description classification, follow these steps:
 ### 1. Setup
 
 Repeat steps 1 and 2 of the [data extraction pipeline](#run-data-extraction) to set up the environment and download the data.
-Pre-trained models can be downloaded with
+
+The pre-trained BERT models (`backbone`, `lithology_head`, `en_main_head`) are stored in the repository via Git LFS and are fetched automatically when cloning with LFS installed. If the `models/` directory contains only small pointer files instead of the actual weights, run:
+
 ```bash
-aws s3 sync s3://stijnvermeeren-boreholes-models models/uscs/your_model_folder
+git lfs pull
 ```
 
 ### 2. Run the Classification Pipeline

--- a/docs/API_and_Docker.md
+++ b/docs/API_and_Docker.md
@@ -53,42 +53,6 @@ Additional endpoints and their functionalities can be found in the project's sou
 To stop the FastAPI server, press `Ctrl + C` in the terminal where the server is running. Please refer to the [FastAPI documentation](https://fastapi.tiangolo.com) for more information on how to work with FastAPI and build APIs using this framework.
 
 
-## Classification Model Configuration
-
-The `/api/V1/classify_lithology` endpoint requires fine-tuned BERT models. The models are committed directly to the repository under `models/` using [Git LFS](https://git-lfs.github.com) and are copied into the Docker image at build time — no external download or environment variable configuration is needed:
-
-- `models/backbone/backbone.safetensors` — shared frozen backbone (~609 MB, stored via Git LFS)
-- `models/en_main_head/` — task-specific head for the EN main classification system
-- `models/lithology_head/` — task-specific head for the lithology classification system
-
-### Cloning the repository
-
-Git LFS must be installed to download the model files when cloning:
-
-```bash
-brew install git-lfs   # macOS; see https://git-lfs.github.com for other platforms
-git lfs install        # one-time setup per machine
-git clone <repo-url>   # model files are downloaded automatically
-```
-
-If you already cloned without LFS installed, fetch the model files afterwards:
-
-```bash
-git lfs pull
-```
-
-### Docker
-
-The pre-built Docker image ships with these models baked in — no additional configuration is needed for classification:
-
-```bash
-docker pull ghcr.io/swisstopo/swissgeol-boreholes-dataextraction-api:latest
-docker run -p 8000:8000 ghcr.io/swisstopo/swissgeol-boreholes-dataextraction-api:latest
-```
-
-To run without loading the BERT models (extraction endpoints only, saves memory), set `BERT_ENABLED=false`. The `/classify_lithology` endpoint will return HTTP 503 in this case.
-
-
 ## Build API as Local Docker Image
 
 The borehole application offers a given amount of functionalities (extract text, number, and coordinates) through an API. To build this API using a Docker Container, you can run the following commands. 

--- a/docs/API_and_Docker.md
+++ b/docs/API_and_Docker.md
@@ -53,6 +53,42 @@ Additional endpoints and their functionalities can be found in the project's sou
 To stop the FastAPI server, press `Ctrl + C` in the terminal where the server is running. Please refer to the [FastAPI documentation](https://fastapi.tiangolo.com) for more information on how to work with FastAPI and build APIs using this framework.
 
 
+## Classification Model Configuration
+
+The `/api/V1/classify_lithology` endpoint requires fine-tuned BERT models. The models are committed directly to the repository under `models/` using [Git LFS](https://git-lfs.github.com) and are copied into the Docker image at build time — no external download or environment variable configuration is needed:
+
+- `models/backbone/backbone.safetensors` — shared frozen backbone (~609 MB, stored via Git LFS)
+- `models/en_main_head/` — task-specific head for the EN main classification system
+- `models/lithology_head/` — task-specific head for the lithology classification system
+
+### Cloning the repository
+
+Git LFS must be installed to download the model files when cloning:
+
+```bash
+brew install git-lfs   # macOS; see https://git-lfs.github.com for other platforms
+git lfs install        # one-time setup per machine
+git clone <repo-url>   # model files are downloaded automatically
+```
+
+If you already cloned without LFS installed, fetch the model files afterwards:
+
+```bash
+git lfs pull
+```
+
+### Docker
+
+The pre-built Docker image ships with these models baked in — no additional configuration is needed for classification:
+
+```bash
+docker pull ghcr.io/swisstopo/swissgeol-boreholes-dataextraction-api:latest
+docker run -p 8000:8000 ghcr.io/swisstopo/swissgeol-boreholes-dataextraction-api:latest
+```
+
+To run without loading the BERT models (extraction endpoints only, saves memory), set `BERT_ENABLED=false`. The `/classify_lithology` endpoint will return HTTP 503 in this case.
+
+
 ## Build API as Local Docker Image
 
 The borehole application offers a given amount of functionalities (extract text, number, and coordinates) through an API. To build this API using a Docker Container, you can run the following commands. 

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -289,7 +289,9 @@ class MaterialDescriptionRectWithSidebarExtractor:
         Returns:
             bool: True if a valid description match is found, False otherwise.
         """
-        candidate_rects = self._find_all_material_description_candidates(sidebar_noise.sidebar)
+        candidate_rects = self._find_all_material_description_candidates(
+            sidebar_noise.sidebar, use_geometric_seeds=False
+        )
 
         for rect in candidate_rects:
             pair = MaterialDescriptionRectWithSidebar(
@@ -376,11 +378,85 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
         return material_descriptions_sidebar_pairs
 
-    def _find_all_material_description_candidates(self, sidebar: Sidebar | None) -> list[pymupdf.Rect]:
+    @staticmethod
+    def _line_has_real_word(text: str) -> bool:
+        """Return True if text contains at least one real-word token.
+
+        A real word requires 3+ alphabetic characters in the token, does not start
+        with a digit, and has at least half of its letters in lowercase. This
+        distinguishes geological description words ("Sand", "schluffig", "Kies")
+        from coded identifiers ("KB1-P6", "4bc", "4a", "4Hb") and unit symbols
+        ("m", "cm") that would otherwise pass a simple alpha-character count.
+        """
+        for token in text.split():
+            alpha = [c for c in token if c.isalpha()]
+            if (
+                len(alpha) >= 3
+                and not token[0].isdigit()
+                and sum(1 for c in alpha if c.islower()) >= 2
+                and sum(1 for c in alpha if c.islower()) / len(alpha) >= 0.5
+            ):
+                return True
+        return False
+
+    def _get_geometric_description_seeds(
+        self, candidate_description: list[TextLine], sidebar: Sidebar | None
+    ) -> list[TextLine] | None:
+        """Return seed lines for description clustering based on spatial proximity.
+
+        Uses the right edge of the sidebar — extended to any strip log that sits between
+        the sidebar and the description column — as an x-anchor. Every candidate line
+        whose left edge starts at or to the right of that anchor is treated as a
+        potential description line, removing the dependency on inclusion keywords.
+
+        Returns None when no spatial anchor can be derived (no sidebar and no strip
+        logs), in which case the caller should fall back to keyword-based seeds.
+
+        Args:
+            candidate_description: Lines already filtered to the correct y-range.
+            sidebar: The sidebar paired with this description, or None.
+
+        Returns:
+            A (possibly empty) list of seed lines, or None if no anchor is available.
+        """
+        if not sidebar and not self.strip_logs:
+            return None
+
+        if sidebar:
+            x_anchor = sidebar.rect.x1
+            # A strip log sitting between the sidebar and the description column shifts the anchor right
+            overlapping_strips = [
+                sl for sl in self.strip_logs if x_overlap(sl.bbox, sidebar.rect) and sl.bbox.x1 > x_anchor
+            ]
+            if overlapping_strips:
+                x_anchor = max(sl.bbox.x1 for sl in overlapping_strips)
+        else:
+            # No sidebar: anchor on the rightmost strip log edge present on the page
+            x_anchor = max(sl.bbox.x1 for sl in self.strip_logs)
+
+        # Small leftward tolerance so lines whose left edge barely overlaps the anchor are not lost
+        x_start = x_anchor - self.page_width * 0.02
+        seeds = [
+            line
+            for line in candidate_description
+            if line.rect.x0 >= x_start
+            and line.rect.width >= line.rect.height  # vertically oriented text is not a description
+            and self._line_has_real_word(line.text)  # excludes codes, unit symbols, pure numbers
+        ]
+        return seeds or None
+
+    def _find_all_material_description_candidates(
+        self, sidebar: Sidebar | None, use_geometric_seeds: bool = True
+    ) -> list[pymupdf.Rect]:
         """Find all material description candidates on the page.
 
         Args:
             sidebar (Sidebar | None): The sidebar for which we want to find the material descriptions.
+            use_geometric_seeds (bool): When True (default), use spatial proximity to the sidebar /
+                strip log as the primary seed signal. Pass False for gating checks such as
+                _has_valid_description_match, where the question is specifically "does real
+                geological keyword content exist here" — geometric seeding would make that check
+                trivially true for any text column and cause false protocol-sidebar blocks.
 
         Returns:
             list[pymupdf.Rect]: A list of candidate rectangles for material descriptions.
@@ -390,7 +466,21 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 line for line in self.lines if x_overlap(line.rect, sidebar.rect) and line.rect.y0 < sidebar.rect.y0
             ]
 
-            min_y0 = max(line.rect.y0 for line in above_sidebar) if above_sidebar else -1
+            if above_sidebar:
+                min_y0 = max(line.rect.y0 for line in above_sidebar)
+            else:
+                # No header lines found above the sidebar in its x-column. Allow a small margin above
+                # the sidebar top so description lines for the synthetic "0 → first entry" interval
+                # are included, but titles and page headers (much higher up) are not.
+                min_y0 = sidebar.rect.y0 - self.page_height * 0.05
+
+            # Strip log top edge: a reliable geometric anchor for where the description zone begins.
+            # If a text header sits between the strip log top and the sidebar start, the header line
+            # would otherwise push min_y0 too high and cause the first description lines to be excluded.
+            overlapping_strips = [sl for sl in self.strip_logs if x_overlap(sl.bbox, sidebar.rect)]
+            if overlapping_strips:
+                strip_top = min(sl.bbox.y0 for sl in overlapping_strips)
+                min_y0 = min(min_y0, strip_top - 1)
 
             def check_y0_condition(y0):
                 return y0 > min_y0 and y0 < sidebar.rect.y1
@@ -406,12 +496,25 @@ class MaterialDescriptionRectWithSidebarExtractor:
             for line in candidate_description
             if line.is_description(self.matching_params, self.language, self.analytics, search_excluding=True)
         ]
-        is_description = [
-            line
-            for line in candidate_description
-            if line.is_description(self.matching_params, self.language, self.analytics, search_excluding=False)
-            and line not in is_not_description
-        ]
+
+        # Primary: use geometric proximity to the sidebar / strip log as the seed signal.
+        # This captures description lines that lack known inclusion keywords (new terminology,
+        # OCR variants, continuation lines) whenever a spatial anchor is available.
+        # Fallback: keyword-based inclusion detection for pages without sidebar or strip logs,
+        # or when geometric seeding is explicitly disabled (e.g. gating checks).
+        geometric_seeds = (
+            self._get_geometric_description_seeds(candidate_description, sidebar) if use_geometric_seeds else None
+        )
+        using_geometric_seeds = geometric_seeds is not None
+        if using_geometric_seeds:
+            is_description = [line for line in geometric_seeds if line not in is_not_description]
+        else:
+            is_description = [
+                line
+                for line in candidate_description
+                if line.is_description(self.matching_params, self.language, self.analytics, search_excluding=False)
+                and line not in is_not_description
+            ]
 
         if len(candidate_description) == 0:
             return []
@@ -455,6 +558,12 @@ class MaterialDescriptionRectWithSidebarExtractor:
             best_x0 = min([line.rect.x0 for line in good_lines])
             best_x1 = max([line.rect.x1 for line in good_lines])
 
+            # A material description must contain at least one line with real word content.
+            # Rejects clusters that are purely numeric or consist only of codes/identifiers,
+            # even when a stray unit symbol or letter-bearing code seeded the cluster.
+            if not any(self._line_has_real_word(line.text) for line in good_lines):
+                continue
+
             # check that no lines that have excluded words are contained in the rect
             cluster_rect = pymupdf.Rect(best_x0, best_y0, best_x1, best_y1)
             non_description_in_rect = [
@@ -489,6 +598,13 @@ class MaterialDescriptionRectWithSidebarExtractor:
                     continue_search = False
 
             candidate_rects.append(pymupdf.Rect(best_x0, best_y0, best_x1, best_y1))
+
+        if using_geometric_seeds and len(candidate_rects) > 1:
+            # Multiple clusters arise when narrow secondary columns (layer codes, measurements)
+            # share the seeding x-range with the real description column. Material descriptions
+            # always occupy the widest column, so prefer by rect width.
+            candidate_rects = [max(candidate_rects, key=lambda r: r.width)]
+
         return candidate_rects
 
     def _find_material_description_column(self, sidebar: Sidebar | None) -> pymupdf.Rect | None:

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -399,6 +399,14 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 return True
         return False
 
+    def _count_keyword_matches(self, rect: pymupdf.Rect) -> int:
+        """Count lines within rect that match including_expressions."""
+        return sum(
+            1
+            for line in get_description_lines(self.lines, rect)
+            if line.is_description(self.matching_params, self.language, None, search_excluding=False)
+        )
+
     def _get_geometric_description_seeds(
         self, candidate_description: list[TextLine], sidebar: Sidebar | None
     ) -> list[TextLine] | None:
@@ -526,12 +534,15 @@ class MaterialDescriptionRectWithSidebarExtractor:
         if using_geometric_seeds:
             is_description = [line for line in geometric_seeds if line not in is_not_description]
         else:
+            # No sidebar or strip log available — use all candidate lines as seeds.
+            # The column-level keyword gate later ensures at least one inclusion keyword
+            # is present in the accepted cluster, so no per-line keyword check is needed.
             is_description = [
                 line
                 for line in candidate_description
-                if line.is_description(self.matching_params, self.language, self.analytics, search_excluding=False)
-                and line not in is_not_description
-                and line.rect.width >= line.rect.height  # vertically oriented text is not a description
+                if line not in is_not_description
+                and line.rect.width >= line.rect.height
+                and self._line_has_real_word(line.text)
             ]
 
         if len(candidate_description) == 0:
@@ -581,6 +592,16 @@ class MaterialDescriptionRectWithSidebarExtractor:
             # Rejects clusters that are purely numeric or consist only of codes/identifiers,
             # even when a stray unit symbol or letter-bearing code seeded the cluster.
             if not any(self._line_has_real_word(line.text) for line in good_lines):
+                continue
+
+            # The column must contain at least one line matching the inclusion keyword list.
+            # This is a column-level gate (not per-line), so geometric and table-based detection
+            # still drive which lines are seeds — we just require at least one keyword hit anywhere
+            # in the cluster to confirm it is a geological description column.
+            if not any(
+                line.is_description(self.matching_params, self.language, self.analytics, search_excluding=False)
+                for line in good_lines
+            ):
                 continue
 
             # check that no lines that have excluded words are contained in the rect
@@ -647,9 +668,10 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
         if using_geometric_seeds and len(candidate_rects) > 1:
             # Multiple clusters arise when narrow secondary columns (layer codes, measurements)
-            # share the seeding x-range with the real description column. Material descriptions
-            # always occupy the widest column, so prefer by rect width.
-            candidate_rects = [max(candidate_rects, key=lambda r: r.width)]
+            # share the seeding x-range with the real description column. Prefer by keyword match
+            # count first (more geological content = more likely the real description column),
+            # then fall back to width as a tiebreaker.
+            candidate_rects = [max(candidate_rects, key=lambda r: (self._count_keyword_matches(r), r.width))]
 
         return candidate_rects
 
@@ -669,10 +691,13 @@ class MaterialDescriptionRectWithSidebarExtractor:
         if sidebar:
             return max(
                 candidate_rects,
-                key=lambda rect: MaterialDescriptionRectWithSidebar(sidebar, rect, self.lines).score_match,
+                key=lambda rect: (
+                    self._count_keyword_matches(rect),
+                    MaterialDescriptionRectWithSidebar(sidebar, rect, self.lines).score_match,
+                ),
             )
         else:
-            return candidate_rects[0]
+            return max(candidate_rects, key=lambda rect: (self._count_keyword_matches(rect), rect.width))
 
     def _match_sidebars_to_description_rects(
         self, sidebars_noise: list[SidebarNoise]

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -569,13 +569,10 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 else:
                     min_y0 = sidebar.rect.y0 - self.page_height * 0.05
 
-            # Strip log top edge: a reliable geometric anchor for where the description zone begins.
-            # If a text header sits between the strip log top and the sidebar start, the header line
-            # would otherwise push min_y0 too high and cause the first description lines to be excluded.
             overlapping_strips = [sl for sl in self.strip_logs if x_overlap(sl.bbox, sidebar.rect)]
             if overlapping_strips:
                 strip_top = min(sl.bbox.y0 for sl in overlapping_strips)
-                min_y0 = min(min_y0, strip_top - 1)
+                min_y0 = min(min_y0, strip_top - 1) if sidebar.rect.y0 < strip_top else strip_top - 1
 
             # If a table encloses the sidebar, its top edge is a hard upper boundary —
             # description content cannot start above the table the sidebar lives in.

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -726,10 +726,11 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 ),
                 default=initial_best_y0,
             )
+            # Search all page lines
             header_y1 = next(
                 (
                     excl_line.rect.y1
-                    for excl_line in sorted(is_not_description, key=lambda ln: -ln.rect.y1)
+                    for excl_line in sorted(self.lines, key=lambda ln: -ln.rect.y1)
                     if excl_line.rect.y1 <= first_keyword_y0 + 5
                     and excl_line.rect.x0 < best_x1
                     and excl_line.rect.x1 > best_x0

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -482,12 +482,29 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 strip_top = min(sl.bbox.y0 for sl in overlapping_strips)
                 min_y0 = min(min_y0, strip_top - 1)
 
+            # If a table encloses the sidebar, its top edge is a hard upper boundary —
+            # description content cannot start above the table the sidebar lives in.
+            for table in self.table_structures:
+                if table.bounding_rect.contains(sidebar.rect):
+                    min_y0 = max(min_y0, table.bounding_rect.y0 - 1)
+                    break
+
             def check_y0_condition(y0):
                 return y0 > min_y0 and y0 < sidebar.rect.y1
         else:
+            if self.table_structures:
+                # No sidebar or strip log available as a spatial anchor. Restrict the description
+                # zone to the largest table on the page so that page titles, footers, and other
+                # non-table content cannot enter the description zone.
+                largest_table = max(self.table_structures, key=lambda t: t.bounding_rect.height)
+                _t_y0, _t_y1 = largest_table.bounding_rect.y0, largest_table.bounding_rect.y1
 
-            def check_y0_condition(y0):
-                return True
+                def check_y0_condition(y0):
+                    return _t_y0 <= y0 <= _t_y1
+            else:
+
+                def check_y0_condition(y0):
+                    return True
 
         candidate_description = [line for line in self.lines if check_y0_condition(line.rect.y0)]
 
@@ -514,6 +531,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 for line in candidate_description
                 if line.is_description(self.matching_params, self.language, self.analytics, search_excluding=False)
                 and line not in is_not_description
+                and line.rect.width >= line.rect.height  # vertically oriented text is not a description
             ]
 
         if len(candidate_description) == 0:
@@ -552,6 +570,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             good_lines = [
                 line
                 for line in candidate_description
+                if line not in is_not_description  # excluded-keyword lines must not expand the rect
                 if line.rect.y0 >= best_y0 and line.rect.y1 <= best_y1
                 if min_description_x0 < line.rect.x0 < max_description_x0
             ]
@@ -570,13 +589,40 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 excl_line
                 for excl_line in is_not_description
                 if x_overlap_significant_smallest(excl_line.rect, cluster_rect, 0.5)
-                and best_y0 < excl_line.rect.y0
-                and excl_line.rect.y1 < best_y1
+                and best_y0 <= excl_line.rect.y0  # inclusive: also catch excluded lines at the cluster top
+                and excl_line.rect.y1 <= best_y1
             ]
 
             # the rect is valid only when description lines are clearly more numerous than non-description lines.
             if len(non_description_in_rect) / len(good_lines) > self.matching_params["non_description_lines_ratio"]:
                 continue
+
+            # Expand upward to capture content above the first seed — most importantly the
+            # description line for the synthetic "0 → first_entry" interval that sits above
+            # sidebar.rect.y0.  candidate_description already enforces the sidebar / strip-log
+            # top boundary via check_y0_condition, so no additional upper-limit check is needed.
+            # Excluded-keyword lines are explicitly blocked so titles and headers are never pulled in.
+            def is_above(best_x0, best_x1, best_y0, line: TextLine) -> bool:
+                return (
+                    line.rect.x0 > best_x0 - 5
+                    and line.rect.x0 < (best_x0 + best_x1) / 2
+                    and line.rect.y1 > best_y0 - 10  # bottom of the line is just above cluster top
+                    and line.rect.y0 < best_y0  # line actually starts above current cluster
+                    and line not in is_not_description  # never pull in excluded-keyword lines
+                )
+
+            continue_search = True
+            while continue_search:
+                line = next(
+                    (line for line in candidate_description if is_above(best_x0, best_x1, best_y0, line)),
+                    None,
+                )
+                if line:
+                    best_x0 = min(best_x0, line.rect.x0)
+                    best_x1 = max(best_x1, line.rect.x1)
+                    best_y0 = line.rect.y0
+                else:
+                    continue_search = False
 
             # expand to include entire last block
             def is_below(best_x0, best_y1, line: TextLine):
@@ -778,6 +824,43 @@ class MaterialDescriptionRectWithSidebarExtractor:
             )
         return None
 
+    @staticmethod
+    def _get_sidebar_first_depth(sidebar: Sidebar) -> float | None:
+        """Return the first (shallowest) numeric depth value from a sidebar, or None.
+
+        Handles all sidebar kinds:
+        - AAboveBSidebar / ProtocolSidebar / SpulprobeSidebar: entries are DepthColumnEntry,
+          first depth is entries[0].value (float).
+        - AToBSidebar: entries are AToBInterval, first depth is entries[0].start.value.
+        - LayerIdentifierSidebar: entries have string values — returns None.
+        """
+        if not sidebar.entries:
+            return None
+        try:
+            if sidebar.kind == "a_to_b":
+                start = sidebar.entries[0].start
+                return start.value if start is not None else None
+            else:
+                value = sidebar.entries[0].value
+                return float(value) if isinstance(value, (int | float)) else None
+        except (AttributeError, IndexError):
+            return None
+
+    def _completeness_score_bonus(self, sidebar: Sidebar) -> float:
+        """Return a bonus score rewarding sidebars that start near ground level and have many entries.
+
+        A sidebar whose first depth is ≤ 1m is very likely the real borehole profile
+        starting from the surface, rather than a sub-interval list (e.g. elevation-based
+        entries like 526.40m). The entry-count bonus rewards completeness: a sidebar
+        covering many layers is more likely to be the primary description column.
+        """
+        first_depth = self._get_sidebar_first_depth(sidebar)
+        bonus = 0.0
+        if first_depth is not None and first_depth <= 1.0:
+            bonus += 20.0
+        bonus += len(sidebar.entries)
+        return bonus
+
     def _extract_filtered_sidebar_pairs(self) -> list[MaterialDescriptionRectWithSidebar]:
         """Extract and filter sidebar pairs using the common pipeline.
 
@@ -790,10 +873,29 @@ class MaterialDescriptionRectWithSidebarExtractor:
         pairs = self._find_layer_identifier_sidebar_pairs()
         pairs.extend(self._find_depth_sidebar_pairs())
 
-        # Step 2: Sort once by score (highest first)
-        pairs.sort(key=lambda pair: pair.score_match, reverse=True)
+        # Step 2: Hard-filter sidebars whose first depth exceeds the configured maximum.
+        # This rejects elevation-based false positives (e.g. 526.40m, 523.50m) that
+        # can score well on geometry alone when the real borehole starts near 0m.
+        max_first_depth = self.matching_params.get("max_sidebar_first_depth", 300)
+        pairs = [
+            pair
+            for pair in pairs
+            if pair.sidebar is None
+            or self._get_sidebar_first_depth(pair.sidebar) is None
+            or self._get_sidebar_first_depth(pair.sidebar) <= max_first_depth
+        ]
 
-        # Step 3: Apply filter chain
+        # Step 3: Sort by score + completeness bonus (highest first).
+        # The completeness bonus rewards sidebars starting near 0m and having many entries,
+        # so that a complete profile (0→20m) is preferred over a sub-interval snippet
+        # even when the snippet happens to sit geometrically closer to some text column.
+        pairs.sort(
+            key=lambda pair: pair.score_match
+            + (self._completeness_score_bonus(pair.sidebar) if pair.sidebar is not None else 0),
+            reverse=True,
+        )
+
+        # Step 4: Apply filter chain
         filtered_pairs = [pair for pair in pairs if pair.score_match >= 0]
         filtered_pairs = self._filter_by_intersections(filtered_pairs)
 

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -210,7 +210,11 @@ class MaterialDescriptionRectWithSidebarExtractor:
         real borehole column without actually overlapping it.
         """
         bbox1 = pair1.material_description_rect
+        if pair1.sidebar:
+            bbox1 = bbox1 | pair1.sidebar.rect
         bbox2 = pair2.material_description_rect
+        if pair2.sidebar:
+            bbox2 = bbox2 | pair2.sidebar.rect
         gap_threshold = self.page_width * 0.05
         y_overlap = bbox1.y0 < bbox2.y1 and bbox2.y0 < bbox1.y1
         h_adjacent = abs(bbox1.x1 - bbox2.x0) < gap_threshold or abs(bbox2.x1 - bbox1.x0) < gap_threshold
@@ -267,14 +271,12 @@ class MaterialDescriptionRectWithSidebarExtractor:
             list[IntervalBlockPair]: The interval block pairs.
         """
         description_lines = get_description_lines(self.lines, pair.material_description_rect)
-        # _gw_keys = self.matching_params.get("groundwater_keys", {}).get(self.language, [])
         _header_kws = self.matching_params.get("material_description_column_headers", {}).get(self.language, [])
         description_lines = [
             line
             for line in description_lines
             if not line.is_description(self.matching_params, self.language, None, search_excluding=True)
             and not any(kw.lower() in line.text.lower() for kw in _header_kws)
-            # and not any(key.lower() in line.text.lower() for key in _gw_keys)
             and self._line_has_real_word(line.text)
         ]
         diagonals = self.get_diagonals_near_textlines(description_lines, self.line_detection_params)
@@ -429,15 +431,11 @@ class MaterialDescriptionRectWithSidebarExtractor:
         """
         for word in re.findall(r"[^\W\d_]{3,}", text, re.UNICODE):
             alpha = [c for c in word if c.isalpha()]
-            if (
-                len(alpha) >= 3
-                and sum(1 for c in alpha if c.islower()) >= 2
-                and sum(1 for c in alpha if c.islower()) / len(alpha) >= 0.5
-            ):
+            if len(alpha) >= 3 and sum(1 for c in alpha if c.islower()) / len(alpha) >= 0.5:
                 return True
         return False
 
-    def _count_keyword_matches(self, rect: pymupdf.Rect) -> int:
+    def _has_keyword_match(self, rect: pymupdf.Rect) -> int:
         """Return 1 if rect contains any line matching including_expressions, 0 otherwise.
 
         Binary so that all keyword-qualifying columns score equally on this dimension,
@@ -460,11 +458,12 @@ class MaterialDescriptionRectWithSidebarExtractor:
         is the material description column, and mark its upper content boundary.
         """
         header_keywords = self.matching_params.get("material_description_column_headers", {}).get(self.language, [])
+        look_above = self.page_height * 0.05
         for line in self.lines:
             if (
                 line.rect.x0 < rect.x1
                 and line.rect.x1 > rect.x0
-                and rect.y0 - 50 <= line.rect.y1 <= rect.y0 + 5
+                and rect.y0 - look_above <= line.rect.y1 <= rect.y0 + 5
                 and any(kw.lower() in line.text.lower() for kw in header_keywords)
             ):
                 return True
@@ -604,12 +603,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
         candidate_description = [line for line in self.lines if check_y0_condition(line.rect.y0)]
 
-        # gw_keys = self.matching_params.get("groundwater_keys", {}).get(self.language, [])
         header_keywords = self.matching_params.get("material_description_column_headers", {}).get(self.language, [])
-
-        # def is_groundwater_line(line: TextLine) -> bool:
-        #     text_lower = line.text.lower()
-        #     return any(key.lower() in text_lower for key in gw_keys)
 
         def is_column_header_line(line: TextLine) -> bool:
             text_lower = line.text.lower()
@@ -619,7 +613,6 @@ class MaterialDescriptionRectWithSidebarExtractor:
             line
             for line in candidate_description
             if line.is_description(self.matching_params, self.language, self.analytics, search_excluding=True)
-            # or is_groundwater_line(line)
             or is_column_header_line(line)
         ]
 
@@ -823,6 +816,8 @@ class MaterialDescriptionRectWithSidebarExtractor:
         gap_threshold = self.page_width * 0.05
         suppressed = set()
         for i, r1 in enumerate(candidate_rects):
+            if i in suppressed:
+                continue
             for j, r2 in enumerate(candidate_rects):
                 if i == j or j in suppressed:
                     continue
@@ -837,7 +832,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
             # share the seeding x-range with the real description column. Prefer by keyword match
             # count first (more geological content = more likely the real description column),
             # then fall back to width as a tiebreaker.
-            candidate_rects = [max(candidate_rects, key=lambda r: (self._count_keyword_matches(r), r.width))]
+            candidate_rects = [max(candidate_rects, key=lambda r: (self._has_keyword_match(r), r.width))]
 
         return candidate_rects
 
@@ -859,7 +854,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 candidate_rects,
                 key=lambda rect: (
                     self._has_column_header(rect),
-                    self._count_keyword_matches(rect),
+                    self._has_keyword_match(rect),
                     MaterialDescriptionRectWithSidebar(sidebar, rect, self.lines).score_match,
                 ),
             )
@@ -868,7 +863,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 candidate_rects,
                 key=lambda rect: (
                     self._has_column_header(rect),
-                    self._count_keyword_matches(rect),
+                    self._has_keyword_match(rect),
                     rect.width,
                 ),
             )

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -267,6 +267,16 @@ class MaterialDescriptionRectWithSidebarExtractor:
             list[IntervalBlockPair]: The interval block pairs.
         """
         description_lines = get_description_lines(self.lines, pair.material_description_rect)
+        # _gw_keys = self.matching_params.get("groundwater_keys", {}).get(self.language, [])
+        _header_kws = self.matching_params.get("material_description_column_headers", {}).get(self.language, [])
+        description_lines = [
+            line
+            for line in description_lines
+            if not line.is_description(self.matching_params, self.language, None, search_excluding=True)
+            and not any(kw.lower() in line.text.lower() for kw in _header_kws)
+            # and not any(key.lower() in line.text.lower() for key in _gw_keys)
+            and self._line_has_real_word(line.text)
+        ]
         diagonals = self.get_diagonals_near_textlines(description_lines, self.line_detection_params)
 
         line_affinities = get_line_affinity(
@@ -393,6 +403,21 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
         return material_descriptions_sidebar_pairs
 
+    def _has_separating_line(self, y_top: float, y_bottom: float, x0: float, x1: float) -> bool:
+        """Return True if a significant horizontal line crosses the x-range between y_top and y_bottom.
+
+        Used to detect fat table/box borders that visually separate a column header from its
+        content, so that the header is never pulled into the material description rect.
+        """
+        slope_tol = self.line_detection_params.get("line_merging_params", {}).get("horizontal_slope_tolerance", 0.1)
+        for line in self.long_or_horizontal_lines:
+            if not line.is_horizontal(slope_tol):
+                continue
+            line_y = (line.start.y + line.end.y) / 2
+            if y_top < line_y < y_bottom and line.start.x < x1 and line.end.x > x0:
+                return True
+        return False
+
     @staticmethod
     def _line_has_real_word(text: str) -> bool:
         """Return True if text contains at least one real word.
@@ -413,12 +438,37 @@ class MaterialDescriptionRectWithSidebarExtractor:
         return False
 
     def _count_keyword_matches(self, rect: pymupdf.Rect) -> int:
-        """Count lines within rect that match including_expressions."""
-        return sum(
-            1
-            for line in get_description_lines(self.lines, rect)
-            if line.is_description(self.matching_params, self.language, None, search_excluding=False)
+        """Return 1 if rect contains any line matching including_expressions, 0 otherwise.
+
+        Binary so that all keyword-qualifying columns score equally on this dimension,
+        making width the true differentiator between candidates.
+        Uses direct rect containment (not get_description_lines) to avoid the right-side
+        cutoff that would penalize wide columns whose keyword lines fall in the outer 40%.
+        """
+        return int(
+            any(
+                line.is_description(self.matching_params, self.language, None, search_excluding=False)
+                for line in self.lines
+                if rect.contains(line.rect)
+            )
         )
+
+    def _has_column_header(self, rect: pymupdf.Rect) -> bool:
+        """Return True if an excluded line sits immediately above this rect (a column header).
+
+        Column headers like "Beschreibung" or "Bodenart" are a positive signal that the rect
+        is the material description column, and mark its upper content boundary.
+        """
+        header_keywords = self.matching_params.get("material_description_column_headers", {}).get(self.language, [])
+        for line in self.lines:
+            if (
+                line.rect.x0 < rect.x1
+                and line.rect.x1 > rect.x0
+                and rect.y0 - 50 <= line.rect.y1 <= rect.y0 + 5
+                and any(kw.lower() in line.text.lower() for kw in header_keywords)
+            ):
+                return True
+        return False
 
     def _get_geometric_description_seeds(
         self, candidate_description: list[TextLine], sidebar: Sidebar | None
@@ -500,10 +550,25 @@ class MaterialDescriptionRectWithSidebarExtractor:
             if above_sidebar:
                 min_y0 = max(line.rect.y0 for line in above_sidebar)
             else:
-                # No header lines found above the sidebar in its x-column. Allow a small margin above
-                # the sidebar top so description lines for the synthetic "0 → first entry" interval
-                # are included, but titles and page headers (much higher up) are not.
-                min_y0 = sidebar.rect.y0 - self.page_height * 0.05
+                # No header lines found above the sidebar in its x-column. Use the nearest
+                # horizontal separator line above the sidebar as a hard upper boundary; fall
+                # back to a small geometric margin so the synthetic "0 → first entry" interval
+                # is still reachable.
+                slope_tol = self.line_detection_params.get("line_merging_params", {}).get(
+                    "horizontal_slope_tolerance", 0.1
+                )
+                lines_above = [
+                    ln
+                    for ln in self.long_or_horizontal_lines
+                    if ln.is_horizontal(slope_tol)
+                    and (ln.start.y + ln.end.y) / 2 < sidebar.rect.y0
+                    and ln.start.x < sidebar.rect.x1
+                    and ln.end.x > sidebar.rect.x0
+                ]
+                if lines_above:
+                    min_y0 = max((ln.start.y + ln.end.y) / 2 for ln in lines_above)
+                else:
+                    min_y0 = sidebar.rect.y0 - self.page_height * 0.05
 
             # Strip log top edge: a reliable geometric anchor for where the description zone begins.
             # If a text header sits between the strip log top and the sidebar start, the header line
@@ -539,10 +604,23 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
         candidate_description = [line for line in self.lines if check_y0_condition(line.rect.y0)]
 
+        # gw_keys = self.matching_params.get("groundwater_keys", {}).get(self.language, [])
+        header_keywords = self.matching_params.get("material_description_column_headers", {}).get(self.language, [])
+
+        # def is_groundwater_line(line: TextLine) -> bool:
+        #     text_lower = line.text.lower()
+        #     return any(key.lower() in text_lower for key in gw_keys)
+
+        def is_column_header_line(line: TextLine) -> bool:
+            text_lower = line.text.lower()
+            return any(kw.lower() in text_lower for kw in header_keywords)
+
         is_not_description = [
             line
             for line in candidate_description
             if line.is_description(self.matching_params, self.language, self.analytics, search_excluding=True)
+            # or is_groundwater_line(line)
+            or is_column_header_line(line)
         ]
 
         # Primary: use geometric proximity to the sidebar / strip log as the seed signal.
@@ -643,11 +721,56 @@ class MaterialDescriptionRectWithSidebarExtractor:
             if len(non_description_in_rect) / len(good_lines) > self.matching_params["non_description_lines_ratio"]:
                 continue
 
-            # Expand upward to capture content above the first seed — most importantly the
-            # description line for the synthetic "0 → first_entry" interval that sits above
-            # sidebar.rect.y0.  candidate_description already enforces the sidebar / strip-log
-            # top boundary via check_y0_condition, so no additional upper-limit check is needed.
-            # Excluded-keyword lines are explicitly blocked so titles and headers are never pulled in.
+            # Detect the material description column header (Beschreibung, Bodenart, etc.).
+            # Anchor to the FIRST KEYWORD-MATCHING line in good_lines, not to initial_best_y0.
+            # initial_best_y0 is often inflated by stray seeds (date lines, page headers) that
+            # share the same x-column as the real content — anchoring to the first geological
+            # keyword line ensures the search window actually reaches "Beschreibung" even when
+            # date lines at y=31 pushed initial_best_y0 far above the real table.
+            initial_best_y0 = best_y0
+            first_keyword_y0 = min(
+                (
+                    ln.rect.y0
+                    for ln in good_lines
+                    if ln.is_description(self.matching_params, self.language, None, search_excluding=False)
+                ),
+                default=initial_best_y0,
+            )
+            header_y1 = next(
+                (
+                    excl_line.rect.y1
+                    for excl_line in sorted(is_not_description, key=lambda ln: -ln.rect.y1)
+                    if excl_line.rect.y1 <= first_keyword_y0 + 5
+                    and excl_line.rect.x0 < best_x1
+                    and excl_line.rect.x1 > best_x0
+                    and any(kw.lower() in excl_line.text.lower() for kw in header_keywords)
+                ),
+                None,
+            )
+            # Extend header_y1 downward to cover multi-line column names
+            # (e.g. "Beschreibung" line 1, "des aufgeschlossenen Bohrgutes" line 2).
+            if header_y1 is not None:
+                extended = True
+                while extended:
+                    extended = False
+                    for excl_line in is_not_description:
+                        if (
+                            excl_line.rect.y0 >= header_y1
+                            and excl_line.rect.y1 <= initial_best_y0 + 5
+                            and excl_line.rect.x0 < best_x1
+                            and excl_line.rect.x1 > best_x0
+                            and excl_line.rect.y1 > header_y1
+                        ):
+                            header_y1 = excl_line.rect.y1
+                            extended = True
+
+            # Hard upper boundary: only the column name bottom.
+            # Everything below header_y1 is accepted; everything above is rejected.
+            # Without a column name, cap is_above expansion at 50 px to avoid runaway chaining.
+            upward_limit = header_y1 if header_y1 is not None else initial_best_y0 - 50
+            if header_y1 is not None:
+                best_y0 = max(best_y0, header_y1)
+
             def is_above(best_x0, best_x1, best_y0, line: TextLine) -> bool:
                 return (
                     line.rect.x0 > best_x0 - 5
@@ -655,6 +778,8 @@ class MaterialDescriptionRectWithSidebarExtractor:
                     and line.rect.y1 > best_y0 - 10  # bottom of the line is just above cluster top
                     and line.rect.y0 < best_y0  # line actually starts above current cluster
                     and line not in is_not_description  # never pull in excluded-keyword lines
+                    and not self._has_separating_line(line.rect.y0, best_y0, best_x0, best_x1)
+                    and line.rect.y0 >= upward_limit  # noqa: B023
                 )
 
             continue_search = True
@@ -673,7 +798,8 @@ class MaterialDescriptionRectWithSidebarExtractor:
             # expand to include entire last block
             def is_below(best_x0, best_y1, line: TextLine):
                 return (
-                    (line.rect.x0 > best_x0 - 5)
+                    line not in is_not_description  # noqa: B023
+                    and (line.rect.x0 > best_x0 - 5)
                     and (line.rect.x0 < (best_x0 + best_x1) / 2)  # noqa: B023
                     and (line.rect.y0 < best_y1 + 10)
                     and (line.rect.y1 > best_y1)
@@ -732,12 +858,20 @@ class MaterialDescriptionRectWithSidebarExtractor:
             return max(
                 candidate_rects,
                 key=lambda rect: (
+                    self._has_column_header(rect),
                     self._count_keyword_matches(rect),
                     MaterialDescriptionRectWithSidebar(sidebar, rect, self.lines).score_match,
                 ),
             )
         else:
-            return max(candidate_rects, key=lambda rect: (self._count_keyword_matches(rect), rect.width))
+            return max(
+                candidate_rects,
+                key=lambda rect: (
+                    self._has_column_header(rect),
+                    self._count_keyword_matches(rect),
+                    rect.width,
+                ),
+            )
 
     def _match_sidebars_to_description_rects(
         self, sidebars_noise: list[SidebarNoise]

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -1,6 +1,7 @@
 """Contains the main extraction pipeline for stratigraphy."""
 
 import logging
+import re
 
 import fastquadtree
 import pymupdf
@@ -124,6 +125,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
         material_descriptions_without_sidebar = self._extract_material_descriptions_without_sidebar()
         if material_descriptions_without_sidebar and not any(
             self._pairs_intersect(material_descriptions_without_sidebar, other_pair)
+            or self._pairs_adjacent(material_descriptions_without_sidebar, other_pair)
             for other_pair in pairs_from_valid_boreholes
         ):
             # add the material descriptions without sidebar if there is no intersection with any of the already
@@ -200,6 +202,19 @@ class MaterialDescriptionRectWithSidebarExtractor:
             bbox2 = bbox2 | pair2.sidebar.rect
 
         return bbox1.intersects(bbox2)
+
+    def _pairs_adjacent(self, pair1, pair2) -> bool:
+        """Check if two pairs are horizontally adjacent with vertical overlap.
+
+        Catches cases where a false-positive column sits immediately next to a
+        real borehole column without actually overlapping it.
+        """
+        bbox1 = pair1.material_description_rect
+        bbox2 = pair2.material_description_rect
+        gap_threshold = self.page_width * 0.05
+        y_overlap = bbox1.y0 < bbox2.y1 and bbox2.y0 < bbox1.y1
+        h_adjacent = abs(bbox1.x1 - bbox2.x0) < gap_threshold or abs(bbox2.x1 - bbox1.x0) < gap_threshold
+        return y_overlap and h_adjacent
 
     def _create_borehole_from_pair(self, pair: MaterialDescriptionRectWithSidebar) -> ExtractedBorehole | None:
         """Create an ExtractedBorehole from a MaterialDescriptionRectWithSidebar."""
@@ -380,19 +395,17 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
     @staticmethod
     def _line_has_real_word(text: str) -> bool:
-        """Return True if text contains at least one real-word token.
+        """Return True if text contains at least one real word.
 
-        A real word requires 3+ alphabetic characters in the token, does not start
-        with a digit, and has at least half of its letters in lowercase. This
-        distinguishes geological description words ("Sand", "schluffig", "Kies")
-        from coded identifiers ("KB1-P6", "4bc", "4a", "4Hb") and unit symbols
-        ("m", "cm") that would otherwise pass a simple alpha-character count.
+        A real word is a contiguous run of 3+ alphabetic characters that does not
+        start with a digit and has at least half its letters in lowercase. Requiring
+        contiguous letters rejects abbreviations like "m.ü.M." or "Nr." whose scattered
+        alpha chars would otherwise satisfy a simple count check.
         """
-        for token in text.split():
-            alpha = [c for c in token if c.isalpha()]
+        for word in re.findall(r"[^\W\d_]{3,}", text, re.UNICODE):
+            alpha = [c for c in word if c.isalpha()]
             if (
                 len(alpha) >= 3
-                and not token[0].isdigit()
                 and sum(1 for c in alpha if c.islower()) >= 2
                 and sum(1 for c in alpha if c.islower()) / len(alpha) >= 0.5
             ):
@@ -430,24 +443,34 @@ class MaterialDescriptionRectWithSidebarExtractor:
         if not sidebar and not self.strip_logs:
             return None
 
+        tolerance = self.page_width * 0.02
+        proximity = self.page_width * 0.15
+
         if sidebar:
-            x_anchor = sidebar.rect.x1
-            # A strip log sitting between the sidebar and the description column shifts the anchor right
+            x_right = sidebar.rect.x1
+            x_left = sidebar.rect.x0
+            # A strip log sitting between the sidebar and the description column shifts the right anchor
             overlapping_strips = [
-                sl for sl in self.strip_logs if x_overlap(sl.bbox, sidebar.rect) and sl.bbox.x1 > x_anchor
+                sl for sl in self.strip_logs if x_overlap(sl.bbox, sidebar.rect) and sl.bbox.x1 > x_right
             ]
             if overlapping_strips:
-                x_anchor = max(sl.bbox.x1 for sl in overlapping_strips)
-        else:
-            # No sidebar: anchor on the rightmost strip log edge present on the page
-            x_anchor = max(sl.bbox.x1 for sl in self.strip_logs)
+                x_right = max(sl.bbox.x1 for sl in overlapping_strips)
 
-        # Small leftward tolerance so lines whose left edge barely overlaps the anchor are not lost
-        x_start = x_anchor - self.page_width * 0.02
+            def close_to_anchor(line: TextLine) -> bool:
+                right_side = line.rect.x0 >= x_right - tolerance
+                left_side = line.rect.x1 <= x_left + tolerance and line.rect.x1 >= x_left - proximity
+                return right_side or left_side
+        else:
+            # No sidebar: only a right anchor from the strip log edge
+            x_right = max(sl.bbox.x1 for sl in self.strip_logs)
+
+            def close_to_anchor(line: TextLine) -> bool:
+                return line.rect.x0 >= x_right - tolerance
+
         seeds = [
             line
             for line in candidate_description
-            if line.rect.x0 >= x_start
+            if close_to_anchor(line)
             and line.rect.width >= line.rect.height  # vertically oriented text is not a description
             and self._line_has_real_word(line.text)  # excludes codes, unit symbols, pure numbers
         ]
@@ -584,6 +607,8 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 if line not in is_not_description  # excluded-keyword lines must not expand the rect
                 if line.rect.y0 >= best_y0 and line.rect.y1 <= best_y1
                 if min_description_x0 < line.rect.x0 < max_description_x0
+                if line.rect.width >= line.rect.height  # vertically oriented text is not a description
+                if self._line_has_real_word(line.text)  # pure-number lines (coordinates, heights) are not descriptions
             ]
             best_x0 = min([line.rect.x0 for line in good_lines])
             best_x1 = max([line.rect.x1 for line in good_lines])
@@ -665,6 +690,21 @@ class MaterialDescriptionRectWithSidebarExtractor:
                     continue_search = False
 
             candidate_rects.append(pymupdf.Rect(best_x0, best_y0, best_x1, best_y1))
+
+        # Suppress narrow rects that are immediately adjacent to a wider one — these are
+        # secondary columns sitting next to the real
+        # description column, not separate boreholes.
+        gap_threshold = self.page_width * 0.05
+        suppressed = set()
+        for i, r1 in enumerate(candidate_rects):
+            for j, r2 in enumerate(candidate_rects):
+                if i == j or j in suppressed:
+                    continue
+                y_overlap_exists = r1.y0 < r2.y1 and r2.y0 < r1.y1
+                horizontally_adjacent = abs(r1.x1 - r2.x0) < gap_threshold or abs(r2.x1 - r1.x0) < gap_threshold
+                if y_overlap_exists and horizontally_adjacent:
+                    suppressed.add(i if r1.width < r2.width else j)
+        candidate_rects = [r for idx, r in enumerate(candidate_rects) if idx not in suppressed]
 
         if using_geometric_seeds and len(candidate_rects) > 1:
             # Multiple clusters arise when narrow secondary columns (layer codes, measurements)

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -150,7 +150,7 @@ material_description:
       - pumpversuch
       - kernbohrung
       # - bohrradius # Should be reviewed, currently not used
-      - wasserzutritt
+      # - wasserzutritt
       - Vollrohr
       - Filterrohr
       - sondier

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -91,6 +91,20 @@ default_language: de
 
 compound_split_threshold: 0.4
 
+# Lines whose text contains any of these substrings (case-insensitive) are treated as column
+# headers for the material description column. They are excluded from the material description
+# output text and act as a hard upper boundary (nothing above them is included). They are also
+# used as a positive selection signal when choosing between candidate columns.
+material_description_column_headers:
+  de:
+    - beschreibung
+    - beschrieb
+    - bodenart
+    - lithologie
+    - materialbezeichnung
+  fr:
+    - description
+
 material_description:
   de:
     including_expressions:
@@ -104,106 +118,89 @@ material_description:
       - kiesig
       - ton
       - tonig
-      - asphalt
-      - asphaltdeckschicht # is not split by the compound splitter
-      - humus
-      - braun
-      - weich
-      - wurzel
-      - belag
       - stein
-      - beige
-      - beton
+      - kalk
       - kreide
       - mergel
-      - kern
-      - lehm
-      - dito
       - dolomit
-      - kristallin
       - gneis
-      - kalke
-      - mikritisch
-      - laminiert
-      - grob
-      - auffüllung
-      - schlacke
-      - überlagerung
+      - kristallin
       - moräne
+      - auffüllung
       - aufschüttung
+      - beton
+      - asphalt
+      - humus
+      - lehm
+      - braun
+      - grob
+      - kern
+      - wurzel
     excluding_expressions:
       - herr
       - ende
       - profil
-      - beschreibung
-      - materialbeschreibung
       - kiesprospektion
       - signaturen
-      - mischprobe # Should be reviewed, currently not used
+      # - mischprobe # Should be reviewed, currently not used
       - projekt
       - ort
       - adresse
       - wetter
       - pumpversuch
       - kernbohrung
-      - bohrradius # Should be reviewed, currently not used
+      # - bohrradius # Should be reviewed, currently not used
       - wasserzutritt
       - Vollrohr
       - Filterrohr
+      - sondier
+      - sondierbohrung
+      - bohrprofil
+      - bohrung
+      - koordinaten
+      - auftrag
+      - aufgenommen
+      - Datum
 
   fr:
     including_expressions:
       - sol
       - végétal
-      - dallage
       - terre
-      - bitume
-      - bitumineux
-      - grave d'infrastructure # Should be reviewed, currently not used
       - sable
       - limon
+      - limoneuse
+      - argileux
+      - argileuse
       - gravier
       - asphalte
-      - humus
-      - brun
-      - gris
-      - grise
-      - mou
-      - dur
-      - dure
-      - ferme
-      - racine
+      - bitume
+      - enrobé
       - revetement
-      - pierre
-      - beige
       - béton
       - craie
       - marne
-      - materiau # Should be reviewed, currently not used
-      - matrice sableuse # Should be reviewed, currently not used
-      - enrobé
-      - phase
-      - limoneuse
-      - argileuse
-      - argileux
-      - mousse # Should be reviewed, currently not used
+      - humus
+      - racine
+      - pierre
     excluding_expressions:
-      - monsieur # Should be reviewed, currently not used
+      # - monsieur # Should be reviewed, currently not used
       - profil
-      - description
-      - signatures # Should be reviewed, currently not used
-      - echantillon mixte # Should be reviewed, currently not used
+      # - signatures # Should be reviewed, currently not used
+      # - echantillon mixte # Should be reviewed, currently not used
       - projet
       - lieu
       - adresse
       - temps
-      - essai de pompage # Should be reviewed, currently not used
+      # - essai de pompage # Should be reviewed, currently not used
       - carottage
-      - rayon de forage # Should be reviewed, currently not used
+      # - rayon de forage # Should be reviewed, currently not used
       - remarque
       - piezometre
       - profondeur
       - désignation
+      - sondage
+      - lithologie
 
   it:
     including_expressions:
@@ -211,20 +208,14 @@ material_description:
       - limo
       - ghiaia
       - asfalto
+      - cemento
+      - marna
+      - gesso
       - humus
-      - marrone
-      - grigio
-      - morbido
-      - duro
       - radice
       - rivestimento
       - pietra
-      - beige
-      - cemento
-      - gesso
-      - marna
       - materiale di carota
-      - idem
     excluding_expressions:
       - signore
       - fine
@@ -239,6 +230,8 @@ material_description:
       - prova di pompaggio
       - carotaggio
       - raggio di perforazione
+      - sondaggio
+      - litologia
 
   en:
     including_expressions:
@@ -251,23 +244,16 @@ material_description:
       - clay
       - claystone
       - gravel
+      - limestone
+      - marl
+      - chalk
+      - stone
       - asphalt
+      - concrete
       - humus
-      - brown
-      - gray
-      - soft
-      - hard
       - root
       - surface layer
-      - stone
-      - beige
-      - concrete
-      - chalk
-      - marl
       - core material
-      - limestone
-      - ditto # Should be reviewed, currently not used
-      - alternation
       - leucosome
     excluding_expressions:
       - Mr.
@@ -280,9 +266,13 @@ material_description:
       - location
       - address
       - weather
-      - pump test # Should be reviewed, currently not used
+      # - pump test # Should be reviewed, currently not used
       - core drilling
       - drilling radius
+      - sounding
+      - lithology
+      - borehole profile
+      - coordinates
 
 coordinate_keys:
   de:


### PR DESCRIPTION
Closes #437 

 **Before**, the first lines of material descriptions were missed sometimes because the detection relied almost entirely on keyword inclusion lists. 
We want to become less dependent on the keyword list. 

The current ideas which could help to detect the material description --> focus on geometrical features and quality of content regardless of keywords
- prefer text which is close to a sidebar/striplog  or which is within a table structure
- check if line has one real world —> exclude numbers and pure abbreviations 
- md column has to have at least one keyword matching 
- reduced keyword list 
- check if two pairs are horizontally adjacent with vertical overlap -> for cases where we detected a trash column tright next to the real md column —> ignore this one
- created header keyword list and check if the column has a header matching the keyword _has_column_header
check for horizontal line above md —> exclude header from being added to md cluster 
- also use strip log top edge as a boundary, because it is unlikely to find md above that —> same with table top edge 
prefer wide columns over narrow columns
- `_get_geometric_description_seeds` —> check for md on the sides of the striplog
-  Upward expansion of the md cluster (is_above loop)
- Multi-line column header expansion: after detecting a header like "Beschreibung", the code iteratively extends header_y1 downward to absorb continuation lines (e.g. "des aufgeschlossenen Bohrgutes") before using it as the cluster's upper boundary.
- Column header excluded from description output text
- 
Currently we are fixing the missing first lines issue described in the issue #437 (but adding DP as well) but overall we do not reach the original performance with the keyword based md detection 

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Zurich | layer_f1 | depth_intervall_f1 | Material_description_f1 | grounwaterf1 | elevation_f1 | coordinates_f1 | Borehole_name_f1
-- | -- | -- | -- | -- | -- | -- | --
develop | 0.842 | 0.893 | 0.88 | 0.373 | 0.814 | 0.694 | 0.73
437 |0.81 | 0.872 | 0.852 | 0.389 | 0.8395 | 0.718 | 0.755

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
geoquat | layer_f1 | depth_intervall_f1 | Material_description_f1 | grounwaterf1 | elevation_f1 | coordinates_f1 | Borehole_name_f1
-- | -- | -- | -- | -- | -- | -- | --
develop | 0.479 | 0.6296 | 0.628 | 0.05 | 0.615 | 0.475 | 0.604
437 | 0.461 | 0.607 | 0.596 | 0.056 | 0.635 | 0.489 | 0.607


There are some examples where the first lines are now detected as well but the main remaining issues are 
- additional lines are included 
- false positives besides the actual material description
- the _line_has_real_word is very strict and is extracting 

I tried to fix some of these, e.g. by not checking `_line_has_real_word` in `_get_interval_block_pairs` or `_get_geometric_description_seeds` which solved the issue with missed non-word lines within a material description block but overall performance got worse, because of FP 
But I cannot beat the current performance despite the efforts.

By implementing only the `is_above` loop we solve the issue and reach _okay_ metrics scores (improving mainly depth_intervall and losing a few percent on the rest) but the keyword logic stays the same. 

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--
Zurich | layer_f1 | depth_intervall_f1 | Material_description_f1 | groundwaterf1 | elevation_f1 | coordinates_f1 | Borehole_name_f1
-- | -- | -- | -- | -- | -- | -- | --
develop | 0.842 | 0.893 | 0.88 | 0.373 | 0.814 | 0.694 | 0.73
check above | 0.841 | 0.912 | 0.874 | 0.0387 | 0.803 | 0.703 | 0.72

<google-sheets-html-origin>><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
geoquat | layer_f1 | depth_intervall_f1 | Material_description_f1 | groundwaterf1 | elevation_f1 | coordinates_f1 | Borehole_name_f1
-- | -- | -- | -- | -- | -- | -- | --
develop | 0.479 | 0.6296 | 0.628 | 0.05 | 0.615 | 0.475 | 0.604
check above | 0.474 | 0.657 | 0.637 | 0.039 | 0.558 | 0.376 | 0.643

(EDIT cant reproduce those numbers anymore --> see #470 for current implementation of check above)




