### PR TITLE
#442: fallback from AAboveBSidebar to ProtocolSidebar if it's a perfect fit

### DIFF
--- a/src/app/api/v1/endpoints/extract_stratigraphy.py
+++ b/src/app/api/v1/endpoints/extract_stratigraphy.py
@@ -75,7 +75,8 @@ def extract_stratigraphy(filename: str, include_groundwater: bool = False) -> Ex
     boreholes_per_page = []
     for page_index, page in enumerate(document):
         # 2. load the png image to infer the scaling, MUST have been generated before
-        png_page = load_png(filename, page_index + 1)  # page number is 1-indexed
+        page_number = page_index + 1  # page number is 1-indexed
+        png_page = load_png(filename, page_number)
         pdf_img_scalings.append((png_page.shape[1] / page.rect.width, png_page.shape[0] / page.rect.height))
 
         # 3. extract layers
@@ -95,7 +96,7 @@ def extract_stratigraphy(filename: str, include_groundwater: bool = False) -> Ex
             table_structures,
             strip_logs,
             language,
-            page_index,
+            page_number,
             page.rect.width,
             page.rect.height,
             line_detection_params,
@@ -107,7 +108,7 @@ def extract_stratigraphy(filename: str, include_groundwater: bool = False) -> Ex
         # Extract groundwater if requested (uses the extracted boreholes as context)
         if include_groundwater and groundwater_extractor and groundwater_in_doc:
             groundwater_entries = groundwater_extractor.extract_groundwater(
-                page_number=page_index + 1,
+                page_number=page_number,
                 text_lines=text_lines,
                 geometric_lines=long_or_horizontal_lines,
                 extracted_boreholes=extracted_boreholes,

--- a/src/app/api/v1/endpoints/extract_stratigraphy.py
+++ b/src/app/api/v1/endpoints/extract_stratigraphy.py
@@ -8,7 +8,7 @@ from app.common.schemas import (
     ExtractStratigraphyResponse,
     GroundwaterSchema,
 )
-from extraction.features.extract import extract_page
+from extraction.features.extract import MaterialDescriptionRectWithSidebarExtractor
 from extraction.features.groundwater.groundwater_extraction import (
     GroundwaterInDocument,
     GroundwaterLevelExtractor,
@@ -88,7 +88,7 @@ def extract_stratigraphy(filename: str, include_groundwater: bool = False) -> Ex
         # Detect strip logs on the page
         strip_logs = detect_strip_logs(page, text_lines, striplog_detection_params)
 
-        extracted_boreholes = extract_page(
+        extracted_boreholes = MaterialDescriptionRectWithSidebarExtractor(
             text_lines,
             long_or_horizontal_lines,
             all_geometric_lines,
@@ -96,11 +96,12 @@ def extract_stratigraphy(filename: str, include_groundwater: bool = False) -> Ex
             strip_logs,
             language,
             page_index,
-            page,
+            page.rect.width,
+            page.rect.height,
             line_detection_params,
-            None,
+            analytics=None,
             **matching_params,
-        )
+        ).process_page()
         boreholes_per_page.append(extracted_boreholes)
 
         # Extract groundwater if requested (uses the extracted boreholes as context)

--- a/src/extraction/core/extract.py
+++ b/src/extraction/core/extract.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pymupdf
 
-from extraction.features.extract import extract_page
+from extraction.features.extract import MaterialDescriptionRectWithSidebarExtractor
 from extraction.features.groundwater.groundwater_extraction import (
     GroundwaterInDocument,
     GroundwaterLevelExtractor,
@@ -139,7 +139,7 @@ def extract(
             strip_logs = detect_strip_logs(page, text_lines, striplog_detection_params)
 
             # Extract the stratigraphy
-            page_layers = extract_page(
+            extracted_boreholes = MaterialDescriptionRectWithSidebarExtractor(
                 text_lines,
                 long_or_horizontal_lines,
                 all_geometric_lines,
@@ -147,12 +147,13 @@ def extract(
                 strip_logs,
                 file_metadata.language,
                 page_index,
-                page,
+                page.rect.width,
+                page.rect.height,
                 line_detection_params,
                 analytics,
                 **matching_params,
-            )
-            boreholes_per_page.append(page_layers)
+            ).process_page()
+            boreholes_per_page.append(extracted_boreholes)
 
             # Extract the groundwater levels
             groundwater_extractor = GroundwaterLevelExtractor(file_metadata.language, matching_params)
@@ -160,7 +161,7 @@ def extract(
                 page_number=page_number,
                 text_lines=text_lines,
                 geometric_lines=long_or_horizontal_lines,
-                extracted_boreholes=page_layers,
+                extracted_boreholes=extracted_boreholes,
             )
             all_groundwater_entries.groundwater_feature_list.extend(groundwater_entries)
 

--- a/src/extraction/core/extract.py
+++ b/src/extraction/core/extract.py
@@ -146,7 +146,7 @@ def extract(
                 table_structures,
                 strip_logs,
                 file_metadata.language,
-                page_index,
+                page_number,
                 page.rect.width,
                 page.rect.height,
                 line_detection_params,

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -912,9 +912,6 @@ def get_pairs_based_on_line_affinity(
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
     threshold = -0.3
 
-    for line, aff in zip(description_lines, affinities, strict=False):
-        print(aff.weighted_affinity(**weights), aff.vertical_spacing_affinity, line.text)
-
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0
         if affinity.weighted_affinity(**weights) <= threshold:

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -910,7 +910,10 @@ def get_pairs_based_on_line_affinity(
     pairs = []
     prev_block_idx = 0
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
-    threshold = -1
+    threshold = -0.3
+
+    for line, aff in zip(description_lines, affinities, strict=False):
+        print(aff.weighted_affinity(**weights), aff.vertical_spacing_affinity, line.text)
 
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -910,11 +910,11 @@ def get_pairs_based_on_line_affinity(
     pairs = []
     prev_block_idx = 0
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
-    # The presence of >=3 horiz. lines should tighten the vertical spacing constrain
-    threshold = -0.99 if sum(affinity.long_lines_affinity for affinity in affinities) <= -3.0 else 0.0
+    threshold = -1
+
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0
-        if affinity.weighted_affinity(**weights) < threshold:
+        if affinity.weighted_affinity(**weights) <= threshold:
             pairs.append(IntervalBlockPair(None, TextBlock(description_lines[prev_block_idx:line_idx])))
             prev_block_idx = line_idx
 

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -910,7 +910,16 @@ def get_pairs_based_on_line_affinity(
     pairs = []
     prev_block_idx = 0
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
-    threshold = -0.2
+
+    horizontal_lines_significance = sum(-affinity.long_lines_affinity for affinity in affinities)
+    vertical_spacing_significance = sum(max(0.0, -affinity.vertical_spacing_affinity) for affinity in affinities)
+    if horizontal_lines_significance > vertical_spacing_significance:
+        # if the precense of horizontal lines seems to be a stronger differentiator than the vertical spacing between
+        # lines, then we set the threshold at the level of the presence of such a horizontal line, making it less
+        # likely that descriptions are split in the absence of such a line.
+        threshold = -weights["line_weight"]
+    else:
+        threshold = -0.2 * weights["spacing_weight"]
 
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -914,7 +914,7 @@ def get_pairs_based_on_line_affinity(
     horizontal_lines_significance = sum(-affinity.long_lines_affinity for affinity in affinities)
     vertical_spacing_significance = sum(max(0.0, -affinity.vertical_spacing_affinity) for affinity in affinities)
     if horizontal_lines_significance > vertical_spacing_significance:
-        # if the precense of horizontal lines seems to be a stronger differentiator than the vertical spacing between
+        # if the presence of horizontal lines seems to be a stronger differentiator than the vertical spacing between
         # lines, then we set the threshold at the level of the presence of such a horizontal line, making it less
         # likely that descriptions are split in the absence of such a line.
         threshold = -weights["line_weight"]

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -5,7 +5,8 @@ import logging
 import fastquadtree
 import pymupdf
 
-from extraction.features.stratigraphy.interval.interval import IntervalBlockPair, IntervalZone
+from extraction.features.stratigraphy.depth_description_alignment import match_lines_to_interval
+from extraction.features.stratigraphy.interval.interval import IntervalBlockPair
 from extraction.features.stratigraphy.layer.layer import (
     ExtractedBorehole,
     Layer,
@@ -15,6 +16,7 @@ from extraction.features.stratigraphy.layer.page_bounding_boxes import (
     MaterialDescriptionRectWithSidebar,
     PageBoundingBoxes,
 )
+from extraction.features.stratigraphy.no_sidebar_description_grouping import get_descriptions_blocks
 from extraction.features.stratigraphy.sidebar.classes.protocol_sidebar import ProtocolSidebar
 from extraction.features.stratigraphy.sidebar.classes.sidebar import (
     Sidebar,
@@ -35,7 +37,6 @@ from extraction.features.stratigraphy.sidebar.extractor.protocol_sidebar_extract
     ProtocolSidebarExtractor,
 )
 from extraction.features.stratigraphy.sidebar.extractor.spulprobe_sidebar_extractor import SpulprobeSidebarExtractor
-from extraction.utils.dynamic_matching import IntervalToLinesDP
 from swissgeol_doc_processing.geometry.geometry_dataclasses import Line
 from swissgeol_doc_processing.geometry.line_detection import find_diags_ending_in_zone
 from swissgeol_doc_processing.geometry.util import x_overlap, x_overlap_significant_smallest
@@ -44,10 +45,9 @@ from swissgeol_doc_processing.text.matching_params_analytics import MatchingPara
 from swissgeol_doc_processing.text.textblock import (
     MaterialDescription,
     MaterialDescriptionLine,
-    TextBlock,
 )
 from swissgeol_doc_processing.text.textline import TextLine
-from swissgeol_doc_processing.text.textline_affinity import Affinity, get_line_affinity
+from swissgeol_doc_processing.text.textline_affinity import get_line_affinity
 from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 from swissgeol_doc_processing.utils.strip_log_detection import StripLog
 from swissgeol_doc_processing.utils.table_detection import (
@@ -210,7 +210,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
         # For protocol sidebars, every depth entry must have a matched description.
         if (
             pair.sidebar
-            and pair.sidebar.kind == "protocol"
+            and isinstance(pair.sidebar, ProtocolSidebar)
             and not all(ibp.block.lines for ibp in interval_block_pairs)
         ):
             return None
@@ -236,7 +236,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
         borehole_layers = [layer for layer in borehole_layers if layer.description_nonempty()]
 
         min_layers = self.matching_params["min_num_layers"]
-        if pair.sidebar and pair.sidebar.kind == "protocol":
+        if pair.sidebar and isinstance(pair.sidebar, ProtocolSidebar):
             min_layers = self.matching_params.get("protocol_min_num_layers", min_layers)
         if len(borehole_layers) < min_layers:
             return None
@@ -264,11 +264,21 @@ class MaterialDescriptionRectWithSidebarExtractor:
             block_line_ratio=self.matching_params["block_line_ratio"],
             left_line_length_threshold=self.matching_params["left_line_length_threshold"],
         )
-        return (
-            match_lines_to_interval(pair.sidebar, description_lines, line_affinities, diagonals)
-            if pair.sidebar
-            else get_pairs_based_on_line_affinity(description_lines, line_affinities, self.matching_params)
-        )
+
+        if pair.sidebar:
+            return match_lines_to_interval(
+                pair.sidebar,
+                description_lines,
+                line_affinities,
+                diagonals,
+                self.matching_params["protocol_great_match_threshold"],
+            )
+        else:
+            no_sidebar_weights = self.matching_params["affinity_params"]["no_sidebar"]["weights"]
+            return [
+                IntervalBlockPair(depth_interval=None, block=text_block)
+                for text_block in get_descriptions_blocks(description_lines, line_affinities, no_sidebar_weights)
+            ]
 
     def _find_layer_identifier_sidebar_pairs(self) -> list[MaterialDescriptionRectWithSidebar]:
         layer_identifier_sidebars = LayerIdentifierSidebarExtractor.from_lines(self.lines)
@@ -748,210 +758,3 @@ class MaterialDescriptionRectWithSidebarExtractor:
         # below the actual scanned page) --> this mechanism could/should be optimized in the future!
         largest_table = max(self.table_structures, key=lambda t: t.bounding_rect.height)
         return (largest_table.bounding_rect.height / max(self.page_height, 1e-16)) >= min_table_height_ratio
-
-
-def extract_page(
-    text_lines: list[TextLine],
-    long_or_horizontal_lines: list[Line],
-    all_geometric_lines: list[Line],
-    table_structures: list[TableStructure],
-    strip_logs: list[StripLog],
-    language: str,
-    page_index: int,
-    page: pymupdf.Page,
-    line_detection_params: dict,
-    analytics: MatchingParamsAnalytics,
-    **matching_params: dict,
-) -> list[ExtractedBorehole]:
-    """Process a single PDF page and extract borehole information.
-
-    Acts as a simple interface to MaterialDescriptionRectWithSidebarExtractor without requiring direct class usage.
-
-    Args:
-        text_lines (list[TextLine]): All text lines on the page.
-        long_or_horizontal_lines (list[Line]): Geometric lines (only the significant ones and the horizontals).
-        all_geometric_lines (list[Line]): All geometric lines (including the shorter ones).
-        table_structures (list[TableStructure]): The identified table structures.
-        strip_logs (list[StripLog]): The identified strip log structures.
-        language (str): Language of the page (used in parsing).
-        page_index (int): The page index (0-indexed).
-        page (pymupdf.Page): The page object from the document.
-        line_detection_params (dict): The parameters for line detection.
-        analytics (MatchingParamsAnalytics): The analytics tracker for matching parameters.
-        **matching_params (dict): Additional parameters for the matching pipeline.
-
-    Returns:
-        list[ExtractedBorehole]: Extracted borehole layers from the page.
-    """
-    # Get page dimensions from the document
-    page_width = page.rect.width
-    page_height = page.rect.height
-
-    # Extract boreholes
-    return MaterialDescriptionRectWithSidebarExtractor(
-        text_lines,
-        long_or_horizontal_lines,
-        all_geometric_lines,
-        table_structures,
-        strip_logs,
-        language,
-        page_index + 1,
-        page_width,
-        page_height,
-        line_detection_params,
-        analytics,
-        **matching_params,
-    ).process_page()
-
-
-def extract_sidebar_information(
-    text_lines: list[TextLine],
-    long_or_horizontal_lines: list[Line],
-    all_geometric_lines: list[Line],
-    table_structures: list[TableStructure],
-    strip_logs: list[StripLog],
-    language: str,
-    page_index: int,
-    page: pymupdf.Page,
-    line_detection_params: dict,
-    analytics: MatchingParamsAnalytics,
-    **matching_params: dict,
-) -> SidebarQualityMetrics:
-    """Extract sidebar information with quality metrics.
-
-    This function serves as a simple interface to extract sidebar information
-    and quality metrics without requiring direct class usage.
-
-    Args:
-        text_lines (list[TextLine]): All text lines on the page.
-        long_or_horizontal_lines (list[Line]): Geometric lines (only the significant ones and the horizontals).
-        all_geometric_lines (list[Line]): All geometric lines (including the shorter ones).
-        table_structures (list[TableStructure]): The identified table structures.
-        strip_logs (list[StripLog]): The identified strip log structures.
-        language (str): Language of the page (used in parsing).
-        page_index (int): The page index (0-indexed).
-        page (pymupdf.Page): The page object from the document.
-        line_detection_params (dict): The parameters for line detection.
-        analytics (MatchingParamsAnalytics): The analytics tracker for matching parameters.
-        **matching_params (dict): Additional parameters for the matching pipeline.
-
-    Returns:
-        SidebarQualityMetrics: Quality metrics for all sidebars found on the page.
-    """
-    # Get page dimensions from the document
-    page_width = page.rect.width
-    page_height = page.rect.height
-
-    # Extract sidebar information
-    return MaterialDescriptionRectWithSidebarExtractor(
-        text_lines,
-        long_or_horizontal_lines,
-        all_geometric_lines,
-        table_structures,
-        strip_logs,
-        language,
-        page_index + 1,
-        page_width,
-        page_height,
-        line_detection_params,
-        analytics,
-        **matching_params,
-    ).extract_sidebars_with_quality_metrics()
-
-
-def match_with_dynamic_programming(
-    sidebar: Sidebar, description_lines: list[TextLine], affinities: list[Affinity]
-) -> list[tuple[IntervalZone, list[TextLine]]]:
-    """Apply dynamic programming to find the best matching between depth intervals and description lines."""
-    depth_interval_zones = sidebar.get_interval_zone()
-
-    # affinities can differ depending on sidebar type
-    affinity_scores = sidebar.dp_weighted_affinities(affinities)
-    dp = IntervalToLinesDP(depth_interval_zones, description_lines, affinity_scores)
-
-    _, mapping = dp.solve(sidebar.dp_scoring_fn)
-    return mapping
-
-
-def is_great_protocol_sidebar_mapping(mapping: list[tuple[IntervalZone, list[TextLine]]]) -> bool:
-    """Check for a great protocol sidebar fit: depths vertically aligned with the first description lines."""
-    total_relative_y_offset = 0
-    for interval, lines in mapping:
-        if interval.start is None or not lines:
-            return False
-        total_relative_y_offset += abs((interval.start.y0 - lines[0].rect.y0) / interval.start.height)
-
-    return total_relative_y_offset / len(mapping) < 0.1
-
-
-def match_lines_to_interval(
-    sidebar: Sidebar,
-    description_lines: list[TextLine],
-    affinities: list[Affinity],
-    diagonals: list[Line],
-) -> list[IntervalBlockPair]:
-    """Match the description lines to the pair intervals.
-
-    Args:
-        sidebar (Sidebar): The sidebar.
-        description_lines (list[TextLine]): The description lines.
-        affinities (list[Affinity]): the affinity between each line pair, previously computed.
-        diagonals (list[Line]): The diagonal lines linking text lines to intervals.
-
-    Returns:
-        list[IntervalBlockPair]: The matched depth intervals and text blocks.
-    """
-    # shift the entries of the sidebar using the diagonals, only relevant for AAboveBSidebars
-    if sidebar.kind == "a_above_b":
-        # If everything fits really well as a protocol sidebar, then we should treat it as one
-        protocol_sidebar = ProtocolSidebar(sidebar.entries)
-        mapping = match_with_dynamic_programming(protocol_sidebar, description_lines, affinities)
-        if is_great_protocol_sidebar_mapping(mapping):
-            return protocol_sidebar.post_processing(mapping)
-
-        # Adjust coordinates based on the presence of diagonal lines
-        sidebar.compute_entries_shift(diagonals)
-        sidebar.prevent_shifts_crossing()
-
-    mapping = match_with_dynamic_programming(sidebar, description_lines, affinities)
-    return sidebar.post_processing(mapping)
-
-
-def get_pairs_based_on_line_affinity(
-    description_lines: list[TextLine], affinities: list[Affinity], matching_params: dict
-) -> list[IntervalBlockPair]:
-    """Based on the line affinity, group the description lines into blocks.
-
-    The grouping is done based on the presence of geometric lines, the indentation of lines
-    and the vertical spacing between lines.
-
-    Args:
-        description_lines (list[TextLine]): The text lines to group into blocks.
-        affinities (list[Affinity]): the affinity between each line pair, previously computed.
-        matching_params (dict): the matching parameters.
-
-    Returns:
-        list[IntervalBlockPair]: A list of objects containing the description lines without any interval.
-    """
-    pairs = []
-    prev_block_idx = 0
-    weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
-
-    horizontal_lines_significance = sum(-affinity.long_lines_affinity for affinity in affinities)
-    vertical_spacing_significance = sum(max(0.0, -affinity.vertical_spacing_affinity) for affinity in affinities)
-    if horizontal_lines_significance > vertical_spacing_significance:
-        # if the presence of horizontal lines seems to be a stronger differentiator than the vertical spacing between
-        # lines, then we set the threshold at the level of the presence of such a horizontal line, making it less
-        # likely that descriptions are split in the absence of such a line.
-        threshold = -weights["line_weight"]
-    else:
-        threshold = -0.2 * weights["spacing_weight"]
-
-    for line_idx, affinity in enumerate(affinities):
-        # note: the affinity of the first line is always 0.0
-        if affinity.weighted_affinity(**weights) <= threshold:
-            pairs.append(IntervalBlockPair(None, TextBlock(description_lines[prev_block_idx:line_idx])))
-            prev_block_idx = line_idx
-
-    pairs.append(IntervalBlockPair(None, TextBlock(description_lines[prev_block_idx:])))
-    return pairs

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -910,7 +910,7 @@ def get_pairs_based_on_line_affinity(
     pairs = []
     prev_block_idx = 0
     weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
-    threshold = -0.3
+    threshold = -0.2
 
     for line_idx, affinity in enumerate(affinities):
         # note: the affinity of the first line is always 0.0

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -5,7 +5,7 @@ import logging
 import fastquadtree
 import pymupdf
 
-from extraction.features.stratigraphy.interval.interval import IntervalBlockPair
+from extraction.features.stratigraphy.interval.interval import IntervalBlockPair, IntervalZone
 from extraction.features.stratigraphy.layer.layer import (
     ExtractedBorehole,
     Layer,
@@ -15,6 +15,7 @@ from extraction.features.stratigraphy.layer.page_bounding_boxes import (
     MaterialDescriptionRectWithSidebar,
     PageBoundingBoxes,
 )
+from extraction.features.stratigraphy.sidebar.classes.protocol_sidebar import ProtocolSidebar
 from extraction.features.stratigraphy.sidebar.classes.sidebar import (
     Sidebar,
     SidebarNoise,
@@ -858,6 +859,31 @@ def extract_sidebar_information(
     ).extract_sidebars_with_quality_metrics()
 
 
+def match_with_dynamic_programming(
+    sidebar: Sidebar, description_lines: list[TextLine], affinities: list[Affinity]
+) -> list[tuple[IntervalZone, list[TextLine]]]:
+    """Apply dynamic programming to find the best matching between depth intervals and description lines."""
+    depth_interval_zones = sidebar.get_interval_zone()
+
+    # affinities can differ depending on sidebar type
+    affinity_scores = sidebar.dp_weighted_affinities(affinities)
+    dp = IntervalToLinesDP(depth_interval_zones, description_lines, affinity_scores)
+
+    _, mapping = dp.solve(sidebar.dp_scoring_fn)
+    return mapping
+
+
+def is_great_protocol_sidebar_mapping(mapping: list[tuple[IntervalZone, list[TextLine]]]) -> bool:
+    """Check for a great protocol sidebar fit: depths vertically aligned with the first description lines."""
+    total_relative_y_offset = 0
+    for interval, lines in mapping:
+        if interval.start is None or not lines:
+            return False
+        total_relative_y_offset += abs((interval.start.y0 - lines[0].rect.y0) / interval.start.height)
+
+    return total_relative_y_offset / len(mapping) < 0.1
+
+
 def match_lines_to_interval(
     sidebar: Sidebar,
     description_lines: list[TextLine],
@@ -877,17 +903,17 @@ def match_lines_to_interval(
     """
     # shift the entries of the sidebar using the diagonals, only relevant for AAboveBSidebars
     if sidebar.kind == "a_above_b":
+        # If everything fits really well as a protocol sidebar, then we should treat it as one
+        protocol_sidebar = ProtocolSidebar(sidebar.entries)
+        mapping = match_with_dynamic_programming(protocol_sidebar, description_lines, affinities)
+        if is_great_protocol_sidebar_mapping(mapping):
+            return protocol_sidebar.post_processing(mapping)
+
+        # Adjust coordinates based on the presence of diagonal lines
         sidebar.compute_entries_shift(diagonals)
         sidebar.prevent_shifts_crossing()
 
-    depth_interval_zones = sidebar.get_interval_zone()
-
-    # affinities can differ depending on sidebar type
-    affinity_scores = sidebar.dp_weighted_affinities(affinities)
-    dp = IntervalToLinesDP(depth_interval_zones, description_lines, affinity_scores)
-
-    _, mapping = dp.solve(sidebar.dp_scoring_fn)
-
+    mapping = match_with_dynamic_programming(sidebar, description_lines, affinities)
     return sidebar.post_processing(mapping)
 
 

--- a/src/extraction/features/stratigraphy/depth_description_alignment.py
+++ b/src/extraction/features/stratigraphy/depth_description_alignment.py
@@ -1,0 +1,87 @@
+"""Methods for finding the best correspondence between depth intervals and material description lines."""
+
+from extraction.features.stratigraphy.interval.interval import IntervalBlockPair, IntervalZone
+from extraction.features.stratigraphy.sidebar.classes.a_above_b_sidebar import AAboveBSidebar
+from extraction.features.stratigraphy.sidebar.classes.protocol_sidebar import ProtocolSidebar
+from extraction.features.stratigraphy.sidebar.classes.sidebar import Sidebar
+from extraction.utils.dynamic_matching import IntervalToLinesDP
+from swissgeol_doc_processing.geometry.geometry_dataclasses import Line
+from swissgeol_doc_processing.text.textline import TextLine
+from swissgeol_doc_processing.text.textline_affinity import Affinity
+
+
+def match_with_dynamic_programming(
+    sidebar: Sidebar, description_lines: list[TextLine], affinities: list[Affinity]
+) -> list[tuple[IntervalZone, list[TextLine]]]:
+    """Apply dynamic programming to find the best matching between depth intervals and description lines.
+
+    Args:
+        sidebar (Sidebar): the sidebar to match the descriptions with.
+        description_lines (list[TextLine]): The text lines that to create the material descriptions from.
+        affinities (list[Affinity]): the affinity between each line pair, previously computed.
+
+    Returns:
+        list[tuple[IntervalZone, list[TextLine]]]: The computed mapping between depth intervals and description lines.
+    """
+    depth_interval_zones = sidebar.get_interval_zone()
+
+    # affinities can differ depending on sidebar type
+    affinity_scores = sidebar.dp_weighted_affinities(affinities)
+    dp = IntervalToLinesDP(depth_interval_zones, description_lines, affinity_scores)
+
+    _, mapping = dp.solve(sidebar.dp_scoring_fn)
+    return mapping
+
+
+def is_great_protocol_sidebar_mapping(mapping: list[tuple[IntervalZone, list[TextLine]]], threshold: float) -> bool:
+    """Check for a great protocol sidebar fit: depths vertically aligned with the first description lines.
+
+    Args:
+        mapping (list[tuple[IntervalZone, list[TextLine]]]): a mapping between depth intervals and description lines.
+        threshold (float): a great fit must have an average vertical offset that is below this threshold.
+
+    Returns:
+        bool: True if the provided mapping matches the expected layout of a protocol sidebar very precisely
+    """
+    total_relative_y_offset = 0
+    for interval, lines in mapping:
+        if interval.start is None or not lines:
+            return False
+        total_relative_y_offset += abs((interval.start.y0 - lines[0].rect.y0) / interval.start.height)
+
+    return total_relative_y_offset / len(mapping) < threshold
+
+
+def match_lines_to_interval(
+    sidebar: Sidebar,
+    description_lines: list[TextLine],
+    affinities: list[Affinity],
+    diagonals: list[Line],
+    protocol_great_match_threshold: float,
+) -> list[IntervalBlockPair]:
+    """Match the description lines to the pair intervals.
+
+    Args:
+        sidebar (Sidebar): The sidebar.
+        description_lines (list[TextLine]): The description lines.
+        affinities (list[Affinity]): the affinity between each line pair, previously computed.
+        diagonals (list[Line]): The diagonal lines linking text lines to intervals.
+        protocol_great_match_threshold (float): Threshold for checking if a mapping is a great protocol sidebar fit.
+
+    Returns:
+        list[IntervalBlockPair]: The matched depth intervals and text blocks.
+    """
+    # shift the entries of the sidebar using the diagonals, only relevant for AAboveBSidebars
+    if isinstance(sidebar, AAboveBSidebar):
+        # If everything fits really well as a protocol sidebar, then we should treat it as one
+        protocol_sidebar = ProtocolSidebar(sidebar.unfiltered_entries)
+        mapping = match_with_dynamic_programming(protocol_sidebar, description_lines, affinities)
+        if is_great_protocol_sidebar_mapping(mapping, protocol_great_match_threshold):
+            return protocol_sidebar.post_processing(mapping)
+
+        # Adjust coordinates based on the presence of diagonal lines
+        sidebar.compute_entries_shift(diagonals)
+        sidebar.prevent_shifts_crossing()
+
+    mapping = match_with_dynamic_programming(sidebar, description_lines, affinities)
+    return sidebar.post_processing(mapping)

--- a/src/extraction/features/stratigraphy/no_sidebar_description_grouping.py
+++ b/src/extraction/features/stratigraphy/no_sidebar_description_grouping.py
@@ -1,0 +1,44 @@
+"""Methods for finding the best grouping of material description lines in the absence of a sidebar."""
+
+from swissgeol_doc_processing.text.textblock import TextBlock
+from swissgeol_doc_processing.text.textline import TextLine
+from swissgeol_doc_processing.text.textline_affinity import Affinity
+
+
+def get_descriptions_blocks(
+    description_lines: list[TextLine], affinities: list[Affinity], no_sidebar_weights: dict[str, float]
+) -> list[TextBlock]:
+    """Based on the line affinity, group the description lines into blocks.
+
+    The grouping is done based on the presence of geometric lines, the indentation of lines
+    and the vertical spacing between lines.
+
+    Args:
+        description_lines (list[TextLine]): The text lines to group into blocks.
+        affinities (list[Affinity]): the affinity between each line pair, previously computed.
+        no_sidebar_weights (dict): the matching parameters.
+
+    Returns:
+        list[TextBlock]: A list of description lines grouped into text blocks
+    """
+    blocks = []
+    prev_block_idx = 0
+
+    horizontal_lines_significance = sum(-affinity.long_lines_affinity for affinity in affinities)
+    vertical_spacing_significance = sum(max(0.0, -affinity.vertical_spacing_affinity) for affinity in affinities)
+    if horizontal_lines_significance > vertical_spacing_significance:
+        # if the presence of horizontal lines seems to be a stronger differentiator than the vertical spacing between
+        # lines, then we set the threshold at the level of the presence of such a horizontal line, making it less
+        # likely that descriptions are split in the absence of such a line.
+        threshold = -no_sidebar_weights["line_weight"]
+    else:
+        threshold = -0.2 * no_sidebar_weights["spacing_weight"]
+
+    for line_idx, affinity in enumerate(affinities):
+        # note: the affinity of the first line is always 0.0
+        if affinity.weighted_affinity(**no_sidebar_weights) <= threshold:
+            blocks.append(TextBlock(description_lines[prev_block_idx:line_idx]))
+            prev_block_idx = line_idx
+
+    blocks.append(TextBlock(description_lines[prev_block_idx:]))
+    return blocks

--- a/src/extraction/features/stratigraphy/sidebar/classes/a_above_b_sidebar.py
+++ b/src/extraction/features/stratigraphy/sidebar/classes/a_above_b_sidebar.py
@@ -34,6 +34,15 @@ class AAboveBSidebar(DepthColumEntrySidebar):
 
     kind: ClassVar[str] = "a_above_b"
 
+    # All entries before filtering based on correlation between depth value and vertical position on the page.
+    # Useful in case we want to check if the depth entries are more suitable as a ProtocolSidebar instead (where
+    # no constraints on correlation coefficient are applicable).
+    unfiltered_entries: list[DepthColumnEntry] = None
+
+    def __post_init__(self):
+        if self.unfiltered_entries is None:
+            self.unfiltered_entries = self.entries
+
     def pearson_correlation_coef(self) -> float:
         # We look at the lower y coordinate, because most often the baseline of the depth value text is aligned with
         # the line of the corresponding layer boundary.
@@ -55,7 +64,10 @@ class AAboveBSidebar(DepthColumEntrySidebar):
             return None
 
         new_columns = [
-            AAboveBSidebar([entry for index, entry in enumerate(self.entries) if index != remove_index])
+            AAboveBSidebar(
+                entries=[entry for index, entry in enumerate(self.entries) if index != remove_index],
+                unfiltered_entries=self.unfiltered_entries,
+            )
             for remove_index in range(len(self.entries))
         ]
         return min(new_columns, key=lambda column: column.linear_fit_loss())

--- a/src/extraction/features/stratigraphy/sidebar/classes/protocol_sidebar.py
+++ b/src/extraction/features/stratigraphy/sidebar/classes/protocol_sidebar.py
@@ -39,7 +39,7 @@ class ProtocolSidebar(DepthColumEntrySidebar):
         for i, interval in enumerate(intervals):
             if has_open_start:
                 # Shift zone boundaries by one entry
-                start_rect = self.entries[i].rect if i > 0 else None
+                start_rect = self.entries[i].rect
                 end_rect = self.entries[i + 1].rect if i + 1 < len(self.entries) else None
             else:
                 start_rect = interval.start.rect if interval.start else None

--- a/src/extraction/features/stratigraphy/sidebar/classes/sidebar.py
+++ b/src/extraction/features/stratigraphy/sidebar/classes/sidebar.py
@@ -128,16 +128,15 @@ class Sidebar(abc.ABC, Generic[EntryT]):
         return [IntervalBlockPair(zone.related_interval, TextBlock(lines)) for zone, lines in interval_lines_mapping]
 
 
+SidebarT = TypeVar("SidebarT", bound=Sidebar)
+
+
 @dataclass
-class SidebarNoise(Generic[EntryT]):
+class SidebarNoise(Generic[SidebarT]):
     """Wrapper class for Sidebar to calculate noise count using intersecting words."""
 
-    sidebar: Sidebar[EntryT]
+    sidebar: SidebarT
     noise_count: int
-
-    def __post_init__(self):
-        if not isinstance(self.sidebar, Sidebar):
-            raise TypeError(f"Expected a Sidebar instance, got {type(self.sidebar).__name__}")
 
     def __repr__(self):
         return f"SidebarNoise(sidebar={repr(self.sidebar)}, noise_count={self.noise_count})"

--- a/src/extraction/features/stratigraphy/sidebar/classes/sidebar.py
+++ b/src/extraction/features/stratigraphy/sidebar/classes/sidebar.py
@@ -87,6 +87,7 @@ class Sidebar(abc.ABC, Generic[EntryT]):
         """Scoring function for dynamic programming matching of description lines to interval zones."""
         pass
 
+    @staticmethod
     def default_score(interval_zone: IntervalZone, line: TextLine) -> float:
         """Returns a default score of 1.0 if the text line is within the zone, or 0.0 otherwise.
 

--- a/src/extraction/minimal_pipeline.py
+++ b/src/extraction/minimal_pipeline.py
@@ -165,6 +165,7 @@ def extract_page_features(
     language_config = material_description_config.get(language, {})
     material_keywords = language_config.get("including_expressions", [])
     split_threshold = matching_params.get("compound_split_threshold", 0.4)
+    page_number = page_index + 1
 
     valid_descriptions = []
     if material_keywords:
@@ -186,7 +187,7 @@ def extract_page_features(
         extraction_context.table_structures,
         extraction_context.strip_logs,
         language,
-        page_index + 1,
+        page_number,
         page.rect.width,
         page.rect.height,
         line_detection_params,
@@ -202,13 +203,13 @@ def extract_page_features(
             extraction_context.table_structures,
             extraction_context.strip_logs,
             language,
-            page_index,
+            page_number,
             page.rect.width,
             page.rect.height,
             line_detection_params,
             analytics=None,
             **matching_params,
-        )
+        ).process_page()
     else:
         extracted_boreholes = []
 

--- a/src/extraction/minimal_pipeline.py
+++ b/src/extraction/minimal_pipeline.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 import pymupdf
 from dotenv import load_dotenv
 
-from extraction.features.extract import extract_page, extract_sidebar_information
+from extraction.features.extract import MaterialDescriptionRectWithSidebarExtractor
 from extraction.features.metadata.borehole_name_extraction import extract_borehole_names
 from extraction.features.stratigraphy.sidebar.classes.sidebar import SidebarQualityMetrics
 from swissgeol_doc_processing.geometry.geometry_dataclasses import Line
@@ -178,22 +178,24 @@ def extract_page_features(
 
     number_of_valid_borehole_descriptions = len(valid_descriptions)
 
-    sidebar_information = extract_sidebar_information(
+    # Extract sidebar information
+    sidebar_information = MaterialDescriptionRectWithSidebarExtractor(
         extraction_context.text_lines,
         extraction_context.long_or_horizontal_lines,
         extraction_context.all_geometric_lines,
         extraction_context.table_structures,
         extraction_context.strip_logs,
         language,
-        page_index,
-        page,
+        page_index + 1,
+        page.rect.width,
+        page.rect.height,
         line_detection_params,
-        None,  # analytics parameter
+        analytics=None,
         **matching_params,
-    )
+    ).extract_sidebars_with_quality_metrics()
 
     if extract_boreholes:
-        extracted_boreholes = extract_page(
+        extracted_boreholes = MaterialDescriptionRectWithSidebarExtractor(
             extraction_context.text_lines,
             extraction_context.long_or_horizontal_lines,
             extraction_context.all_geometric_lines,
@@ -201,9 +203,10 @@ def extract_page_features(
             extraction_context.strip_logs,
             language,
             page_index,
-            page,
+            page.rect.width,
+            page.rect.height,
             line_detection_params,
-            None,  # analytics parameter
+            analytics=None,
             **matching_params,
         )
     else:

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -49,7 +49,7 @@ affinity_params:
     weights:
       line_weight: 1.0
       left_line_weight: 1.0
-      spacing_weight: 1.2
+      spacing_weight: 1.0
       right_end_weight: 1.0
       diagonal_weight: 1.0
       indentation_weight: 0.0
@@ -67,7 +67,7 @@ affinity_params:
       weights:
         line_weight: 1.0
         left_line_weight: 1.0
-        spacing_weight: 1.2
+        spacing_weight: 1.0
         right_end_weight: 1.0
         diagonal_weight: 1.0
         indentation_weight: 0.0

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -17,7 +17,6 @@ affinity_params:
       spacing_weight: 1.25
       right_end_weight: 1.0
       diagonal_weight: 1.25
-      gap_weight: 0.0
       indentation_weight: 0.6
   a_to_b:
     importance: 2.0
@@ -27,7 +26,6 @@ affinity_params:
       spacing_weight: 1.0
       right_end_weight: 1.0
       diagonal_weight: 0.0
-      gap_weight: 0.0
       indentation_weight: 0.0
   layer_identifier:
     importance: 0.66
@@ -37,7 +35,6 @@ affinity_params:
       spacing_weight: 1.0
       right_end_weight: 0.6
       diagonal_weight: 0.0
-      gap_weight: 0.0
       indentation_weight: 0.0
   spulprobe:
     importance: 2.0
@@ -47,16 +44,14 @@ affinity_params:
       spacing_weight: 1.0
       right_end_weight: 1.0
       diagonal_weight: 0.0
-      gap_weight: 0.0
       indentation_weight: 0.0
   no_sidebar:
     weights:
       line_weight: 1.0
       left_line_weight: 1.0
-      spacing_weight: 1.0
+      spacing_weight: 1.2
       right_end_weight: 1.0
       diagonal_weight: 1.0
-      gap_weight: 0.2
       indentation_weight: 0.0
   protocol:
       importance: 1.0
@@ -72,10 +67,9 @@ affinity_params:
       weights:
         line_weight: 1.0
         left_line_weight: 1.0
-        spacing_weight: 1.0
+        spacing_weight: 1.2
         right_end_weight: 1.0
         diagonal_weight: 1.0
-        gap_weight: 0.2
         indentation_weight: 0.0
 empty_interval_penalty: 0.2
 

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -7,6 +7,7 @@ left_line_length_threshold: 7
 duplicate_layer_threshold: 0.95
 min_num_layers: 2
 protocol_min_num_layers: 1
+protocol_great_match_threshold: 0.1
 fallback_min_table_height_ratio: 0.85
 affinity_params:
   a_above_b:

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -50,7 +50,7 @@ affinity_params:
       line_weight: 1.0
       left_line_weight: 1.0
       spacing_weight: 1.0
-      right_end_weight: 1.0
+      right_end_weight: 0.5
       diagonal_weight: 1.0
       indentation_weight: 0.0
   protocol:

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -55,23 +55,23 @@ affinity_params:
       diagonal_weight: 1.0
       indentation_weight: 0.0
   protocol:
-      importance: 1.0
-      min_entries: 2
-      header_keywords:
-        - Tiefe
-        - Tiefe bis
-        - Tiefe bis m
-        - bis
-        - Depth
-      max_header_gap: 40
-      # those parameters were chosen randomly but they behave well so far.
-      weights:
-        line_weight: 1.0
-        left_line_weight: 1.0
-        spacing_weight: 1.0
-        right_end_weight: 1.0
-        diagonal_weight: 1.0
-        indentation_weight: 0.0
+    importance: 1.0
+    min_entries: 2
+    header_keywords:
+      - Tiefe
+      - Tiefe bis
+      - Tiefe bis m
+      - bis
+      - Depth
+    max_header_gap: 40
+    # those parameters were chosen randomly but they behave well so far.
+    weights:
+      line_weight: 1.0
+      left_line_weight: 1.0
+      spacing_weight: 1.0
+      right_end_weight: 1.0
+      diagonal_weight: 1.0
+      indentation_weight: 0.0
 empty_interval_penalty: 0.2
 
 material_description_column_width: 0.08

--- a/src/swissgeol_doc_processing/text/textline_affinity.py
+++ b/src/swissgeol_doc_processing/text/textline_affinity.py
@@ -96,7 +96,7 @@ class LineAffinityCalculator:
         geometric_lines: list[Line],
         line_detection_params: dict,
         description_lines: list[TextLine],
-        diagonals: list[TextLine],
+        diagonals: list[Line],
     ):
         """Initialize the LineAffinityCalculator.
 

--- a/src/swissgeol_doc_processing/text/textline_affinity.py
+++ b/src/swissgeol_doc_processing/text/textline_affinity.py
@@ -13,7 +13,7 @@ from swissgeol_doc_processing.text.textline import TextLine
 
 @dataclass
 class Affinity:
-    """class holding the 4 types of affinities.
+    """Class holding the 6 types of affinities.
 
     Each affinity is a float between -1.0 and 1.0 and measures how likely two lines belong together.
 
@@ -21,6 +21,8 @@ class Affinity:
     lines_on_the_left_affinity: affinity based on the presence of lines cutting the left side of the text lines.
     vertical_spacing_affinity: affinity based on the vertical spacing between the two text lines.
     right_end_affinity: affinity based on the alignment of the right end of the two text lines.
+    diagonal_line_affinity: affinity based on the presence of diagonal lines inbetween the two text lines.
+    indentation_affinity: affinity based on the indentation difference between the two text lines.
     """
 
     long_lines_affinity: float

--- a/src/swissgeol_doc_processing/text/textline_affinity.py
+++ b/src/swissgeol_doc_processing/text/textline_affinity.py
@@ -28,13 +28,12 @@ class Affinity:
     vertical_spacing_affinity: float
     right_end_affinity: float
     diagonal_line_affinity: float
-    gap_with_previous_affinity: float
     indentation_affinity: float
 
     @classmethod
     def get_zero_affinity(cls) -> Affinity:
         """Get an affinity with all zero values."""
-        return cls(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        return cls(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
     def weighted_affinity(
         self,
@@ -43,7 +42,6 @@ class Affinity:
         spacing_weight: float,
         right_end_weight: float,
         diagonal_weight: float,
-        gap_weight: float,
         indentation_weight: float,
     ) -> float:
         """Compute the weighted affinity using the provided weights."""
@@ -53,13 +51,12 @@ class Affinity:
             + spacing_weight * self.vertical_spacing_affinity
             + right_end_weight * self.right_end_affinity
             + diagonal_weight * self.diagonal_line_affinity
-            + gap_weight * self.gap_with_previous_affinity
             + indentation_weight * self.indentation_affinity
         )
 
     def total_affinity(self) -> float:
         """Compute the total affinity with equal weights."""
-        return self.weighted_affinity(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+        return self.weighted_affinity(1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
 
     def weighted_mean_affinity(
         self,
@@ -68,7 +65,6 @@ class Affinity:
         spacing_weight: float,
         right_end_weight: float,
         diagonal_weight: float,
-        gap_weight: float,
         indentation_weight: float,
     ) -> float:
         """Compute the weighted affinity using the provided weights."""
@@ -78,14 +74,13 @@ class Affinity:
             spacing_weight,
             right_end_weight,
             diagonal_weight,
-            gap_weight,
             indentation_weight,
         ]
         return self.weighted_affinity(*weights) / sum(weights)
 
     def mean_affinity(self) -> float:
         """Compute the mean affinity."""
-        return self.weighted_mean_affinity(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+        return self.weighted_mean_affinity(1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
 
 
 class LineAffinityCalculator:
@@ -141,12 +136,6 @@ class LineAffinityCalculator:
 
         # diagonals separator
         self.diagonals = diagonals
-
-        # overlap affinity
-        self.overlapping_distances = [None] + [
-            line.rect.y0 - prev_line.rect.y1
-            for prev_line, line in zip(description_lines, description_lines[1:], strict=False)
-        ]
 
     def _is_spanning_description(self, line: Line) -> bool:
         """Check if a line spans the material description rectangle.
@@ -246,30 +235,6 @@ class LineAffinityCalculator:
         h_reference = current_rect.height if self.at_least_one_overlap else self.spacing_threshold
         score = max(-1.0, 1.0 - (current_rect.y1 - previous_rect.y1) / h_reference)  # not capped at 0
         return score
-
-    def compute_gap_affinity(self, previous_line: TextLine, prev_line_idx: int) -> float:
-        """Check the gap between the two lines.
-
-        If the gap is significantly larger than the previous gap, it is unlikely that the current line is the
-        continuation of the description.
-
-        Args:
-            previous_line (TextLine): The previous line.
-            prev_line_idx (int): The index of the previous line, to acess the gaps lookup.
-
-        Returns:
-            float: The affinity: 0.0 if lines are not compatible, 1.0 otherwise.
-        """
-        previous_gap = self.overlapping_distances[prev_line_idx]
-        current_gap = self.overlapping_distances[prev_line_idx + 1]
-        previous_line_height = previous_line.rect.height  # involved in both gaps
-        if current_gap > 0.6 * previous_line_height:
-            # gap is too big
-            return 0.0
-        if previous_gap is None or current_gap <= previous_gap + previous_line_height * 0.2:
-            # current gap is roughly the same as the previous, or smaller
-            return 1.0
-        return 0.0
 
     def compute_right_end_affinity(self, previous_line: TextLine, current_line: TextLine) -> float:
         """Check the alignment of the right end of the lines.
@@ -378,7 +343,7 @@ def get_line_affinity(
         diagonals,
     )
     affinities = [Affinity.get_zero_affinity()]  # first line has no previous
-    for prev_line_idx, (previous_line, line) in enumerate(zip(description_lines, description_lines[1:], strict=False)):
+    for previous_line, line in zip(description_lines, description_lines[1:], strict=False):
         affinities.append(
             Affinity(
                 calculator.compute_long_lines_affinity(previous_line, line),
@@ -386,7 +351,6 @@ def get_line_affinity(
                 calculator.compute_vertical_spacing_affinity(previous_line, line),
                 calculator.compute_right_end_affinity(previous_line, line),
                 calculator.compute_diagonal_affinity(previous_line, line),
-                calculator.compute_gap_affinity(previous_line, prev_line_idx),
                 calculator.compute_indentation_affinity(previous_line, line),
             )
         )

--- a/tests/test_line_affinity.py
+++ b/tests/test_line_affinity.py
@@ -35,7 +35,7 @@ matching_params = read_params("matching_params.yml")
         pytest.param([], [], 2, id="no_geom_lines"),
         pytest.param(geometric_lines_cut, [], 3, id="span_line"),
         pytest.param(geometric_lines_lefthandside, [], 3, id="left_line"),
-        pytest.param([], diagonal_line, 3, id="diag_line"),
+        pytest.param([], diagonal_line, 2, id="diag_line"),
     ],
 )
 def test_get_description_blocks(geometrical_lines, diagonals, expected_num_block):
@@ -45,7 +45,7 @@ def test_get_description_blocks(geometrical_lines, diagonals, expected_num_block
         1. no geometrical lines: expect 2 blocks (first two lines together as they slightly overlap, third separate)
         2. span line cutting through first two lines: expect 3 blocks (all separate)
         3. left-hand side line cutting through first two lines: expect 3 blocks (all separate)
-        4. diagonal line cutting through first two lines: expect 3 blocks (all separate)
+        4. diagonal line cutting through first two lines: expect 2 blocks
     """
     line_affinities = get_line_affinity(
         description_lines,

--- a/tests/test_line_affinity.py
+++ b/tests/test_line_affinity.py
@@ -45,7 +45,7 @@ def test_get_description_blocks(geometrical_lines, diagonals, expected_num_block
         1. no geometrical lines: expect 2 blocks (first two lines together as they slightly overlap, third separate)
         2. span line cutting through first two lines: expect 3 blocks (all separate)
         3. left-hand side line cutting through first two lines: expect 3 blocks (all separate)
-        4. diagonal line cutting through first two lines: expect 2 blocks
+        4. diagonal line cutting through first two lines: expect 3 blocks (all separate)
     """
     line_affinities = get_line_affinity(
         description_lines,

--- a/tests/test_line_affinity.py
+++ b/tests/test_line_affinity.py
@@ -3,7 +3,7 @@
 import pymupdf
 import pytest
 
-from extraction.features.extract import get_pairs_based_on_line_affinity
+from extraction.features.stratigraphy.no_sidebar_description_grouping import get_descriptions_blocks
 from swissgeol_doc_processing.geometry.geometry_dataclasses import Line, Point
 from swissgeol_doc_processing.text.textline import TextLine, TextWord
 from swissgeol_doc_processing.text.textline_affinity import get_line_affinity
@@ -56,6 +56,7 @@ def test_get_description_blocks(geometrical_lines, diagonals, expected_num_block
         block_line_ratio,
         left_line_length_threshold,
     )
-    pairs = get_pairs_based_on_line_affinity(description_lines, line_affinities, matching_params)
+    no_sidebar_weights = matching_params["affinity_params"]["no_sidebar"]["weights"]
+    blocks = get_descriptions_blocks(description_lines, line_affinities, no_sidebar_weights)
 
-    assert len(pairs) == expected_num_block
+    assert len(blocks) == expected_num_block

--- a/tests/test_line_affinity.py
+++ b/tests/test_line_affinity.py
@@ -35,7 +35,7 @@ matching_params = read_params("matching_params.yml")
         pytest.param([], [], 2, id="no_geom_lines"),
         pytest.param(geometric_lines_cut, [], 3, id="span_line"),
         pytest.param(geometric_lines_lefthandside, [], 3, id="left_line"),
-        pytest.param([], diagonal_line, 2, id="diag_line"),
+        pytest.param([], diagonal_line, 3, id="diag_line"),
     ],
 )
 def test_get_description_blocks(geometrical_lines, diagonals, expected_num_block):


### PR DESCRIPTION
Resolves #442

Builds on top of #460, and is inspired by the discussions with @AgathaSchmidt in the context of #456.

Fixes the two examples from the issue, as well as significantly improves A11358, leading to a 0.3% improvement in Layer F1 score for GeoQuat validation. There are no other changes on Zurich or GeoQuat validation (compared to #460).

@AgathaSchmidt what do you think of this approach? Before merging, I would still improve a couple of things, but maybe you can first let me know what you think of this method in general.

To be improved:
- Parameter descriptions in the docstrings of the new methods.
- The threshold value `0.1` should probably be configurable.
- The interval zones for the ProtocolSidebar are defined in a rather counterintuitive way. I had to use `start` whereas I intuitively thought that I would have to use `end`. Maybe this could be simplified as well?

3184_KB_41_37_Kreuzlingen_Weinberg:
<img width="913" height="581" alt="image" src="https://github.com/user-attachments/assets/5ffd8ca2-a0ec-43ef-8828-011fd031913b" />

3266_RKB_41_131_Kreuzlingen_Weinberg:
<img width="908" height="582" alt="image" src="https://github.com/user-attachments/assets/9f8f89dd-7bf2-42c7-aefe-9687de77419e" />

A11358 new:
<img width="659" height="235" alt="image" src="https://github.com/user-attachments/assets/cdc5efbe-d36e-46a0-8d16-9b1e76452c68" />

A11358 old:
<img width="651" height="248" alt="image" src="https://github.com/user-attachments/assets/3ab8851c-6e2f-4292-9250-528cdc3c0f96" />


