### PR TITLE
Classification cementation (BERT)

### DIFF
--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -8,7 +8,7 @@
 | `accessory_components`             | x        |         152,2083 (47) |  Multi |    0.842 |    0.972 |
 | `alteration_degree_consolidated`   |          |             2,716 (8) | Single |    0.392 |    0.782 |
 | `alteration_degree_unconsolidated` |          |                41 (8) | Single |        - |        - |
-| `cementation`                      |          |                78 (7) | Single |        - |        - |
+| `cementation`                      | x        |           119,404 (7) | Single |    0.851 |    0.959|
 | `color_consolidated`*              |          |           16,143 (91) | Single |    0.487 |    0.752 |
 | `color_unconsolidated`*            |          |           20,121 (91) | Single |    0.502 |    0.803 |
 | `debris`                           |          |           70,084, (7) |  Multi |    0.797 |    0.983 |

--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -4,22 +4,22 @@
 ## Overview (BERT Only)
 
 
-| Dataset                            | Support (num classes)      | Target | F1-macro | F1-micro |
-|------------------------------------|-----------------------     |--------|----------|----------|
-| `accessory_components`             |               75 (66)      |  Multi |        - |        - |
-| `alteration_degree_consolidated`   |             2,716 (8)      | Single |        - |        - |
-| `alteration_degree_unconsolidated` |                41 (8)      | Single |        - |        - |
+| Dataset                            | Support (num classes) | Target | F1-macro | F1-micro |
+|------------------------------------|-----------------------|--------|----------|----------|
+| `accessory_components`             |               75 (66) |  Multi |        - |        - |
+| `alteration_degree_consolidated`   |             2,716 (8) | Single |    0.392 |    0.782 |
+| `alteration_degree_unconsolidated` |                41 (8) | Single |        - |        - |
 | `cementation`                      | 78 (7) / enhanced: 119,404 | Single |    0.851 |    0.959 |
-| `color_consolidated`*              |           16,143 (91)      | Single |    0.487 |    0.752 |
-| `color_unconsolidated`*            |           20,121 (91)      | Single |    0.502 |    0.803 |
-| `debris`                           |           70,084, (7)      |  Multi |        - |        - |
-| `en_main`                          |           89,842 (34)      | Single |    0.859 |    0.905 |
-| `grain_angularity`                 |            70,377 (8)      |  Multi |        - |        - |
-| `grain_shape`                      |            70,087 (5)      |  Multi |        - |        - |
-| `lithology`                        |           45,323 (61)      | Single |    0.848 |    0.942 |
-| `mineral_components`               |              63 (111)      |  Multi |        - |        - |
-| `organic_components`               |           70,102 (11)      |  Multi |        - |        - |
-| `uscs`                             |            9,917 (38)      | Single |    0.329 |    0.602 |
+| `color_consolidated`*              |           16,143 (91) | Single |    0.487 |    0.752 |
+| `color_unconsolidated`*            |           20,121 (91) | Single |    0.502 |    0.803 |
+| `debris`                           |           70,084, (7) |  Multi |    0.797 |    0.983 |
+| `en_main`                          |           89,842 (34) | Single |    0.859 |    0.905 |
+| `grain_angularity`                 |            70,377 (8) |  Multi |    0.831 |    0.974 |
+| `grain_shape`                      |            70,087 (5) |  Multi |    0.560 |    0.998 |
+| `lithology`                        |           45,323 (61) | Single |    0.848 |    0.942 |
+| `mineral_components`               |              63 (111) |  Multi |        - |        - |
+| `organic_components`               |           70,102 (11) |  Multi |    0.839 |    0.983 |
+| `uscs`                             |            9,917 (38) | Single |    0.329 |    0.602 |
 
 * Model jointly trained, same for both tasks.
 

--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -3,23 +3,22 @@
 
 ## Overview (BERT Only)
 
