### PR TITLE
Introduce BoreholeCandidate helper class

### DIFF
--- a/src/app/api/v1/endpoints/extract_stratigraphy.py
+++ b/src/app/api/v1/endpoints/extract_stratigraphy.py
@@ -8,7 +8,7 @@ from app.common.schemas import (
     ExtractStratigraphyResponse,
     GroundwaterSchema,
 )
-from extraction.features.extract import MaterialDescriptionRectWithSidebarExtractor
+from extraction.features.extract import BoreholeExtractor
 from extraction.features.groundwater.groundwater_extraction import (
     GroundwaterInDocument,
     GroundwaterLevelExtractor,
@@ -91,7 +91,7 @@ def extract_stratigraphy(filename: str, include_groundwater: bool = False) -> Ex
         # Detect strip logs on the page
         strip_logs = detect_strip_logs(page, text_lines, striplog_detection_params)
 
-        extracted_boreholes = MaterialDescriptionRectWithSidebarExtractor(
+        extracted_boreholes = BoreholeExtractor(
             text_lines,
             long_or_horizontal_lines,
             all_geometric_lines,

--- a/src/extraction/core/extract.py
+++ b/src/extraction/core/extract.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pymupdf
 
-from extraction.features.extract import MaterialDescriptionRectWithSidebarExtractor
+from extraction.features.extract import BoreholeExtractor
 from extraction.features.groundwater.groundwater_extraction import (
     GroundwaterInDocument,
     GroundwaterLevelExtractor,
@@ -139,7 +139,7 @@ def extract(
             strip_logs = detect_strip_logs(page, text_lines, striplog_detection_params)
 
             # Extract the stratigraphy
-            extracted_boreholes = MaterialDescriptionRectWithSidebarExtractor(
+            extracted_boreholes = BoreholeExtractor(
                 text_lines,
                 long_or_horizontal_lines,
                 all_geometric_lines,

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -125,7 +125,15 @@ class BoreholeExtractor:
             # constructed valid boreholes
             valid_candidates.append(candidate_without_sidebar)
 
-        return [candidate.borehole for candidate in valid_candidates]
+        # Only return layers with nonempty description for the time being, for the sake of consistency.
+        # TODO After verifying the impact on benchmarking scores, we should also return layers without description.
+        return [
+            ExtractedBorehole(
+                [layer for layer in candidate.borehole.predictions if layer.description_nonempty()],
+                candidate.borehole.bounding_boxes,
+            )
+            for candidate in valid_candidates
+        ]
 
     def _contained_in_table_index(
         self, pair: MaterialDescriptionRectWithSidebar, table_structures: list[TableStructure], proximity_buffer: float
@@ -212,9 +220,7 @@ class BoreholeExtractor:
         min_layers = self.matching_params["min_num_layers"]
         if pair.sidebar and isinstance(pair.sidebar, ProtocolSidebar):
             min_layers = self.matching_params.get("protocol_min_num_layers", min_layers)
-        if len(borehole_layers_with_description) < min_layers or len(borehole_layers_with_description) <= 0.5 * len(
-            borehole_layers
-        ):
+        if len(borehole_layers_with_description) < min_layers:
             return None
 
         return ExtractedBorehole(borehole_layers, [bounding_boxes])  # takes a list of bounding boxes

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -596,6 +596,12 @@ class BoreholeExtractor:
             selected_boreholes.append(best_borehole)
             used_sidebars_idx.add(best_sidebar_index)
 
+        # Step 2: Assign remaining sidebars (if any) to best match
+        remaining_sidebars_idx = [s_idx for s_idx in range(len(sidebars_noise)) if s_idx not in used_sidebars_idx]
+        for sidebar_index in remaining_sidebars_idx:
+            if candidates := sidebar_boreholes[sidebar_index]:
+                best_candidate = max(candidates, key=lambda candidate: candidate.score)
+                selected_boreholes.append(best_candidate)
         return selected_boreholes
 
     def get_diagonals_near_textlines(

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -710,7 +710,7 @@ class BoreholeExtractor:
         """
         # Get filtered pairs (without descriptions without sidebar)
         good_borehole_candidates = self._extract_filtered_borehole_candidates()
-        best_candidate_score = max((candidate.core for candidate in good_borehole_candidates), default=0.0)
+        best_candidate_score = max((candidate.score for candidate in good_borehole_candidates), default=0.0)
 
         return SidebarQualityMetrics(
             number_of_good_sidebars=len(good_borehole_candidates),

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -6,6 +6,7 @@ import re
 import fastquadtree
 import pymupdf
 
+from extraction.features.stratigraphy.borehole_candidate import BoreholeCandidate
 from extraction.features.stratigraphy.depth_description_alignment import match_lines_to_interval
 from extraction.features.stratigraphy.interval.interval import IntervalBlockPair
 from extraction.features.stratigraphy.layer.layer import (
@@ -58,7 +59,7 @@ from swissgeol_doc_processing.utils.table_detection import (
 logger = logging.getLogger(__name__)
 
 
-class MaterialDescriptionRectWithSidebarExtractor:
+class BoreholeExtractor:
     """Class with methods to extract pairs of a material description rect with a corresponding sidebar."""
 
     def __init__(
@@ -76,7 +77,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
         analytics: MatchingParamsAnalytics = None,
         **matching_params: dict,
     ):
-        """Creates a new MaterialDescriptionRectWithSidebarExtractor.
+        """Creates a new BoreholeExtractor.
 
         Args:
             lines (list[TextLine]): all the text lines on the page.
@@ -113,28 +114,18 @@ class MaterialDescriptionRectWithSidebarExtractor:
         Returns:
             list[ExtractedBorehole]: The extracted boreholes from the page.
         """
-        filtered_pairs = self._extract_filtered_sidebar_pairs()
+        valid_candidates = self._extract_filtered_borehole_candidates()
 
-        valid_boreholes = []
-        pairs_from_valid_boreholes = []
-        for pair in filtered_pairs:
-            borehole = self._create_borehole_from_pair(pair)
-            if borehole is not None:
-                valid_boreholes.append(borehole)
-                pairs_from_valid_boreholes.append(pair)
-
-        material_descriptions_without_sidebar = self._extract_material_descriptions_without_sidebar()
-        if material_descriptions_without_sidebar and not any(
-            self._pairs_intersect(material_descriptions_without_sidebar, other_pair)
-            for other_pair in pairs_from_valid_boreholes
+        candidate_without_sidebar = self._extract_borehole_without_sidebar()
+        if candidate_without_sidebar and not any(
+            candidate_without_sidebar.bounding_box.intersects(other_candidate.bounding_box)
+            for other_candidate in valid_candidates
         ):
             # add the material descriptions without sidebar if there is no intersection with any of the already
             # constructed valid boreholes
-            borehole = self._create_borehole_from_pair(material_descriptions_without_sidebar)
-            if borehole is not None:
-                valid_boreholes.append(borehole)
+            valid_candidates.append(candidate_without_sidebar)
 
-        return valid_boreholes
+        return [candidate.borehole for candidate in valid_candidates]
 
     def _contained_in_table_index(
         self, pair: MaterialDescriptionRectWithSidebar, table_structures: list[TableStructure], proximity_buffer: float
@@ -169,39 +160,21 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
         return -1
 
-    def _filter_by_intersections(
-        self, pairs: list[MaterialDescriptionRectWithSidebar]
-    ) -> list[MaterialDescriptionRectWithSidebar]:
-        """Remove pairs that intersect with higher-scoring pairs."""
-        kept_pairs = []
+    def _filter_by_intersections(self, candidates: list[BoreholeCandidate]) -> list[BoreholeCandidate]:
+        """Remove candidates that intersect with higher-scoring candidates."""
+        kept_candidates = []
 
-        for pair in pairs:
+        for candidate in candidates:
             # Check if this pair intersects with any already-kept (higher-scoring) pair
-            intersects = any(self._pairs_intersect(pair, kept_pair) for kept_pair in kept_pairs)
+            intersects = any(
+                candidate.bounding_box.intersects(kept_candidate.bounding_box) for kept_candidate in kept_candidates
+            )
 
             # Only keep if no conflicts found
             if not intersects:
-                kept_pairs.append(pair)
+                kept_candidates.append(candidate)
 
-        return kept_pairs
-
-    def _pairs_intersect(self, pair1, pair2) -> bool:
-        """Check if two pairs have any intersecting bounding boxes.
-
-        Creates a bounding box around each pair (union of material description rect and sidebar rect,
-        if present) and checks for intersection.
-        """
-        # Create bounding box for pair1, expanding to include sidebar if present
-        bbox1 = pair1.material_description_rect
-        if pair1.sidebar:
-            bbox1 = bbox1 | pair1.sidebar.rect
-
-        # Create bounding box for pair2 , expanding to include sidebar if present
-        bbox2 = pair2.material_description_rect
-        if pair2.sidebar:
-            bbox2 = bbox2 | pair2.sidebar.rect
-
-        return bbox1.intersects(bbox2)
+        return kept_candidates
 
     def _create_borehole_from_pair(self, pair: MaterialDescriptionRectWithSidebar) -> ExtractedBorehole | None:
         """Create an ExtractedBorehole from a MaterialDescriptionRectWithSidebar."""
@@ -281,16 +254,18 @@ class MaterialDescriptionRectWithSidebarExtractor:
                 for text_block in get_descriptions_blocks(description_lines, line_affinities, no_sidebar_weights)
             ]
 
-    def _find_layer_identifier_sidebar_pairs(self) -> list[MaterialDescriptionRectWithSidebar]:
+    def _find_layer_identifier_candidates(self) -> list[BoreholeCandidate]:
         layer_identifier_sidebars = LayerIdentifierSidebarExtractor.from_lines(self.lines, self.table_structures)
-        material_descriptions_sidebar_pairs = []
+        candidates = []
         for layer_identifier_sidebar in layer_identifier_sidebars:
             material_description_rect = self._find_material_description_column(layer_identifier_sidebar)
             if material_description_rect:
-                material_descriptions_sidebar_pairs.append(
-                    MaterialDescriptionRectWithSidebar(layer_identifier_sidebar, material_description_rect, self.lines)
+                pair = MaterialDescriptionRectWithSidebar(
+                    layer_identifier_sidebar, material_description_rect, self.lines
                 )
-        return material_descriptions_sidebar_pairs
+                if borehole := self._create_borehole_from_pair(pair):
+                    candidates.append(BoreholeCandidate.from_pair(borehole, pair))
+        return candidates
 
     def _has_valid_description_match(self, sidebar_noise: SidebarNoise) -> bool:
         """Return True if the sidebar can form at least one plausible sidebar/description pair.
@@ -322,7 +297,7 @@ class MaterialDescriptionRectWithSidebarExtractor:
         """Return True if protocol extraction should be skipped because a usable AAboveB exists."""
         return any(self._has_valid_description_match(sidebar_noise) for sidebar_noise in a_above_b_sidebars_noise)
 
-    def _find_depth_sidebar_pairs(self) -> list[MaterialDescriptionRectWithSidebar]:
+    def _find_depth_sidebar_candidates(self) -> list[BoreholeCandidate]:
         if not self.lines:
             return []
 
@@ -384,8 +359,11 @@ class MaterialDescriptionRectWithSidebarExtractor:
 
         # assign all sidebar to their best match
         material_descriptions_sidebar_pairs = self._match_sidebars_to_description_rects(sidebars_noise)
-
-        return material_descriptions_sidebar_pairs
+        candidates = []
+        for pair in material_descriptions_sidebar_pairs:
+            if borehole := self._create_borehole_from_pair(pair):
+                candidates.append(BoreholeCandidate.from_pair(borehole, pair))
+        return candidates
 
     def _find_all_material_description_candidates(self, sidebar: Sidebar | None) -> list[pymupdf.Rect]:
         """Find all material description candidates on the page.
@@ -695,21 +673,23 @@ class MaterialDescriptionRectWithSidebarExtractor:
         )
         return diagonals
 
-    def _extract_material_descriptions_without_sidebar(self) -> MaterialDescriptionRectWithSidebar | None:
+    def _extract_borehole_without_sidebar(self) -> BoreholeCandidate | None:
         """Extract material descriptions without a sidebar (if there is strong enough evidence).
 
         Returns:
-            An optional MaterialDescriptionRectWithSidebar object, which will not have a sidebar.
+            An optional BoreholeCandidate object, which will not have a sidebar.
         """
         # only allow sidebar=None fallback if strong evidence exists
         if self._allow_description_only_fallback():
             material_description_rect_without_sidebar = self._find_material_description_column(sidebar=None)
             if material_description_rect_without_sidebar:
-                return MaterialDescriptionRectWithSidebar(
+                pair = MaterialDescriptionRectWithSidebar(
                     sidebar=None,
                     material_description_rect=material_description_rect_without_sidebar,
                     lines=self.lines,
                 )
+                if borehole := self._create_borehole_from_pair(pair):
+                    return BoreholeCandidate.from_pair(borehole, pair)
         else:
             logger.debug(
                 "Page %s: skipping description-only fallback (insufficient evidence)",
@@ -717,26 +697,25 @@ class MaterialDescriptionRectWithSidebarExtractor:
             )
         return None
 
-    def _extract_filtered_sidebar_pairs(self) -> list[MaterialDescriptionRectWithSidebar]:
-        """Extract and filter sidebar pairs using the common pipeline.
+    def _extract_filtered_borehole_candidates(self) -> list[BoreholeCandidate]:
+        """Extract and filter borehole candidates using the common pipeline.
 
         Returns:
-            List of filtered MaterialDescriptionRectWithSidebar pairs, sorted by
-            score (highest first) and filtered by score, table criteria, and
-            intersections.
+            List of filtered BoreholeCandidate objects, sorted by score (highest first) and filtered by score, table
+            criteria, and intersections.
         """
         # Step 1: Find all potential pairs
-        pairs = self._find_layer_identifier_sidebar_pairs()
-        pairs.extend(self._find_depth_sidebar_pairs())
+        candidates = self._find_layer_identifier_candidates()
+        candidates.extend(self._find_depth_sidebar_candidates())
 
         # Step 2: Sort once by score (highest first)
-        pairs.sort(key=lambda pair: pair.score_match, reverse=True)
+        candidates.sort(key=lambda candidate: candidate.score, reverse=True)
 
         # Step 3: Apply filter chain
-        filtered_pairs = [pair for pair in pairs if pair.score_match >= 0]
-        filtered_pairs = self._filter_by_intersections(filtered_pairs)
+        filtered_candidates = [candidate for candidate in candidates if candidate.score >= 0]
+        filtered_candidates = self._filter_by_intersections(filtered_candidates)
 
-        return filtered_pairs
+        return filtered_candidates
 
     @staticmethod
     def _filter_diagonals(
@@ -770,12 +749,12 @@ class MaterialDescriptionRectWithSidebarExtractor:
             SidebarQualityMetrics: Quality metrics for all sidebars found on the page.
         """
         # Get filtered pairs (without descriptions without sidebar)
-        good_sidebar_pairs = self._extract_filtered_sidebar_pairs()
-        best_sidebar_score = max((pair.score_match for pair in good_sidebar_pairs), default=0.0)
+        good_borehole_candidates = self._extract_filtered_borehole_candidates()
+        best_candidate_score = max((candidate.core for candidate in good_borehole_candidates), default=0.0)
 
         return SidebarQualityMetrics(
-            number_of_good_sidebars=len(good_sidebar_pairs),
-            best_sidebar_score=best_sidebar_score,
+            number_of_good_sidebars=len(good_borehole_candidates),
+            best_sidebar_score=best_candidate_score,
         )
 
     def _allow_description_only_fallback(self) -> bool:

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -207,12 +207,14 @@ class BoreholeExtractor:
             for pair in interval_block_pairs
         ]
 
-        borehole_layers = [layer for layer in borehole_layers if layer.description_nonempty()]
+        borehole_layers_with_description = [layer for layer in borehole_layers if layer.description_nonempty()]
 
         min_layers = self.matching_params["min_num_layers"]
         if pair.sidebar and isinstance(pair.sidebar, ProtocolSidebar):
             min_layers = self.matching_params.get("protocol_min_num_layers", min_layers)
-        if len(borehole_layers) < min_layers:
+        if len(borehole_layers_with_description) < min_layers or len(borehole_layers_with_description) <= 0.5 * len(
+            borehole_layers
+        ):
             return None
 
         return ExtractedBorehole(borehole_layers, [bounding_boxes])  # takes a list of bounding boxes
@@ -258,13 +260,8 @@ class BoreholeExtractor:
         layer_identifier_sidebars = LayerIdentifierSidebarExtractor.from_lines(self.lines, self.table_structures)
         candidates = []
         for layer_identifier_sidebar in layer_identifier_sidebars:
-            material_description_rect = self._find_material_description_column(layer_identifier_sidebar)
-            if material_description_rect:
-                pair = MaterialDescriptionRectWithSidebar(
-                    layer_identifier_sidebar, material_description_rect, self.lines
-                )
-                if borehole := self._create_borehole_from_pair(pair):
-                    candidates.append(BoreholeCandidate.from_pair(borehole, pair))
+            if candidate := self._find_borehole_candidate(layer_identifier_sidebar):
+                candidates.append(candidate)
         return candidates
 
     def _has_valid_description_match(self, sidebar_noise: SidebarNoise) -> bool:
@@ -282,7 +279,6 @@ class BoreholeExtractor:
             pair = MaterialDescriptionRectWithSidebar(
                 sidebar=sidebar_noise.sidebar,
                 material_description_rect=rect,
-                lines=self.lines,
                 noise_count=sidebar_noise.noise_count,
             )
             if pair.score_match >= 0:
@@ -358,12 +354,7 @@ class BoreholeExtractor:
             sidebars_noise.extend(protocol_sidebars_noise)
 
         # assign all sidebar to their best match
-        material_descriptions_sidebar_pairs = self._match_sidebars_to_description_rects(sidebars_noise)
-        candidates = []
-        for pair in material_descriptions_sidebar_pairs:
-            if borehole := self._create_borehole_from_pair(pair):
-                candidates.append(BoreholeCandidate.from_pair(borehole, pair))
-        return candidates
+        return self._match_sidebars_to_description_rects(sidebars_noise)
 
     def _find_all_material_description_candidates(self, sidebar: Sidebar | None) -> list[pymupdf.Rect]:
         """Find all material description candidates on the page.
@@ -524,30 +515,29 @@ class BoreholeExtractor:
             candidate_rects.append(pymupdf.Rect(best_x0, best_y0, best_x1, best_y1))
         return candidate_rects
 
-    def _find_material_description_column(self, sidebar: Sidebar | None) -> pymupdf.Rect | None:
-        """Find the best material description column for a given depth column.
+    def _find_borehole_candidate(self, sidebar: Sidebar | None) -> BoreholeCandidate | None:
+        """Create a borehole candidate by finding the best material description column for a given depth column.
 
         Args:
             sidebar (Sidebar | None): The sidebar to be associated with the material descriptions.
 
         Returns:
-            pymupdf.Rect | None: The material description column.
+            BoreholeCandidate | None: The selected borehole candidate (if any).
         """
-        candidate_rects = self._find_all_material_description_candidates(sidebar)
+        candidate_boreholes = []
+        for rect in self._find_all_material_description_candidates(sidebar):
+            pair = MaterialDescriptionRectWithSidebar(sidebar=sidebar, material_description_rect=rect)
+            if borehole := self._create_borehole_from_pair(pair):
+                candidate_boreholes.append(BoreholeCandidate.from_pair(borehole, pair))
 
-        if len(candidate_rects) == 0:
+        if len(candidate_boreholes) == 0:
             return None
         if sidebar:
-            return max(
-                candidate_rects,
-                key=lambda rect: MaterialDescriptionRectWithSidebar(sidebar, rect, self.lines).score_match,
-            )
+            return max(candidate_boreholes, key=lambda candidate: candidate.score)
         else:
-            return candidate_rects[0]
+            return candidate_boreholes[0]
 
-    def _match_sidebars_to_description_rects(
-        self, sidebars_noise: list[SidebarNoise]
-    ) -> list[MaterialDescriptionRectWithSidebar]:
+    def _match_sidebars_to_description_rects(self, sidebars_noise: list[SidebarNoise]) -> list[BoreholeCandidate]:
         """Matches sidebar objects to material description rectangles based on score.
 
         The algorithm performs greedy matching: each sidebar is paired with the material description rectangle that
@@ -559,82 +549,45 @@ class BoreholeExtractor:
             sidebars_noise (List[SidebarNoise]): List of sidebar objects to match.
 
         Returns:
-            List[MaterialDescriptionRectWithSidebar]: List of matched pairs.
+            List[BoreholeCandidate]: List of candidate boreholes constructed from matched pairs.
         """
-        # Store all possible matched rect with the associate scores in a dictionary: (s_idx, rect) -> score
-        score_map = {
-            (s_idx, rect): MaterialDescriptionRectWithSidebar(sn.sidebar, rect, self.lines, sn.noise_count).score_match
-            for s_idx, sn in enumerate(sidebars_noise)
-            for rect in self._find_all_material_description_candidates(sn.sidebar)
-        }
+        sidebar_boreholes: dict[int, list[BoreholeCandidate]] = dict()
 
-        matched_pairs = []
+        for sidebar_index, sn in enumerate(sidebars_noise):
+            candidate_boreholes = []
+            for rect in self._find_all_material_description_candidates(sn.sidebar):
+                pair = MaterialDescriptionRectWithSidebar(sn.sidebar, rect, sn.noise_count)
+                if borehole := self._create_borehole_from_pair(pair):
+                    candidate_boreholes.append(BoreholeCandidate.from_pair(borehole, pair))
+
+            sidebar_boreholes[sidebar_index] = candidate_boreholes
+
+        selected_boreholes = []
         used_sidebars_idx = set()
-        used_descr_rects = set()
 
-        def is_valid_pair(
-            s_idx: int,
-            mat_desc_rect: pymupdf.Rect,
-            used_sidebars_idx: set[int],
-            sidebars_noise: list[SidebarNoise],
-            matched_pairs: list[MaterialDescriptionRectWithSidebar],
-        ) -> bool:
-            """Check if a sidebar index and material description rectangle can form a valid pair.
+        def no_intersection(candidate: BoreholeCandidate, selected_boreholes: list[BoreholeCandidate]) -> bool:
+            """Check if the bounding boxes of the candidate do not intersect with selected candidates."""
+            joined_rect = candidate.sidebar.rect | candidate.material_description_rect
 
-            A pair is valid if:
-            - The sidebar index has not been used yet.
-            - The rectangle has not been used yet.
-            - The potential pair does not have an already matched sidebar or rectangle between its elements.
-            """
-            joined_rect = joined_rect = sidebars_noise[s_idx].sidebar.rect | mat_desc_rect
-
-            return (
-                s_idx not in used_sidebars_idx  # don't re-match an already matched sidebar
-                and all(
-                    (joined_rect & (pair.sidebar.rect | pair.material_description_rect)).is_empty
-                    for pair in matched_pairs
-                )  # don't allow taking the same rect or crossing pairs (pair having another pair element in between)
-            )
+            return all(
+                (joined_rect & (other_candidate.sidebar.rect | other_candidate.material_description_rect)).is_empty
+                for other_candidate in selected_boreholes
+            )  # don't allow taking the same rect or crossing pairs (pair having another pair element in between)
 
         # Step 1: Greedy match based on max scores
-        while True:
-            # Filter available scores
-            available_scores = {
-                (s_idx, rect): v
-                for (s_idx, rect), v in score_map.items()
-                if is_valid_pair(s_idx, rect, used_sidebars_idx, sidebars_noise, matched_pairs)
-            }
-            if not available_scores:
-                break
-
+        while available_boreholes := [
+            (sidebar_index, sidebar_boreholes[sidebar_index][borehole_index])
+            for sidebar_index, boreholes_for_sidebar in sidebar_boreholes.items()
+            if sidebar_index not in used_sidebars_idx
+            for borehole_index, candidate in enumerate(boreholes_for_sidebar)
+            if no_intersection(candidate, selected_boreholes)
+        ]:
             # Get best available match
-            (best_sidebar_idx, best_rect), _ = max(available_scores.items(), key=lambda x: x[1])
-            matched_pairs.append(
-                MaterialDescriptionRectWithSidebar(
-                    sidebars_noise[best_sidebar_idx].sidebar,
-                    best_rect,
-                    self.lines,
-                    sidebars_noise[best_sidebar_idx].noise_count,
-                )
-            )
-            used_sidebars_idx.add(best_sidebar_idx)
-            used_descr_rects.add(best_rect)
+            best_sidebar_index, best_borehole = max(available_boreholes, key=lambda pair: pair[1].score)
+            selected_boreholes.append(best_borehole)
+            used_sidebars_idx.add(best_sidebar_index)
 
-        # Step 2: Assign remaining sidebars (if any) to best match (reuse descr_rects)
-        remaining_sidebars_idx = [s_idx for s_idx in range(len(sidebars_noise)) if s_idx not in used_sidebars_idx]
-        for s_idx in remaining_sidebars_idx:
-            sidebar = sidebars_noise[s_idx].sidebar
-            noise = sidebars_noise[s_idx].noise_count
-            mat_rects = self._find_all_material_description_candidates(sidebar)
-            if not mat_rects:
-                continue
-            best_rect = max(
-                mat_rects,
-                key=lambda rect: MaterialDescriptionRectWithSidebar(sidebar, rect, self.lines, noise).score_match,
-            )
-            matched_pairs.append(MaterialDescriptionRectWithSidebar(sidebar, best_rect, self.lines, noise))
-
-        return matched_pairs
+        return selected_boreholes
 
     def get_diagonals_near_textlines(
         self, description_lines: list[TextLine], line_detection_params: dict
@@ -681,15 +634,7 @@ class BoreholeExtractor:
         """
         # only allow sidebar=None fallback if strong evidence exists
         if self._allow_description_only_fallback():
-            material_description_rect_without_sidebar = self._find_material_description_column(sidebar=None)
-            if material_description_rect_without_sidebar:
-                pair = MaterialDescriptionRectWithSidebar(
-                    sidebar=None,
-                    material_description_rect=material_description_rect_without_sidebar,
-                    lines=self.lines,
-                )
-                if borehole := self._create_borehole_from_pair(pair):
-                    return BoreholeCandidate.from_pair(borehole, pair)
+            return self._find_borehole_candidate(sidebar=None)
         else:
             logger.debug(
                 "Page %s: skipping description-only fallback (insufficient evidence)",

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -379,7 +379,11 @@ class BoreholeExtractor:
             def check_y0_condition(y0):
                 return True
 
-        horizontal_text_lines = [line for line in self.lines if line.rect.width > line.rect.height]
+        horizontal_text_lines = [
+            line
+            for line in self.lines
+            if line.rect.width > line.rect.height and not re.fullmatch(r"[\d\s.,\-/]+", line.text.strip())
+        ]
         candidate_description = [line for line in horizontal_text_lines if check_y0_condition(line.rect.y0)]
 
         is_not_description = [
@@ -492,12 +496,11 @@ class BoreholeExtractor:
                         desc_line
                         for desc_line in sorted_above
                         if is_above(best_x0, best_y0, desc_line)
-                        and not re.fullmatch(r"[\d\s.,\-/]+", desc_line.text.strip())
                         and (
                             sidebar is not None
                             or not any(
                                 other
-                                for other in horizontal_text_lines
+                                for other in candidate_description
                                 if other is not desc_line
                                 and abs(other.rect.y0 - desc_line.rect.y0) < desc_line.rect.height
                                 and (other.rect.x1 < best_x0 - 10 or other.rect.x0 > best_x1 + 10)

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 
 
 class BoreholeExtractor:
-    """Class with methods to extract boreholes by combining a optional sidebar with a material description rect."""
+    """Class with methods to extract boreholes by combining an optional sidebar with a material description rect."""
 
     def __init__(
         self,

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 
 
 class BoreholeExtractor:
-    """Class with methods to extract pairs of a material description rect with a corresponding sidebar."""
+    """Class with methods to extract boreholes by combining a optional sidebar with a material description rect."""
 
     def __init__(
         self,
@@ -576,12 +576,8 @@ class BoreholeExtractor:
 
         def no_intersection(candidate: BoreholeCandidate, selected_boreholes: list[BoreholeCandidate]) -> bool:
             """Check if the bounding boxes of the candidate do not intersect with selected candidates."""
-            joined_rect = candidate.sidebar.rect | candidate.material_description_rect
-
-            return all(
-                (joined_rect & (other_candidate.sidebar.rect | other_candidate.material_description_rect)).is_empty
-                for other_candidate in selected_boreholes
-            )  # don't allow taking the same rect or crossing pairs (pair having another pair element in between)
+            joined_rect = candidate.bounding_box
+            return all((joined_rect & other_candidate.bounding_box).is_empty for other_candidate in selected_boreholes)
 
         # Step 1: Greedy match based on max scores
         while available_boreholes := [

--- a/src/extraction/features/stratigraphy/borehole_candidate.py
+++ b/src/extraction/features/stratigraphy/borehole_candidate.py
@@ -1,0 +1,34 @@
+"""Module containing a dataclass for scored candidate boreholes."""
+
+from dataclasses import dataclass
+
+import pymupdf
+
+from extraction.features.stratigraphy.layer.layer import ExtractedBorehole
+from extraction.features.stratigraphy.layer.page_bounding_boxes import MaterialDescriptionRectWithSidebar
+from extraction.features.stratigraphy.sidebar.classes.sidebar import Sidebar
+
+
+@dataclass
+class BoreholeCandidate:
+    """Dataclass for a potential borehole created from a material description rect and optional sidebar."""
+
+    borehole: ExtractedBorehole
+    material_description_rect: pymupdf.Rect
+    sidebar: Sidebar | None
+    score: float
+
+    @property
+    def bounding_box(self) -> pymupdf.Rect:
+        """Creates a bounding box around the candidate.
+
+        The box is the union of the material description rect and the sidebar rect (if present).
+        """
+        bbox = self.material_description_rect
+        if self.sidebar:
+            bbox = bbox | self.sidebar.rect
+        return bbox
+
+    @classmethod
+    def from_pair(cls, borehole: ExtractedBorehole, pair: MaterialDescriptionRectWithSidebar) -> "BoreholeCandidate":
+        return BoreholeCandidate(borehole, pair.material_description_rect, pair.sidebar, pair.score_match)

--- a/src/extraction/features/stratigraphy/borehole_candidate.py
+++ b/src/extraction/features/stratigraphy/borehole_candidate.py
@@ -31,8 +31,12 @@ class BoreholeCandidate:
 
     @classmethod
     def from_pair(cls, borehole: ExtractedBorehole, pair: MaterialDescriptionRectWithSidebar) -> "BoreholeCandidate":
-        layers_with_description = sum(1 for layer in borehole.predictions if len(layer.material_description.text) > 0)
-        layer_count_score = (1 - 1 / (1 + layers_with_description)) ** 2
+        layers_without_description = sum(
+            1 for layer in borehole.predictions if len(layer.material_description.text) == 0
+        )
+        layers_without_description_penalty = 1 / (1 + layers_without_description)
 
-        score = pair.score_match * layer_count_score
+        description_length_score = sum([len(layer.material_description.text) for layer in borehole.predictions])
+
+        score = pair.score_match * layers_without_description_penalty * description_length_score
         return BoreholeCandidate(borehole, pair.material_description_rect, pair.sidebar, score)

--- a/src/extraction/features/stratigraphy/borehole_candidate.py
+++ b/src/extraction/features/stratigraphy/borehole_candidate.py
@@ -31,12 +31,10 @@ class BoreholeCandidate:
 
     @classmethod
     def from_pair(cls, borehole: ExtractedBorehole, pair: MaterialDescriptionRectWithSidebar) -> "BoreholeCandidate":
-        layers_without_description = sum(
-            1 for layer in borehole.predictions if len(layer.material_description.text) == 0
-        )
+        layers_without_description = sum(1 for layer in borehole.predictions if not layer.description_nonempty())
         layers_without_description_penalty = 1 / (1 + layers_without_description)
 
-        description_lines_score = sum([len(layer.material_description.lines) for layer in borehole.predictions])
+        description_lines_score = sum(len(layer.material_description.lines) for layer in borehole.predictions)
 
         score = pair.score_match * layers_without_description_penalty * description_lines_score
-        return BoreholeCandidate(borehole, pair.material_description_rect, pair.sidebar, score)
+        return cls(borehole, pair.material_description_rect, pair.sidebar, score)

--- a/src/extraction/features/stratigraphy/borehole_candidate.py
+++ b/src/extraction/features/stratigraphy/borehole_candidate.py
@@ -31,4 +31,8 @@ class BoreholeCandidate:
 
     @classmethod
     def from_pair(cls, borehole: ExtractedBorehole, pair: MaterialDescriptionRectWithSidebar) -> "BoreholeCandidate":
-        return BoreholeCandidate(borehole, pair.material_description_rect, pair.sidebar, pair.score_match)
+        layers_with_description = sum(1 for layer in borehole.predictions if len(layer.material_description.text) > 0)
+        layer_count_score = (1 - 1 / (1 + layers_with_description)) ** 2
+
+        score = pair.score_match * layer_count_score
+        return BoreholeCandidate(borehole, pair.material_description_rect, pair.sidebar, score)

--- a/src/extraction/features/stratigraphy/borehole_candidate.py
+++ b/src/extraction/features/stratigraphy/borehole_candidate.py
@@ -36,7 +36,7 @@ class BoreholeCandidate:
         )
         layers_without_description_penalty = 1 / (1 + layers_without_description)
 
-        description_length_score = sum([len(layer.material_description.text) for layer in borehole.predictions])
+        description_lines_score = sum([len(layer.material_description.lines) for layer in borehole.predictions])
 
-        score = pair.score_match * layers_without_description_penalty * description_length_score
+        score = pair.score_match * layers_without_description_penalty * description_lines_score
         return BoreholeCandidate(borehole, pair.material_description_rect, pair.sidebar, score)

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -185,8 +185,8 @@ def _is_duplicate(cur_text: str, prev_text: str, threshold: float, is_extremity:
     if is_extremity:
         min_length = min(len(cur_text), len(prev_text))
         score = max(
-            Levenshtein.ratio(cur_text, prev_text[-min_length:]),
-            Levenshtein.ratio(cur_text[:min_length], prev_text),
+            Levenshtein.ratio(cur_text, prev_text[:min_length]),
+            Levenshtein.ratio(cur_text[-min_length:], prev_text),
         )
     else:
         score = Levenshtein.ratio(cur_text, prev_text)

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -185,8 +185,8 @@ def _is_duplicate(cur_text: str, prev_text: str, threshold: float, is_extremity:
     if is_extremity:
         min_length = min(len(cur_text), len(prev_text))
         score = max(
-            Levenshtein.ratio(cur_text, prev_text[:min_length]),
-            Levenshtein.ratio(cur_text[-min_length:], prev_text),
+            Levenshtein.ratio(cur_text, prev_text[-min_length:]),
+            Levenshtein.ratio(cur_text[:min_length], prev_text),
         )
     else:
         score = Levenshtein.ratio(cur_text, prev_text)

--- a/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
+++ b/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
@@ -27,6 +27,7 @@ class MaterialDescriptionRectWithSidebar:
           left-hand-side of) the material descriptions
         - positively influenced by the height of the sidebar
         - negatively influenced by vertical distance between the top of the sidebar and the top of the material
+          descriptions, and the vertical distance between the bottom of the sidebar and the bottom of the material
           descriptions
         The resulting score is also reduced if the sidebar has a high noise count (many unrelated tokens in between
         the extracted depths values).
@@ -39,20 +40,15 @@ class MaterialDescriptionRectWithSidebar:
         if not self.sidebar:
             return 0.0
         rect = self.sidebar.rect
-        sidebar_top, sidebar_bottom, sidebar_left, sidebar_right = rect.y0, rect.y1, rect.x0, rect.x1
-        material_left, material_right = self.material_description_rect.x0, self.material_description_rect.x1
-        material_top = self.material_description_rect.y0
+        sidebar_top, sidebar_bottom, sidebar_right = rect.y0, rect.y1, rect.x1
+        material_left = self.material_description_rect.x0
+        material_top, material_bottom = self.material_description_rect.y0, self.material_description_rect.y1
         x_distance = abs(sidebar_right - material_left)
-        y_distance = abs(sidebar_top - material_top)
+        y_distance = abs(sidebar_top - material_top) + abs(sidebar_bottom - material_bottom)
+
         height = sidebar_bottom - sidebar_top
-        sidebar_right_of_descriptions_penalty = max(0, sidebar_left - material_right)
-        geometry_score = (
-            self.material_description_rect.width
-            - x_distance
-            + height
-            - 2 * y_distance
-            - 10 * sidebar_right_of_descriptions_penalty
-        )
+
+        geometry_score = self.material_description_rect.width - 1.64 * x_distance + height - 2 * y_distance
 
         noise_penalty_multiplier = math.pow(0.8, 10 * self.noise_count / len(self.sidebar.entries))
 

--- a/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
+++ b/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
@@ -5,10 +5,9 @@ from dataclasses import dataclass
 
 import pymupdf
 
+from extraction.features.stratigraphy.sidebar.classes.a_above_b_sidebar import AAboveBSidebar
 from extraction.features.stratigraphy.sidebar.classes.sidebar import Sidebar
 from swissgeol_doc_processing.geometry.geometry_dataclasses import BoundingBox
-from swissgeol_doc_processing.text.find_description import get_description_lines
-from swissgeol_doc_processing.text.textline import TextLine
 
 
 @dataclass
@@ -17,7 +16,6 @@ class MaterialDescriptionRectWithSidebar:
 
     sidebar: Sidebar | None
     material_description_rect: pymupdf.Rect
-    lines: list[TextLine]
     noise_count: int = 0
 
     @property
@@ -30,9 +28,7 @@ class MaterialDescriptionRectWithSidebar:
           left-hand-side of) the material descriptions
         - positively influenced by the height of the sidebar
         - negatively influenced by vertical distance between the top of the sidebar and the top of the material
-          descriptions, and the vertical distance between the bottom of the sidebar and the bottom of the material
           descriptions
-        - positively influenced by the number of text lines contained in the material description rectangle
         The resulting score is also reduced if the sidebar has a high noise count (many unrelated tokens in between
         the extracted depths values).
 
@@ -44,23 +40,24 @@ class MaterialDescriptionRectWithSidebar:
         if not self.sidebar:
             return 0.0
         rect = self.sidebar.rect
-        sidebar_top, sidebar_bottom, sidebar_right = rect.y0, rect.y1, rect.x1
-        material_left = self.material_description_rect.x0
-        material_top, material_bottom = self.material_description_rect.y0, self.material_description_rect.y1
+        sidebar_top, sidebar_bottom, sidebar_left, sidebar_right = rect.y0, rect.y1, rect.x0, rect.x1
+        material_left, material_right = self.material_description_rect.x0, self.material_description_rect.x1
+        material_top = self.material_description_rect.y0
         x_distance = abs(sidebar_right - material_left)
-        y_distance = abs(sidebar_top - material_top) + abs(sidebar_bottom - material_bottom)
-
+        y_distance = abs(sidebar_top - material_top)
         height = sidebar_bottom - sidebar_top
+        geometry_score = self.material_description_rect.width - x_distance + height - 2 * y_distance
 
-        geometry_score = self.material_description_rect.width - 1.64 * x_distance + height - 2 * y_distance
+        if sidebar_left > material_left and (
+            not isinstance(self.sidebar, AAboveBSidebar) or material_right <= sidebar_left - self.sidebar.rect.width
+        ):
+            # sidebar to the right of descriptions is only allowed for AAboveBSidebar and the descriptions should not
+            # be far to the left of the sidebar
+            return -1
 
         noise_penalty_multiplier = math.pow(0.8, 10 * self.noise_count / len(self.sidebar.entries))
 
-        description_lines = get_description_lines(self.lines, self.material_description_rect)
-        # Increases from 0 (for 0 lines) and converges to 1 (for infinite number of lines)
-        num_lines_score = 1 - 1 / (1 + len(description_lines))
-
-        return geometry_score * num_lines_score * noise_penalty_multiplier
+        return geometry_score * noise_penalty_multiplier
 
 
 @dataclass

--- a/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
+++ b/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
@@ -57,9 +57,10 @@ class MaterialDescriptionRectWithSidebar:
         noise_penalty_multiplier = math.pow(0.8, 10 * self.noise_count / len(self.sidebar.entries))
 
         description_lines = get_description_lines(self.lines, self.material_description_rect)
-        num_lines_score = len(description_lines)
+        # Increases from 0 (for 0 lines) and converges to 1 (for infinite number of lines)
+        num_lines_score = 1 - 1 / (1 + len(description_lines))
 
-        return (geometry_score + num_lines_score) * noise_penalty_multiplier
+        return geometry_score * num_lines_score * noise_penalty_multiplier
 
 
 @dataclass

--- a/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
+++ b/src/extraction/features/stratigraphy/layer/page_bounding_boxes.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 
 import pymupdf
 
-from extraction.features.stratigraphy.sidebar.classes.a_above_b_sidebar import AAboveBSidebar
 from extraction.features.stratigraphy.sidebar.classes.sidebar import Sidebar
 from swissgeol_doc_processing.geometry.geometry_dataclasses import BoundingBox
 
@@ -46,14 +45,14 @@ class MaterialDescriptionRectWithSidebar:
         x_distance = abs(sidebar_right - material_left)
         y_distance = abs(sidebar_top - material_top)
         height = sidebar_bottom - sidebar_top
-        geometry_score = self.material_description_rect.width - x_distance + height - 2 * y_distance
-
-        if sidebar_left > material_left and (
-            not isinstance(self.sidebar, AAboveBSidebar) or material_right <= sidebar_left - self.sidebar.rect.width
-        ):
-            # sidebar to the right of descriptions is only allowed for AAboveBSidebar and the descriptions should not
-            # be far to the left of the sidebar
-            return -1
+        sidebar_right_of_descriptions_penalty = max(0, sidebar_left - material_right)
+        geometry_score = (
+            self.material_description_rect.width
+            - x_distance
+            + height
+            - 2 * y_distance
+            - 10 * sidebar_right_of_descriptions_penalty
+        )
 
         noise_penalty_multiplier = math.pow(0.8, 10 * self.noise_count / len(self.sidebar.entries))
 

--- a/src/extraction/minimal_pipeline.py
+++ b/src/extraction/minimal_pipeline.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 import pymupdf
 from dotenv import load_dotenv
 
-from extraction.features.extract import MaterialDescriptionRectWithSidebarExtractor
+from extraction.features.extract import BoreholeExtractor
 from extraction.features.metadata.borehole_name_extraction import extract_borehole_names
 from extraction.features.stratigraphy.sidebar.classes.sidebar import SidebarQualityMetrics
 from swissgeol_doc_processing.geometry.geometry_dataclasses import Line
@@ -182,7 +182,7 @@ def extract_page_features(
     number_of_valid_borehole_descriptions = len(valid_descriptions)
 
     # Extract sidebar information
-    sidebar_information = MaterialDescriptionRectWithSidebarExtractor(
+    sidebar_information = BoreholeExtractor(
         extraction_context.text_lines,
         extraction_context.long_or_horizontal_lines,
         extraction_context.all_geometric_lines,
@@ -198,7 +198,7 @@ def extract_page_features(
     ).extract_sidebars_with_quality_metrics()
 
     if extract_boreholes:
-        extracted_boreholes = MaterialDescriptionRectWithSidebarExtractor(
+        extracted_boreholes = BoreholeExtractor(
             extraction_context.text_lines,
             extraction_context.long_or_horizontal_lines,
             extraction_context.all_geometric_lines,


### PR DESCRIPTION
We introduce a new BoreholeCandidate helper class which contains:
- a material description bounding box
- an optional sidebar
- an extracted borehole derived from those
- a score

Previously, we would do a lot of computation with just the first two (a pair of material description bounding box and an optional sidebar), only deriving the extracted borehole later on. While this in some cases reduced the amount of computation required (creating a borehole from a material description - sidebar pair needs to be computed less frequently when we do more filtering purely based on the material description - sidebar pair), the new approach has several advantages:
- simpler code
- more efficiency in other ways (e.g. reduced redundant computation of matching scores; no need for having a list of all lines when computing matching scores)
- filtering works more robustly when applied directly on the candidate boreholes (e.g. we avoid filtering away a valid material description - sidebar pair, when there is an overlap with another higher-scoring pair, but then this second pair later on might get rejected after all when deriving the extracted borehole form it)
- more possibilities for more accurate scoring of the best candidate boreholes (e.g. we can now take into account the layers of the derived borehole)

There is a also a small change to the logic for expanding the material description bounding box above and below. Text lines that only contain numeric values, no words, are now filtered out earlier on in the relevant method, leading to more consistent behaviour.

**Impact on benchmarking: Zurich**
Layer F1 score improves by 0.1% from 84.5% to 84.6%. On other metrics either a similarly small improvement, or no change at all.

Minor changes on the following files:
- `268124125-bp.pdf` (small change on handwritten file which has bad-quality results anyway)
- `681249142-bp.pdf` (better accuracy due to numbers no longer being included as candidate lines for material description rect expansion)
- `690251013-bp.pdf` (a different second (false-positive) extracted borehole)
- `695265009-bp.pdf` (better accuracy due to numbers no longer being included as candidate lines for material description rect expansion)
- `695265010-bp.pdf` (one fewer false-positive borehole due to numbers no longer being included as candidate lines for material description rect expansion)

**Impact on benchmarking: Geoquat**
No noticeable impact on overall benchmarking scores.

Minor changes on the following files:
- `1506.pdf` (AAboveBSidebar wins over IndicatorSidebar due to small changes in scoring, will probably change back again with a proper solution for #512 )
- `A1011.pdf` (better accuracy due to numbers no longer being included as candidate lines for material description rect expansion)
- `A11406.pdf` (different material descriptions rects selected on page 1 and 3; neither result is great)
- `A1287.pdf` and `A1290.pdf` (header "Klassifikation" is now incorrectly included in the material description rect, as a consequence of filtering out numbers earlier on in the method; this should be fixed with a proper solution for #512 )
- `B147.pdf` (page 2) and `B169.pdf` (minor changes on low quality scans that have pretty bad results anyway)
- `V69.pdf` (missing description line is no longer skipped)