### PR TITLE
Classification Mineral Components (BERT) 

### DIFF
--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -16,7 +16,7 @@
 | `grain_angularity`                 |          |            70,377 (8) |  Multi |    0.831 |    0.974 |
 | `grain_shape`                      |          |            70,087 (5) |  Multi |    0.560 |    0.998 |
 | `lithology`                        |          |           45,323 (61) | Single |    0.848 |    0.942 |
-| `mineral_components`               |          |              63 (111) |  Multi |        - |        - |
+| `mineral_components`               | x        |         141,825 (111) |  Multi |    0.794 |    0.984 |
 | `organic_components`               |          |           70,102 (11) |  Multi |    0.839 |    0.983 |
 | `uscs`                             |          |            9,917 (38) | Single |    0.329 |    0.602 |
 
@@ -98,6 +98,16 @@
 | Thurgau   | 0.363            | 0.864            | 0.576         | 0.916         |
 | Overall   | -                | -                | 0.848         | 0.942         |
 
+
+## Mineral Components - Enhanced
+
+| Test set  | Bedrock F1-macro | Bedrock F1-micro | BERT F1-macro | BERT F1-micro |
+|-----------|------------------|------------------|---------------|---------------|
+| Deepwells | -                | -                | 0.78          | 0.942         |
+| Geoquat   | -                | -                | 0.739         | 0.997         |
+| Nagra     | -                | -                | 0.924         | 0.984         |
+| Zurich    | -                | -                | 0.369         | 0.984         |
+| Overall   | -                | -                | 0.794         | 0.984         |
 
 ## Organic Components
 

--- a/docs/Experiment_Results.md
+++ b/docs/Experiment_Results.md
@@ -16,7 +16,7 @@
 | `grain_angularity`                 |            70,377 (8) |  Multi |    0.831 |    0.974 |
 | `grain_shape`                      |            70,087 (5) |  Multi |    0.560 |    0.998 |
 | `lithology`                        |           45,323 (61) | Single |    0.848 |    0.942 |
-| `mineral_components`               |              63 (111) |  Multi |        - |        - |
+| `mineral_components`               |  63 (111)/ enhanced: 141,825  |  Multi |        - |        - |
 | `organic_components`               |           70,102 (11) |  Multi |    0.839 |    0.983 |
 | `uscs`                             |            9,917 (38) | Single |    0.329 |    0.602 |
 


### PR DESCRIPTION
Closes #409 

### Data 
Was generated with bedrock since we did not have enough ground truth data available.
Total sampels: 141,825
Specified: 54,216 
Present classes: 60
<img width="750" height="1500" alt="mineral_components_classes" src="https://github.com/user-attachments/assets/53ad4884-b4c3-4041-9b7b-db73612cb496" />


### Metrics 
Training was done with
      - deepwells_ground_truth_enhanced.json
      - geoquat_ground_truth_enhanced.json
      - zurich_ground_truth_enhanced.json
      - nagra_ground_truth_enhanced.json

| Test set   |    BERT F1-macro | BERT F1-micro |
|------------|----------------|------------------|
| deepwells_ground_truth_enhanced.json | 0.78 | 0.942 | 
| geoquat_ground_truth_enhanced.json | 0.739 | 0.997 | 
| zurich_ground_truth_enhanced.json | 0.369 | 0.975 | 
| nagra_ground_truth_enhanced.json | 0.924 | 0.984 |
| global | 0.794 | 0.984 |

### Per class metrics (global test) 