-
-| Dataset                            | Support (num classes) | Target | F1-macro | F1-micro |
-|------------------------------------|-----------------------|--------|----------|----------|
-| `accessory_components`             |               75 (66) |  Multi |        - |        - |
-| `alteration_degree_consolidated`   |             2,716 (8) | Single |    0.392 |    0.782 |
-| `alteration_degree_unconsolidated` |                41 (8) | Single |        - |        - |
-| `cementation`                      | 78 (7) / enhanced: 119,404 (7)| Single |    0.851 |    0.959 |
-| `color_consolidated`*              |           16,143 (91) | Single |    0.487 |    0.752 |
-| `color_unconsolidated`*            |           20,121 (91) | Single |    0.502 |    0.803 |
-| `debris`                           |           70,084, (7) |  Multi |    0.797 |    0.983 |
-| `en_main`                          |           89,842 (34) | Single |    0.859 |    0.905 |
-| `grain_angularity`                 |            70,377 (8) |  Multi |    0.831 |    0.974 |
-| `grain_shape`                      |            70,087 (5) |  Multi |    0.560 |    0.998 |
-| `lithology`                        |           45,323 (61) | Single |    0.848 |    0.942 |
-| `mineral_components`               |              63 (111) |  Multi |        - |        - |
-| `organic_components`               |           70,102 (11) |  Multi |    0.839 |    0.983 |
-| `uscs`                             |            9,917 (38) | Single |    0.329 |    0.602 |
+| Dataset                            | Enhanced | Support (num classes) | Target | F1-macro | F1-micro |
+|------------------------------------|----------|-----------------------|--------|----------|----------|
+| `accessory_components`             | x        |         152,2083 (47) |  Multi |    0.842 |    0.972 |
+| `alteration_degree_consolidated`   |          |             2,716 (8) | Single |    0.392 |    0.782 |
+| `alteration_degree_unconsolidated` |          |                41 (8) | Single |        - |        - |
+| `cementation`                      | x        |           119,404 (7) | Single |    0.851 |    0.959 |
+| `color_consolidated`*              |          |           16,143 (91) | Single |    0.487 |    0.752 |
+| `color_unconsolidated`*            |          |           20,121 (91) | Single |    0.502 |    0.803 |
+| `debris`                           |          |           70,084, (7) |  Multi |    0.797 |    0.983 |
+| `en_main`                          |          |           89,842 (34) | Single |    0.859 |    0.905 |
+| `grain_angularity`                 |          |            70,377 (8) |  Multi |    0.831 |    0.974 |
+| `grain_shape`                      |          |            70,087 (5) |  Multi |    0.560 |    0.998 |
+| `lithology`                        |          |           45,323 (61) | Single |    0.848 |    0.942 |
+| `mineral_components`               |          |              63 (111) |  Multi |        - |        - |
+| `organic_components`               |          |           70,102 (11) |  Multi |    0.839 |    0.983 |
+| `uscs`                             |          |            9,917 (38) | Single |    0.329 |    0.602 |
 
 * Model jointly trained, same for both tasks.
 
@@ -29,6 +28,17 @@
 | Test set  | Train set    | Bedrock F1-macro | Bedrock F1-micro | BERT F1-macro | BERT F1-micro |
 |-----------|--------------|------------------|------------------|---------------|---------------|
 | Geoquat-C | Consolidated | 0.179            | 0.536            | 0.392         | 0.782         |
+
+
+## Cementation - Enhanced
+
+| Test set  | Bedrock F1-macro | Bedrock F1-micro | BERT F1-macro | BERT F1-micro |
+|-----------|------------------|------------------|---------------|---------------|
+| Deepwells | -                | -                | 0.774         | 0.891         |
+| Geoquat   | -                | -                | 0.785         | 0.956         |
+| Nagra     | -                | -                | 0.982         | 0.997         |
+| Zurich    | -                | -                | 0.725         | 0.949         |
+| Overall   | -                | -                | 0.851         | 0.959         |
 
 
 ## Color (Consolidated + Unconsolidated)

--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -9,7 +9,7 @@
 | `accessory_components`             |               75 (66) |  Multi |        - |        - |
 | `alteration_degree_consolidated`   |             2,716 (8) | Single |    0.392 |    0.782 |
 | `alteration_degree_unconsolidated` |                41 (8) | Single |        - |        - |
-| `cementation`                      | 78 (7) / enhanced: 119,404 | Single |    0.851 |    0.959 |
+| `cementation`                      | 78 (7) / enhanced: 119,404 (7)| Single |    0.851 |    0.959 |
 | `color_consolidated`*              |           16,143 (91) | Single |    0.487 |    0.752 |
 | `color_unconsolidated`*            |           20,121 (91) | Single |    0.502 |    0.803 |
 | `debris`                           |           70,084, (7) |  Multi |    0.797 |    0.983 |

