### PR TITLE
add borehole type and purpose to ground truth

### DIFF
--- a/src/core/ground_truth.py
+++ b/src/core/ground_truth.py
@@ -87,6 +87,8 @@ class GroundTruthMetadata(BaseModel):
 
     model_config = {"extra": "forbid"}
     coordinates: GroundTruthCoordinates | None = None
+    borehole_type: str | None = None
+    borehole_purpose: str | None = None
     drilling_date: str | None = None
     drilling_methods: list[str] | None = None
     original_name: str | None = None


### PR DESCRIPTION
Small fix that avoid an error when using new ground truth files that contain new properties `borehole_type` and `borehole_purpose`. 