### PR TITLE
Classification of Accessory Components (BERT)

### DIFF
--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -3,24 +3,35 @@
 
 ## Overview (BERT Only)
 
-| Dataset                            | Support (num classes) | Target | F1-macro | F1-micro |
-|------------------------------------|-----------------------|--------|----------|----------|
-| `accessory_components`             | 75 (66) / enhanced : 152,2083 (47) |  Multi | 0.842 | 0.972       - |        - |
-| `alteration_degree_consolidated`   |             2,716 (8)| Single  |    0.392 |    0.782 |
-| `alteration_degree_unconsolidated` |                41 (8) | Single |        - |        - |
-| `cementation`                      |                78 (7) | Single |        - |        - |
-| `color_consolidated`*              |           16,143 (91) | Single |    0.487 |    0.752 |
-| `color_unconsolidated`*            |           20,121 (91) | Single |    0.502 |    0.803 |
-| `debris`                           |           70,084, (7) |  Multi |    0.797 |    0.983 |
-| `en_main`                          |           89,842 (34) | Single |    0.859 |    0.905 |
-| `grain_angularity`                 |            70,377 (8) |  Multi |    0.831 |    0.974 |
-| `grain_shape`                      |            70,087 (5) |  Multi |    0.560 |    0.998 |
-| `lithology`                        |           45,323 (61) | Single |    0.848 |    0.942 |
-| `mineral_components`               |              63 (111) |  Multi |        - |        - |
-| `organic_components`               |           70,102 (11) |  Multi |    0.839 |    0.983 |
-| `uscs`                             |            9,917 (38) | Single |    0.329 |    0.602 |
+| Dataset                            | Enhanced | Support (num classes) | Target | F1-macro | F1-micro |
+|------------------------------------|----------|-----------------------|--------|----------|----------|
+| `accessory_components`             | x        |         152,2083 (47) |  Multi |    0.842 |    0.972 |
+| `alteration_degree_consolidated`   |          |             2,716 (8) | Single |    0.392 |    0.782 |
+| `alteration_degree_unconsolidated` |          |                41 (8) | Single |        - |        - |
+| `cementation`                      |          |                78 (7) | Single |        - |        - |
+| `color_consolidated`*              |          |           16,143 (91) | Single |    0.487 |    0.752 |
+| `color_unconsolidated`*            |          |           20,121 (91) | Single |    0.502 |    0.803 |
+| `debris`                           |          |           70,084, (7) |  Multi |    0.797 |    0.983 |
+| `en_main`                          |          |           89,842 (34) | Single |    0.859 |    0.905 |
+| `grain_angularity`                 |          |            70,377 (8) |  Multi |    0.831 |    0.974 |
+| `grain_shape`                      |          |            70,087 (5) |  Multi |    0.560 |    0.998 |
+| `lithology`                        |          |           45,323 (61) | Single |    0.848 |    0.942 |
+| `mineral_components`               |          |              63 (111) |  Multi |        - |        - |
+| `organic_components`               |          |           70,102 (11) |  Multi |    0.839 |    0.983 |
+| `uscs`                             |          |            9,917 (38) | Single |    0.329 |    0.602 |
+
 
 * Model jointly trained, same for both tasks.
+
+## Accessory Components - Enhanced
+
+| Test set  | Bedrock F1-macro | Bedrock F1-micro | BERT F1-macro | BERT F1-micro |
+|-----------|------------------|------------------|---------------|---------------|
+| Deepwells | -                | -                | 0.721         | 0.914         |
+| Geoquat   | -                | -                | 0.560         | 0.980         |
+| Nagra     | -                | -                | 0.924         | 0.978         |
+| Zurich    | -                | -                | 0.600         | 0.963         |
+| Overall   | -                | -                | 0.842         | 0.972         |
 
 
 ## Alteration Degree (Consolidated)

--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -5,7 +5,7 @@
 
 | Dataset                            | Support (num classes) | Target | F1-macro | F1-micro |
 |------------------------------------|-----------------------|--------|----------|----------|
-| `accessory_components`             |               75 (66) / enhanced : 152,2083 (47) |  Multi |        - |        - |
+| `accessory_components`             | 75 (66) / enhanced : 152,2083 (47) |  Multi | 0.842 | 0.972       - |        - |
 | `alteration_degree_consolidated`   |             2,716 (8)| Single  |    0.392 |    0.782 |
 | `alteration_degree_unconsolidated` |                41 (8) | Single |        - |        - |
 | `cementation`                      |                78 (7) | Single |        - |        - |

--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -5,8 +5,8 @@
 
 | Dataset                            | Support (num classes) | Target | F1-macro | F1-micro |
 |------------------------------------|-----------------------|--------|----------|----------|
-| `accessory_components`             |               75 (66) |  Multi |        - |        - |
-| `alteration_degree_consolidated`   |             2,716 (8) | Single |    0.392 |    0.782 |
+| `accessory_components`             |               75 (66) / enhanced : 152,2083 (47) |  Multi |        - |        - |
+| `alteration_degree_consolidated`   |             2,716 (8)| Single  |    0.392 |    0.782 |
 | `alteration_degree_unconsolidated` |                41 (8) | Single |        - |        - |
 | `cementation`                      |                78 (7) | Single |        - |        - |
 | `color_consolidated`*              |           16,143 (91) | Single |    0.487 |    0.752 |