--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -4,22 +4,22 @@
 ## Overview (BERT Only)
 
 
-| Dataset                            | Support (num classes) | Target | F1-macro | F1-micro |
-|------------------------------------|-----------------------|--------|----------|----------|
-| `accessory_components`             |               75 (66) |  Multi |        - |        - |
-| `alteration_degree_consolidated`   |             2,716 (8) | Single |        - |        - |
-| `alteration_degree_unconsolidated` |                41 (8) | Single |        - |        - |
-| `cementation`                      |                78 (7) | Single |        - |        - |
-| `color_consolidated`*              |           16,143 (91) | Single |    0.487 |    0.752 |
-| `color_unconsolidated`*            |           20,121 (91) | Single |    0.502 |    0.803 |
-| `debris`                           |           70,084, (7) |  Multi |        - |        - |
-| `en_main`                          |           89,842 (34) | Single |    0.859 |    0.905 |
-| `grain_angularity`                 |            70,377 (8) |  Multi |        - |        - |
-| `grain_shape`                      |            70,087 (5) |  Multi |        - |        - |
-| `lithology`                        |           45,323 (61) | Single |    0.848 |    0.942 |
-| `mineral_components`               |              63 (111) |  Multi |        - |        - |
-| `organic_components`               |           70,102 (11) |  Multi |        - |        - |
-| `uscs`                             |            9,917 (38) | Single |    0.329 |    0.602 |
+| Dataset                            | Support (num classes)      | Target | F1-macro | F1-micro |
+|------------------------------------|-----------------------     |--------|----------|----------|
+| `accessory_components`             |               75 (66)      |  Multi |        - |        - |
+| `alteration_degree_consolidated`   |             2,716 (8)      | Single |        - |        - |
+| `alteration_degree_unconsolidated` |                41 (8)      | Single |        - |        - |
+| `cementation`                      | 78 (7) / enhanced: 119,404 | Single |    0.851 |    0.959 |
+| `color_consolidated`*              |           16,143 (91)      | Single |    0.487 |    0.752 |
+| `color_unconsolidated`*            |           20,121 (91)      | Single |    0.502 |    0.803 |
+| `debris`                           |           70,084, (7)      |  Multi |        - |        - |
+| `en_main`                          |           89,842 (34)      | Single |    0.859 |    0.905 |
+| `grain_angularity`                 |            70,377 (8)      |  Multi |        - |        - |
+| `grain_shape`                      |            70,087 (5)      |  Multi |        - |        - |
+| `lithology`                        |           45,323 (61)      | Single |    0.848 |    0.942 |
+| `mineral_components`               |              63 (111)      |  Multi |        - |        - |
+| `organic_components`               |           70,102 (11)      |  Multi |        - |        - |
+| `uscs`                             |            9,917 (38)      | Single |    0.329 |    0.602 |
 
 * Model jointly trained, same for both tasks.
 

--- a/src/scripts/enhance_groundtruth.py
+++ b/src/scripts/enhance_groundtruth.py
@@ -68,24 +68,21 @@ def _apply_predictions(ground_truth: GroundTruth, predictions_path: Path) -> int
 
     updated = 0
     for entry in predictions:
-        prediction = entry.get("prediction_class") or entry.get("prediction_classes")
+        prediction = entry.get("prediction_class")
         if not prediction:
             continue
 
-        boreholes = ground_truth.ground_truth.get(entry["filename"], [])
+        boreholes = ground_truth.for_file(entry["filename"]) or []
         borehole = next((b for b in boreholes if b.borehole_index == entry["borehole_index"]), None)
         if borehole is None or entry["layer_index"] >= len(borehole.layers):
             continue
 
         layer = borehole.layers[entry["layer_index"]]
-        if getattr(layer, sub_model_key) is None:
-            setattr(layer, sub_model_key, sub_model_cls())
+        values = prediction if isinstance(prediction, list) else [prediction]
+        value = values if is_list else values[0]
 
-        if is_list:
-            value = prediction if isinstance(prediction, list) else [prediction]
-        else:
-            value = prediction[0] if isinstance(prediction, list) else prediction
-        setattr(getattr(layer, sub_model_key), field_name, value)
+        sub_model = getattr(layer, sub_model_key) or sub_model_cls()
+        setattr(layer, sub_model_key, sub_model.model_copy(update={field_name: value}))
         updated += 1
 
     logger.info("Applied %d predictions from %s (%s).", updated, predictions_path.name, class_system_name)