| Class | F1 score |
|---|---|
| amphibole | 0.8621 |
| anhydrite | 0.9328 |
| ankerite | 0.8 |
| baryte | 0.0 |
| biotite | 0.9718 |
| calcite | 0.8 |
| chalcopyrite | 0.0 |
| chlorite | 0.971 |
| chloritoid | 0.0 |
| cordierite | 0.0 |
| dolomite | 0.9629 |
| epidote | 1.0 |
| feldspar | 0.9081 |
| galena | 0.991 |
| garnet | 0.25 |
| glauconite | 0.9945 |
| graphite | 1.0 |
| gypsum | 0.9168 |
| halite | 0.9748 |
| hematite | 1.0 |
| hornblende | 0.8764 |
| k_feldspar | 0.9756 |
| kaolinite | 0.9831 |
| lignite | 0.0 |
| limonite | 0.974 |
| mica | 0.9786 |
| muscovite | 0.9259 |
| not_specified | 0.9956 |
| orthoclase | 1.0 |
| other | 0.6292 |
| plagioclase | 0.7619 |
| pyrite | 0.9938 |
| quartz | 0.9747 |
| sericite | 1.0 |
| siderite | 0.988 |
| sphalerite | 1.0 |
| tourmaline | 1.0 |


### Examples 

Deepwells

| Doc ID | Description | BERT | GT / Bedrock |
|----|----------------------|------|--------------|
| 16062_Composite_log_1_2000 | Kalkstein, blaßgelblichbraun und hellgrünlichgrau, feine olivgrüne Tonbutzen, vereinzelt **Glaukonit** (?), kleine **Pyritfünkchen**, grobspätig und grobkristallin, hart, unregelmäßig splitteriger Bruch, gelegentlich Kalzitäderchen; daneben nicht selten weißgraue, etwas blaustichige, manchmal dunkel pigmentierte splitterharte, scharfkantig brechende, etwas kalkige **Quarzsplitter**; ferner zu meist in groben Bröckchen, ziemlich viel, in Sp. 442 m abnehmend Kalkstein, mittel - bis dunkelgrau, schwach tonig, schwach siltig, feine spätige Kristallflächen, z.T. feinkörnige Struktur, hart, unregelmäßig- eckiger Bruch; ganz untergeordnet gelbbrauner, glaukonitführender, z.T. pseudo-oolithischer, schwach spätiger, grobkristalliner Kalkstein." | "glauconite", “pyrite", "quartz" | "glauconite", “pyrite", "quartz" | 
| 20752_Geologisches_Bohrprofil_1_200 | Chlorit-Sericit(-Muskovit)-Gneis bis -Schiefer, bräunlich-grau (Muskovit, Biotit). ab 1109 m: grünlich (Chlorit, Epidot), Schieferung ~70-80° zur BA, mit dünnen Quarzlagen | "biotite", "chlorite", "epidote", "muscovite", "quartz", "sericite" | "biotite", "chlorite", "epidote", "muscovite", "quartz", "sericite" | "dolomite", "quartz" | "dolomite", "quartz" | 
|20752_Geologisches_Bohrprofil_1_200 | Kalksandstein, grau, Basis quarzitisch, schwarze Schiefer|  "quartz" | "quartz" |
| 18855_Uebersicht_Bohrprofil_1_5000 | Tonstein, dolomitisch, schiefrig, siltig bis feinsandig, mit Hellglimmer dkl. grau - schwarz | "muscovite" | "dolomite",  "muscovite" | 
| 62621_Composite_log_1_2000 | Dolomit (95 - 100 %), mittelgrau, am Kopf (Sp. 2532 m) auch hellgrau bis hellbeige; ziemlich anhydritisch, feinkristallin bis staubkörnig, schwach rauh, hart, dünnblätterig brechend; in Sp. 2542 m noch ca. 5 %\nweißer Anhydrit; gelegentlich einzelne grobkristalline, hellrötliche Anhydritbröckchen. |  "not_specified" | "anhydrite" |
| 20752_Geologisches_Bohrprofil_1_200 | Kalk, grau, fein laminiert bis plattig, Typ Quintner Kalk Calcitäderchen, meist linsig-boudiniert, dünne Schieferlagen, lokal schwach mergelig-aufblätternde Schichtflächen\n~60 - 70° zur BA, Klüfte subparallel zur Schichtung, plattig (ca. 1 cm dicke Disken) | "not_specified", "calcite" | "calcite"| 

### Model 
Uploaded to https://huggingface.co/swissgeol/mineral_components