### PR TITLE
Return and evaluate layers without material description

### DIFF
--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -54,19 +54,14 @@ class LayerEvaluator:
             Metrics: Aggregated material metrics across all boreholes.
         """
 
-        def per_layer_action(layer: Layer):
-            if parse_text(layer.material_description.text) == "":
-                logger.warning("Empty string found in predictions")
-
         def num_ground_truth_fn(ground_truth_layers: list[GroundTruthLayer]):
             return sum(lay.material_description is not None for lay in ground_truth_layers)
 
         return LayerEvaluator.calculate_metrics(
             file_predictions=file_predictions,
             num_ground_truth_fn=num_ground_truth_fn,
-            per_layer_filter=lambda layer: True,
+            per_layer_filter=lambda layer: layer.description_nonempty(),
             per_layer_condition=lambda layer: layer.material_description.is_correct,
-            per_layer_action=per_layer_action,
         )
 
     @staticmethod
@@ -96,7 +91,6 @@ class LayerEvaluator:
         num_ground_truth_fn: Callable[[list[GroundTruthLayer]], int],
         per_layer_filter: Callable[[Layer], bool],
         per_layer_condition: Callable[[Layer], bool],
-        per_layer_action: Callable[[Layer], None] | None = None,
     ) -> Metrics:
         """Calculate metrics based on a condition per layer, after applying a filter.
 
@@ -106,7 +100,6 @@ class LayerEvaluator:
                 ground truth.
             per_layer_filter (Callable[[Layer], bool]): Function to filter layers to consider.
             per_layer_condition (Callable[[Layer], bool]): Function that returns True if the layer is a hit.
-            per_layer_action (Optional[Callable[[Layer], None]]): Optional action to perform per layer.
 
         Returns:
             Metrics: The calculated metrics.
@@ -122,8 +115,6 @@ class LayerEvaluator:
 
             layers = borehole_data.layers.layers if borehole_data.layers else []
             for layer in layers:
-                if per_layer_action:
-                    per_layer_action(layer)
                 if per_layer_filter(layer):
                     total_predictions += 1
                     if per_layer_condition(layer):
@@ -187,9 +178,10 @@ class LayerEvaluator:
                 LayerEvaluator.apply_mapping(
                     borehole_data.ground_truth, predicted_layers, score_depths, set_depths_flag
                 )
+                # Only consider predicted layers with a description when scoring the material descriptions
                 LayerEvaluator.apply_mapping(
                     borehole_data.ground_truth,
-                    predicted_layers,
+                    [layer for layer in predicted_layers if layer.description_nonempty()],
                     score_material_descriptions,
                     set_material_description_flag,
                 )

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -125,15 +125,7 @@ class BoreholeExtractor:
             # constructed valid boreholes
             valid_candidates.append(candidate_without_sidebar)
 
-        # Only return layers with nonempty description for the time being, for the sake of consistency.
-        # TODO After verifying the impact on benchmarking scores, we should also return layers without description.
-        return [
-            ExtractedBorehole(
-                [layer for layer in candidate.borehole.predictions if layer.description_nonempty()],
-                candidate.borehole.bounding_boxes,
-            )
-            for candidate in valid_candidates
-        ]
+        return [candidate.borehole for candidate in valid_candidates]
 
     def _contained_in_table_index(
         self, pair: MaterialDescriptionRectWithSidebar, table_structures: list[TableStructure], proximity_buffer: float

--- a/src/extraction/features/stratigraphy/sidebar/classes/layer_identifier_sidebar.py
+++ b/src/extraction/features/stratigraphy/sidebar/classes/layer_identifier_sidebar.py
@@ -178,7 +178,7 @@ class LayerIdentifierSidebar(Sidebar[LayerIdentifierEntry]):
                 if not start_depth:
                     start_depth = a_to_b_interval.start.value
                 if a_to_b_interval.start.value >= start_depth:
-                    if current_interval:
+                    if current_interval and current_block:
                         entries.append(IntervalBlockPair(current_interval, TextBlock(current_block)))
                         current_block = []
                     current_interval = a_to_b_interval

--- a/src/extraction/features/stratigraphy/sidebar/classes/layer_identifier_sidebar.py
+++ b/src/extraction/features/stratigraphy/sidebar/classes/layer_identifier_sidebar.py
@@ -175,7 +175,7 @@ class LayerIdentifierSidebar(Sidebar[LayerIdentifierEntry]):
             if a_to_b_interval:
                 # We assume that the first depth encountered is the start depth, and we reject further depth values
                 # smaller than this first one. This avoids some false positives (e.g. GeoQuat 3339.pdf).
-                if not start_depth:
+                if start_depth is None:
                     start_depth = a_to_b_interval.start.value
                 if a_to_b_interval.start.value >= start_depth:
                     if current_interval and current_block:


### PR DESCRIPTION
(PR based on https://github.com/swisstopo/swissgeol-boreholes-dataextraction/pull/521)

Until now, we removed layers without a material description before returning an extracted borehole. This could lead to gaps in the sequence of depth intervals. For the end-user, it actually makes more sense to return the full list of depth intervals, even when some intervals don't have an associated description, as just fixing missing description is easier than inserting new intervals from scratch. Therefore, we now also allow layers without description in the extraction output.

Keeping layers without material description also has some impact on the benchmarking metrics.
- The material description scores remains unchanged, since we still ignore extracted layers without a material description when evaluating these metrics.
- The depth interval scores for individual files sometimes go down, but sometimes go up as well (the depths for an extracted layer without material description might actually be correct).
- The layer scores for affected files always go down, but never by much (there are never many extracted layers without material description).

Overall, the new scores should be considered to be a more accurate representation of the actual accuracy, rather than as an actual change in extraction quality.

The PR also fixes a small oversight in the logic for indicator sidebars.

**Effect on Zurich benchmark**
- Layer F1: 84.57% -> 84.43%
- Depth interval F1: 89.55% -> 89.54%
- Material description F1: unchanged at 88.42%

Minor drop in layer F1 score due to extracted layers without material description in the following files:
- 267125294-bp.pdf
- 267125338-bp.pdf
- 268124232-bp.pdf
- 268124570-bp.pdf
- 268124613-bp.pdf
- 675244002-bp.pdf
- 675246002-bp.pdf
- 681249142-bp.pdf
- 683248005-bp.pdf
- 695265009-bp.pdf
- 699243001-bp.pdf

**Effect on Geoquat benchmark**
- Layer F1: 48.92% -> 48.79%
- Depth interval F1: 63.54% -> 63.63%
- Material description F1: unchanged at 63.96%

Minor drop in layer F1 score due to extracted layers without material description in the following files:
- A1025.pdf
- A11370.pdf
- A11406.pdf
- A11430.pdf
- A11452.pdf
- A1207.pdf
- A1227.pdf
- A1304.pdf
- A170.pdf
- A7229.pdf
- AKB_137.pdf
- B579.pdf
- V141.pdf