--- a/src/scripts/enhance_groundtruth.py
+++ b/src/scripts/enhance_groundtruth.py
@@ -1,0 +1,140 @@
+"""Script to enhance a ground truth file with predicted labels from classification JSON outputs.
+
+Usage:
+python src/scripts/enhance_groundtruth.py \
+  -g Path to ground truth file which should be enhanced  \
+  -p class prediction json  \
+  -p optional further class prediction json
+  -o optional path to output file (default: <ground_truth_stem>_enhanced.json next to the input file)
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import get_args, get_origin
+
+import click
+
+from classification.utils.datasets import ExistingClassificationSystems
+from core.ground_truth import GroundTruth, GroundTruthConsolidated, GroundTruthUnconsolidated
+
+logger = logging.getLogger(__name__)
+
+_SUB_MODEL_CLASSES: dict[str, type] = {
+    "consolidated": GroundTruthConsolidated,
+    "unconsolidated": GroundTruthUnconsolidated,
+}
+
+
+def _is_list_field(sub_model_cls: type, field_name: str) -> bool:
+    """Return True if the Pydantic field is annotated as a list type.
+
+    Args:
+        sub_model_cls: The Pydantic model class containing the field.
+        field_name: The field name to inspect.
+
+    Returns:
+        bool: True when the field holds a list, False for scalar fields.
+    """
+    annotation = sub_model_cls.model_fields[field_name].annotation
+    return any(get_origin(arg) is list for arg in get_args(annotation))
+
+
+def _apply_predictions(ground_truth: GroundTruth, predictions_path: Path) -> int:
+    """Write predicted labels from a class predictions JSON into the ground truth in-place.
+
+    The target sub-model (consolidated / unconsolidated) and field are resolved from
+    the classification system declared inside the predictions file.
+
+    Args:
+        ground_truth: GroundTruth object to update.
+        predictions_path: Path to a class predictions JSON file.
+
+    Returns:
+        int: Number of layers updated.
+    """
+    with open(predictions_path, encoding="utf-8") as f:
+        predictions = json.load(f)
+
+    if not predictions:
+        return 0
+
+    class_system_name = predictions[0]["class_system"]
+    classification_system = ExistingClassificationSystems.get_classification_system_type(class_system_name)
+    sub_model_key, field_name = classification_system.get_layer_ground_truth_keys()
+
+    sub_model_cls = _SUB_MODEL_CLASSES[sub_model_key]
+    is_list = _is_list_field(sub_model_cls, field_name)
+
+    updated = 0
+    for entry in predictions:
+        prediction = entry.get("prediction_class") or entry.get("prediction_classes")
+        if not prediction:
+            continue
+
+        boreholes = ground_truth.ground_truth.get(entry["filename"], [])
+        borehole = next((b for b in boreholes if b.borehole_index == entry["borehole_index"]), None)
+        if borehole is None or entry["layer_index"] >= len(borehole.layers):
+            continue
+
+        layer = borehole.layers[entry["layer_index"]]
+        if getattr(layer, sub_model_key) is None:
+            setattr(layer, sub_model_key, sub_model_cls())
+
+        if is_list:
+            value = prediction if isinstance(prediction, list) else [prediction]
+        else:
+            value = prediction[0] if isinstance(prediction, list) else prediction
+        setattr(getattr(layer, sub_model_key), field_name, value)
+        updated += 1
+
+    logger.info("Applied %d predictions from %s (%s).", updated, predictions_path.name, class_system_name)
+    return updated
+
+
+@click.command(help="Enhance a ground truth file with predicted labels from one or more prediction JSON files.")
+@click.option(
+    "-g",
+    "--ground-truth",
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help="Path to the input ground truth JSON file.",
+)
+@click.option(
+    "-p",
+    "--predictions",
+    "predictions_paths",
+    type=click.Path(exists=True, path_type=Path),
+    multiple=True,
+    required=True,
+    help="Path to a class predictions JSON file. Repeat to apply multiple files.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Output path. Defaults to <ground_truth_stem>_enhanced.json next to the input file.",
+)
+def enhance(ground_truth: Path, predictions_paths: tuple[Path, ...], output: Path | None) -> None:
+    """Enhance a ground truth file with predicted labels from classification outputs.
+
+    Args:
+        ground_truth (Path): Path to the input ground truth JSON file.
+        predictions_paths (tuple[Path, ...]): Paths to class predictions JSON files.
+        output (Path | None): Output path for the enhanced ground truth.
+    """
+    output = output or ground_truth.parent / f"{ground_truth.stem}_enhanced{ground_truth.suffix}"
+
+    gt = GroundTruth(ground_truth)
+    for predictions_path in predictions_paths:
+        _apply_predictions(gt, predictions_path)
+
+    with open(output, "w", encoding="utf-8") as f:
+        json.dump(gt.to_json(), f, ensure_ascii=False, indent=4)
+
+    logger.info("Enhanced ground truth saved to %s.", output)
+
+
+if __name__ == "__main__":
+    enhance()


### PR DESCRIPTION
Closes #431 and #451 (duplicated issues (?))

### Data 
Was generated with bedrock since we did not have enough ground truth data available.
Total sampels: 119,404  
Not not_specified: 20,331

<img width="700" height="350" alt="Screenshot 2026-07-01 at 10 21 23" src="https://github.com/user-attachments/assets/82a96e7c-cd43-4b0a-b454-62f76175d5b0" />

### Metrics 
Training was done with
      - deepwells_ground_truth_enhanced.json
      - geoquat_ground_truth_enhanced.json
      - zurich_ground_truth_enhanced.json
      - nagra_ground_truth_enhanced.json

| Test set   |    BERT F1-macro | BERT F1-micro |
|------------|----------------|------------------|
deepwells_ground_truth_enhanced.json | 0.7741 | 0.8914
geoquat_ground_truth_enhanced.json | 0.7853 | 0.9563
zurich_ground_truth_enhanced.json | 0.7253 |  0.9486
nagra_ground_truth_enhanced.json | 0.9824 |  0.9969

### Per class metrics (global test) 

| Class               |F1 score | 
|-----------------------|-----------------------|
| moderately_cemented_f1 |     0.9005 |
| not_specified_f1 |     0.9819 |
| other_f1 |     0 |
| strongly_cemented_f1 |     0.6555 |
| uncemented_f1 |     0.8374 |
| weakly_cemented_f1 |     0.8528 |
| cemented_f1 |     0.8799 |

### Confusion matrix (global test)
<img width="600" height="500" alt="confusion_matrix_global_cementation" src="https://github.com/user-attachments/assets/7a202e55-6620-4994-8e8a-25cd8df768be" />


### Examples 

Deepwells

| Doc ID | Description | BERT | GT / Bedrock |
|----|----------------------|------|--------------|
| UTRSP5F900_bp_11110101_Cuarny-2 | Macigno kalkig, hart | well_cemented | well_cemented |
| 28222.ocr | graue dichte bröckelige Tone | weakly_cemented | weakly_cemented |
| 7KPE17I800_bp_19811207_Herdern-1 | zunehmend Tonstein dunkelgrau, mässig fest | moderately_cemented | moderately_cemented |
| 6BQE17I800_bp_20131215_Engerfeld | Hellroter, sehr harter Aplit | strongly_cemented | strongly_cemented |
| UTRSP5F900_bp_11110101_Cuarny-2 | Macigno grau zu Sand verwittert | uncemented | uncemented |
| 28222.ocr | derber Anhydrit Stinkmergel | not_specified | well_cemented |
| 92RE17I800_bp_19940430_Tujetsch-SB3-1 | Quarz-Chloritphyllit. Grün, hart, mürbe. | well_cemented | weakly_cemented |
| XRPE17I800_bp_11110101_Lindau-1 | 80% Mittelsandstein wie zuvor; 20% Mergelstein feinsandig bis Feinsandstein mergelig, wie zuvor. | not_specified | moderately_cemented |
| 16064_Composite_log_1_2000 | Tonmergelstein, grau bis bräunlich, häufig olivfarben und etwas rötlich gefleckt, überwiegend staubsandfrei, i.a. schwach glimmerstaubig, sehr fest | well_cemented | strongly_cemented |
| GT-1_uebersichtsprofil_1_20000 | Sandstein, fein bis mittelkörnig, überwiegend zu losen Quarzen zerbohrt; im Wechsel mit Mergel, bunt | not_specified | uncemented |

### Model 
Already uploaded to HuggingFace 
[swissgeol/cementation](https://huggingface.co/swissgeol/cementation)