### PR DESCRIPTION
Closes #410

### Data 
Was generated with bedrock since we did not have enough ground truth data available.
There, we ensured by human-in-the-loop evaluation, that the quality is good. 
Nevertheless, there are limitations due to an inconsistent ground truth. In the ground truth, sometime the keyword "bioclastiques" leads to a "bioclast" label and sometimes not. e..g 

| Material description               |label | 
|-----------------------|-----------------------|
|"Calcaires beiges foncés **bioclastiques**, à oncoïdes et encroûtements algaires, bréchique (épikarst) avec présence d'argiles et marnes (remplissage fissures)"  |algal_mats, **bioclasts**, oncoids |  
|"Calcaires **bioclastiques** à dacycladales, blanc-beige (packstone/grainstone)" | algae|

The bedrock prediction mostly predicts a label when it detects the keyword. 

Total sampels: 152,083  
Specified: 58,526

<img width="750" height="1500" alt="accessory_components_classes" src="https://github.com/user-attachments/assets/05bf9748-a844-4d78-b39e-d7fc11482e88" />

### Metrics 
Training was done with
      - deepwells_ground_truth_enhanced.json
      - geoquat_ground_truth_enhanced.json
      - zurich_ground_truth_enhanced.json
      - nagra_ground_truth_enhanced.json

| Test set   |    BERT F1-macro | BERT F1-micro |
|------------|----------------|------------------|
deepwells_ground_truth_enhanced.json |0.7214 | 0.9144 | 
 geoquat_ground_truth_enhanced.json | 0.5596 | 0.9802 |
zurich_ground_truth_enhanced.json | 0.6003 | 0.963
nagra_ground_truth_enhanced.json | 0.9238 |  0.9776 | 
global | 0.8421 |  0.9718 | 

### Per class metrics (global test) 

| Class               |F1 score | 
|-----------------------|-----------------------|
| algae | 0.8333 |
| algal_mats | 0.9879 |
| ammonites | 0.9901 |
| aptychi | 1.0 |
| components_ash | 0.0 |
| belemnites | 0.9966 |
| bioclasts | 0.9579 |
| biodetritus | 0.9147 |
| bitumen | 0.8901 |
| bivalves | 0.9929 |
| brachiopods | 0.9825 |
| bryozoans | 1.0 |
| calcareous_concretion | 0.8803 |
| calcareous_ooids | 0.06 |
| cephalopods | 1.0 |
| chert | 0.9703 |
| coal_fragments | 0.9083 |
| concretion | 0.5588 |
| corals | 0.989 |
| crinoids | 0.9976 |
| crystals | 0.7874 |
| echinoderms | 0.9885 |
| echinoids | 0.9773 |
| fish_remains | 0.7778 |
| foraminifera | 0.7368 |
| fossils | 0.8777 |
| gastropods | 0.9667 |
| gryphaea | 0.9706 |
| iron_ooids | 0.9586 |
| iron_pisoids | 1.0 |
| lithoclasts | 0.8999 |
| molluscs | 0.9333 |
| nautilids | 1.0 |
| not_specified | 0.9915 |
| oncoids | 0.9935 |
| ooids | 0.7816 |
| organic_matter | 0.8748 |
| ostracods | 0.0 |
| other | 0.2807 |
| oysters | 0.9273 |
| pellets | 0.975 |
| plant_remains | 0.8611 |
| plant_root_tubes | 0.9391 |
| pyroclast | 0.0 |
| radiolarians | 0.8 |
| rootlets | 0.9692 |
| sideritic_concretion | 0.9069 |
| spicules | 0.8 |
| sponges | 0.9962 |
| stromatolites | 1.0 |
| vertebrates | 0.9524 |
| wood_fragments | 0.9535 |

### Examples 

Zurich

| Doc ID | Description | BERT | GT / Bedrock |
|----|----------------------|------|--------------|
| 267123107-bp.pdf | Leicht tonig-siltiger Feinsand mit vereinzelt Feinkies, praktisch skelettfrei, gut durchwurzelt, dunkelbraun, locker gelagert " | rootlets | rootlets | 
|267125274-bp.pdf | stark toniger Silt mittlerer bis hoher Plastizität mit reichlich organischen Material und Blöcken (Komp. z.T. stark verwittert), dunkelgrau, mittelsteif | organic_matter | organic_matter |
| 267125047-bp.pdf | schwarzer, bituminoser Mergel | bitumen | bitumen |
| 267125047-bp.pdf| rauer Sand mit Sandsteintrümmern | lithoclasts | not_specified | 
 | 267125058-bp.pdf | beiger bis beige-bunter Mergel, lehmig verwittert, 14.0 - 14.1 m steil einfallende Kluft 14.4 - 14.5 m rötlich grauer, sandiger Mergel, rötliche Schneckenschalen, Schwarzhorizont | gastropods | gastropods, bioclastst |
|267123041-bp.pdf | Dunkelbrauner, lehmiger Kies mit reichlich Sand, Ziegelreste, wenig Holz / Organisches Material und mit vereinzelt Steinen | organic_matter, wood_fragments, other | organic_matter, wood_fragments|



### Model 
Already saved to https://huggingface.co/swissgeol/accessory_components
