### PR TITLE
Incorrect page combination

### DIFF
--- a/src/extraction/features/stratigraphy/sidebar/classes/a_above_b_sidebar.py
+++ b/src/extraction/features/stratigraphy/sidebar/classes/a_above_b_sidebar.py
@@ -101,9 +101,8 @@ class AAboveBSidebar(DepthColumEntrySidebar):
             median_value = np.median(np.array([entry.value for entry in self.entries]))
 
             for i, entry in enumerate(self.entries):
-                if entry.value.is_integer() and entry.value > median_value:
+                if entry.value.is_integer() and entry.value > median_value and not entry.has_decimal_point:
                     candidate_values = [entry.value / 100, entry.value / 10]
-
                     for new_value in candidate_values:
                         new_score = score(new_sidebar(i, new_value))
                         if new_score > best_score:

--- a/tests/test_aabovebsidebar.py
+++ b/tests/test_aabovebsidebar.py
@@ -82,12 +82,20 @@ def test_aabovebsidebar_ascendingcount(input, expected):
 def test_aabovebsidebar_fixocrmistakes():  # noqa: D103
     """Test the fix_ocr_mistakes method of the AAboveBSidebar class."""
 
-    def run_test(in_values, out_values):
+    def run_test(in_values: list[float], out_values: list[float], has_decimal_point: list[bool] = None) -> None:
+        if not has_decimal_point:
+            has_decimal_point = [False] * len(in_values)
+
         sidebar = AAboveBSidebar(
             [
                 # TODO: actually specify the y-coordinate instead of using the index as a proxy
-                DepthColumnEntry(rect=pymupdf.Rect(0, index, 0, index), value=value, page_number=0)
-                for index, value in enumerate(in_values)
+                DepthColumnEntry(
+                    rect=pymupdf.Rect(0, index, 0, index),
+                    has_decimal_point=decimal,
+                    value=value,
+                    page_number=0,
+                )
+                for index, (value, decimal) in enumerate(zip(in_values, has_decimal_point, strict=True))
             ]
         )
         result = [entry.value for entry in sidebar.fix_ocr_mistakes().entries]
@@ -125,6 +133,11 @@ def test_aabovebsidebar_fixocrmistakes():  # noqa: D103
 
     # edge case
     run_test([], [])
+
+    # Test decimal point for 383_Schlatt_Gishalden_KB1 (if decimal detected, not rescaled)
+    run_test([1.0, 2.0, 30.0, 4.0], [1.0, 2.0, 3.0, 4.0], has_decimal_point=[False, False, False, False])
+    run_test([1.0, 2.0, 30.0, 4.0], [1.0, 2.0, 3.0, 4.0], has_decimal_point=[True, True, False, True])
+    run_test([1.0, 2.0, 30.0, 4.0], [1.0, 2.0, 30.0, 4.0], has_decimal_point=[False, False, True, False])
 
 
 def test_generate_alternatives():


### PR DESCRIPTION
Close #453 

# Description
The detection was failing because the value `10.0` was converted to `0.1` to align with the rest of the values in the array. To solve this issue we use the approach proposed in the issue comment:
* Since `10.0` already has a decimal point present, we could disallow the "fix OCR mistakes" method for this value (and others that have an explicit decimal point in the OCR already).

# Results
This simple implementation solves the issue for file `TH:383`, but changes the results of `GQ:A57.` Note that the overall metrics stay the same on Geoquat because the prediction on `GQ:A57` was already failing due to the graduated sidebar.

<img width="524" height="764" alt="Screenshot 2026-04-29 at 13 01 19" src="https://github.com/user-attachments/assets/d60511c4-5538-47db-8aa7-473776a540ef" />
