### PR TITLE
Fix/tag release candidate version

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -42,18 +42,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull, retag and push release-candidate
-        run: |
-          docker pull ${{ env.IMAGE }}:${{ env.BASE }}
-          docker tag ${{ env.IMAGE }}:${{ env.BASE }} ${{ env.IMAGE }}:release-candidate
-          docker push ${{ env.IMAGE }}:release-candidate
-
       - name: Extract and save version from image labels
         id: version
         run: |
+          docker pull ${{ env.IMAGE }}:${{ env.BASE }}
           VERSION=$(docker inspect --format '{{index .Config.Labels "org.opencontainers.image.version"}}' ${{ env.IMAGE }}:${{ env.BASE }} | sed 's/^v//' | sed 's/-dev[0-9]*//')
           if [ -z "$VERSION" ]; then echo "ERROR: Could not extract version from image labels" && exit 1; fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Pull, retag and push release-candidate
+        run: |
+          docker tag ${{ env.IMAGE }}:${{ env.BASE }} ${{ env.IMAGE }}:release-candidate
+          docker push ${{ env.IMAGE }}:release-candidate
+          docker tag ${{ env.IMAGE }}:${{ env.BASE }} ${{ env.IMAGE }}:v${{ steps.version.outputs.version }}-rc
+          docker push ${{ env.IMAGE }}:v${{ steps.version.outputs.version }}-rc
 
   tag_rc_commit:
     name: Tag release-candidate commit
@@ -79,7 +81,7 @@ jobs:
       - name: Tag clean version
         uses: ./.github/actions/tag-commit
         with:
-          TAG_NAME: ${{ needs.tag-release-candidate.outputs.version }}
+          TAG_NAME: v${{ needs.tag-release-candidate.outputs.version }}
           SHA: ${{ steps.get_base_commit.outputs.sha }}
 
   publish-package:

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -44,11 +44,13 @@ feature/issue-001/name    →    develop    →    main    →    GitHub Release
 │           pre-release.yml                                           |
 |  · Retag (no rebuild)                                               │
 │      :edge → :release-candidate                                     │
+|      :edge → :v1.0.0-rc                                             |
 │  · Create GitHub pre-release                                        │
 │  · Build and publish Python package                                 │
 │      swissgeol_boreholes_dataextraction-1.0.0-py3-none-any.whl      │
 │  · Create git tag                                                   │
 │      1.0.0 (no v — signals full release to versioning)              │
+|      release-candidate                                              |
 └────────────────────┬────────────────────────────────────────────────┘
                      │ GitHub Release published (manual)
                      ▼
@@ -99,6 +101,7 @@ These run automatically on every pull request to `develop` or `main`.
 | `:edge` | Latest `develop` build | DEV |
 | `:v1.0.0-dev1` | Specific dev build | DEV |
 | `:release-candidate` | Latest `main` promotion | INT / Staging |
+| `:v1.0.0-rc` | 	Specific pre-release build | INT / Staging |
 | `:latest` | Latest stable release | PROD |
 | `:v1` | Latest release in major version 1 | PROD |
 | `:v1.0` | Latest release in minor version 1.0 | PROD |


### PR DESCRIPTION
This PR updates the pre-release workflow to improve Docker image tagging and versioning. The main changes ensure that pre-release images are tagged with both the generic `release-candidate` tag and a version-specific `vX.Y.Z-rc` tag. CI/CD documentation is update to reflect these changes.

**CI/CD Workflow Improvements:**

* The pre-release workflow now tags and pushes Docker images with both `release-candidate` and version-specific `vX.Y.Z-rc` tags, ensuring clearer traceability of pre-release builds.
* The tag for the clean version is now prefixed with `v` to maintain consistency with semantic versioning.