### PR TITLE
More robust continuation detection 

### DIFF
--- a/src/extraction/core/extract.py
+++ b/src/extraction/core/extract.py
@@ -14,17 +14,18 @@ from extraction.features.groundwater.groundwater_extraction import (
     GroundwaterInDocument,
     GroundwaterLevelExtractor,
 )
-from extraction.features.metadata.borehole_name_extraction import NameInDocument, extract_borehole_names
+from extraction.features.metadata.borehole_name_extraction import BoreholeName, NameInDocument, extract_borehole_names
 from extraction.features.metadata.metadata import FileMetadata, MetadataInDocument
 from extraction.features.predictions.borehole_predictions import BoreholePredictions
 from extraction.features.predictions.file_predictions import FilePredictions
 from extraction.features.predictions.predictions import BoreholeListBuilder
 from extraction.features.stratigraphy.layer.continuation_detection import merge_boreholes
-from extraction.features.stratigraphy.layer.layer import LayersInDocument
+from extraction.features.stratigraphy.layer.layer import ExtractedBorehole, LayersInDocument
 from swissgeol_doc_processing.geometry.geometry_dataclasses import Line
 from swissgeol_doc_processing.geometry.line_detection import extract_lines
 from swissgeol_doc_processing.text.extract_text import extract_text_lines
 from swissgeol_doc_processing.text.matching_params_analytics import MatchingParamsAnalytics
+from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 from swissgeol_doc_processing.utils.file_utils import read_params
 from swissgeol_doc_processing.utils.strip_log_detection import StripLog, detect_strip_logs
 from swissgeol_doc_processing.utils.table_detection import TableStructure, detect_table_structures
@@ -36,6 +37,25 @@ table_detection_params = read_params("table_detection_params.yml")
 striplog_detection_params = read_params("striplog_detection_params.yml")
 
 logger = logging.getLogger(__name__)
+
+
+def _assign_borehole_names(
+    extracted_boreholes: list[ExtractedBorehole], name_entries: list[FeatureOnPage[BoreholeName]]
+) -> None:
+    """Attach the closest name candidate found on this same page to each borehole, if any were found.
+
+    A page essentially always has at most a couple of boreholes and name candidates, so matching by
+    vertical distance to the top of each borehole's column on this page is enough.
+
+    Args:
+        extracted_boreholes (list[ExtractedBorehole]): The boreholes just extracted from this page.
+        name_entries (list[FeatureOnPage[BoreholeName]]): The name candidates found on this same page.
+    """
+    if not name_entries:
+        return
+    for borehole in extracted_boreholes:
+        borehole_top = borehole.bounding_boxes[-1].get_outer_rect().y0
+        borehole.name = min(name_entries, key=lambda entry: abs(entry.rect.y0 - borehole_top))
 
 
 @dataclasses.dataclass
@@ -153,6 +173,7 @@ def extract(
                 analytics,
                 **matching_params,
             ).process_page()
+            _assign_borehole_names(extracted_boreholes, name_entries)
             boreholes_per_page.append(extracted_boreholes)
 
             # Extract the groundwater levels

--- a/src/extraction/features/stratigraphy/layer/continuation_detection.py
+++ b/src/extraction/features/stratigraphy/layer/continuation_detection.py
@@ -15,6 +15,21 @@ DEPTHS_QUANTILE_SLACK = 0.1
 MIN_NAME_CONFIDENCE = 0.5
 
 
+def _confident_names(borehole_a: ExtractedBorehole, borehole_b: ExtractedBorehole) -> tuple[str, str] | None:
+    """Return both boreholes' normalized printed names, if each was confidently detected, else None."""
+    if not (
+        borehole_a.name
+        and borehole_b.name
+        and borehole_a.name.feature.confidence >= MIN_NAME_CONFIDENCE
+        and borehole_b.name.feature.confidence >= MIN_NAME_CONFIDENCE
+    ):
+        return None
+    return (
+        _normalize_for_comparison(borehole_a.name.feature.name),
+        _normalize_for_comparison(borehole_b.name.feature.name),
+    )
+
+
 def _names_conflict(borehole_a: ExtractedBorehole, borehole_b: ExtractedBorehole) -> bool:
     """Check whether both boreholes have their own confidently detected name, and those names disagree.
 
@@ -29,16 +44,45 @@ def _names_conflict(borehole_a: ExtractedBorehole, borehole_b: ExtractedBorehole
     Returns:
         bool: True if both boreholes have a confidently detected name and those names disagree.
     """
-    if not (
-        borehole_a.name
-        and borehole_b.name
-        and borehole_a.name.feature.confidence >= MIN_NAME_CONFIDENCE
-        and borehole_b.name.feature.confidence >= MIN_NAME_CONFIDENCE
-    ):
-        return False
-    name_a = _normalize_for_comparison(borehole_a.name.feature.name)
-    name_b = _normalize_for_comparison(borehole_b.name.feature.name)
-    return name_a != name_b
+    names = _confident_names(borehole_a, borehole_b)
+    return names is not None and names[0] != names[1]
+
+
+def _names_match(borehole_a: ExtractedBorehole, borehole_b: ExtractedBorehole) -> bool:
+    """Check whether both boreholes have their own confidently detected name, and those names agree.
+
+    Args:
+        borehole_a (ExtractedBorehole): One of the two boreholes being considered for a merge.
+        borehole_b (ExtractedBorehole): The other borehole being considered for a merge.
+
+    Returns:
+        bool: True if both boreholes have a confidently detected name and those names agree.
+    """
+    names = _confident_names(borehole_a, borehole_b)
+    return names is not None and names[0] == names[1]
+
+
+def _select_boreholes_by_matching_name(
+    previous_page_boreholes: list[ExtractedBorehole], current_page_boreholes: list[ExtractedBorehole]
+) -> tuple[ExtractedBorehole | None, ExtractedBorehole | None]:
+    """Find a pair of boreholes across the page break whose confidently detected names agree.
+
+    A matching, confidently detected name on both sides is direct evidence of continuation, strong
+    enough to treat as a continuation even when the overlap/depth heuristics found no candidate at all.
+
+    Args:
+        previous_page_boreholes (list[ExtractedBorehole]): The boreholes than can potentially be extended.
+        current_page_boreholes (list[ExtractedBorehole]): The boreholes than can potentially be a continuation.
+
+    Returns:
+        tuple[ExtractedBorehole | None, ExtractedBorehole | None]:
+                A pair of boreholes, or (None, None) if no pair has a matching name.
+    """
+    for previous_borehole in previous_page_boreholes:
+        for current_borehole in current_page_boreholes:
+            if _names_match(previous_borehole, current_borehole):
+                return previous_borehole, current_borehole
+    return None, None
 
 
 def _reconcile_duplicated_boundary_layer(previous_layer: Layer, current_layer: Layer) -> Layer | None:
@@ -87,6 +131,7 @@ def _prepare_merge_candidates(
     If it finds overlapping boreholes, it identifies the duplicated layers and prepares the boreholes for
     merging by reconciling the boundary layers if necessary.
     If no overlap is detected, it falls back to depth/position-based matching.
+    If that also finds no candidate, it falls back to a matching, confidently-detected borehole name.
 
     Args:
         previous_page_boreholes (list[ExtractedBorehole]): List of boreholes from the previous page.
@@ -110,6 +155,13 @@ def _prepare_merge_candidates(
         # 2) Depth/position-based (returns a pair) → normalize to triple
         borehole_to_extend, borehole_continuation = _select_boreholes_for_concatenation(
             previous_page_boreholes, current_page_boreholes, page_number
+        )
+
+    if borehole_to_extend is None or borehole_continuation is None:
+        # 3) Neither of the above found a candidate: a matching, confidently-detected name on both
+        # sides is still direct evidence of continuation, even without overlap or depth continuity.
+        borehole_to_extend, borehole_continuation = _select_boreholes_by_matching_name(
+            previous_page_boreholes, current_page_boreholes
         )
 
     # A disagreeing, confidently-detected name on both sides overrides any of the above: it's direct

--- a/src/extraction/features/stratigraphy/layer/continuation_detection.py
+++ b/src/extraction/features/stratigraphy/layer/continuation_detection.py
@@ -5,10 +5,43 @@ import dataclasses
 import numpy as np
 
 from extraction.features.stratigraphy.layer.layer import ExtractedBorehole, Layer, LayerDepths, LayerDepthsEntry
-from extraction.features.stratigraphy.layer.overlap_detection import select_boreholes_with_overlap
+from extraction.features.stratigraphy.layer.overlap_detection import (
+    _normalize_for_comparison,
+    select_boreholes_with_overlap,
+)
 from swissgeol_doc_processing.text.textblock import MaterialDescription
 
 DEPTHS_QUANTILE_SLACK = 0.1
+MIN_NAME_CONFIDENCE = 0.5
+
+
+def _names_conflict(borehole_a: ExtractedBorehole, borehole_b: ExtractedBorehole) -> bool:
+    """Check whether both boreholes have their own confidently detected name, and those names disagree.
+
+    A borehole's own printed name is stronger evidence of identity than the layer text or depth
+    heuristics used elsewhere in this module: if both pages name their borehole and the names don't
+    match, they must be different boreholes, regardless of what those other heuristics conclude.
+    Names are short identifiers (e.g. "KB12" vs "KB13"), not prose, so unlike the fuzzy material
+    description matching elsewhere in this module, a single differing digit is a real conflict, not
+    noise - comparing for exact equality (after the same normalization) is the correct check here.
+
+    Args:
+        borehole_a (ExtractedBorehole): One of the two boreholes being considered for a merge.
+        borehole_b (ExtractedBorehole): The other borehole being considered for a merge.
+
+    Returns:
+        bool: True if both boreholes have a confidently detected name and those names disagree.
+    """
+    if not (
+        borehole_a.name
+        and borehole_b.name
+        and borehole_a.name.feature.confidence >= MIN_NAME_CONFIDENCE
+        and borehole_b.name.feature.confidence >= MIN_NAME_CONFIDENCE
+    ):
+        return False
+    name_a = _normalize_for_comparison(borehole_a.name.feature.name)
+    name_b = _normalize_for_comparison(borehole_b.name.feature.name)
+    return name_a != name_b
 
 
 def _reconcile_duplicated_boundary_layer(previous_layer: Layer, current_layer: Layer) -> Layer | None:
@@ -81,6 +114,11 @@ def _prepare_merge_candidates(
         borehole_to_extend, borehole_continuation = _select_boreholes_for_concatenation(
             previous_page_boreholes, current_page_boreholes, page_number
         )
+
+    # A disagreeing, confidently-detected name on both sides overrides any of the above: it's direct
+    # evidence these are two different boreholes, regardless of what the text/depth heuristics conclude.
+    if borehole_to_extend and borehole_continuation and _names_conflict(borehole_to_extend, borehole_continuation):
+        borehole_to_extend, borehole_continuation, overlap_result = None, None, None
 
     unaffected_boreholes_previous_page = [
         borehole for borehole in previous_page_boreholes if borehole is not borehole_to_extend
@@ -310,6 +348,7 @@ def _merge_boreholes(
         borehole_to_extend,
         predictions=new_predictions,
         bounding_boxes=borehole_to_extend.bounding_boxes + borehole_continuation.bounding_boxes,
+        name=borehole_to_extend.name or borehole_continuation.name,
     )
 
 

--- a/src/extraction/features/stratigraphy/layer/continuation_detection.py
+++ b/src/extraction/features/stratigraphy/layer/continuation_detection.py
@@ -258,9 +258,12 @@ def _is_continuation(
 
     ok_layers = [lay for lay in borehole_continuation.predictions if lay.depths is not None]
     depths = [d.value for lay in ok_layers for d in (lay.depths.start, lay.depths.end) if d is not None]
+    if not depths or not prev_depths:
+        # no depth values to compare on either side: without evidence, don't assume continuation
+        return False
     # use quantile to allow some slack (e.g. few undetected duplicated layers)
     # if depth values decrease, it must be a new borehole
-    return not (depths and prev_depths and depths[0] < np.quantile(prev_depths, 1 - DEPTHS_QUANTILE_SLACK))
+    return depths[0] >= np.quantile(prev_depths, 1 - DEPTHS_QUANTILE_SLACK)
 
 
 def _merge_boreholes(

--- a/src/extraction/features/stratigraphy/layer/continuation_detection.py
+++ b/src/extraction/features/stratigraphy/layer/continuation_detection.py
@@ -21,9 +21,6 @@ def _names_conflict(borehole_a: ExtractedBorehole, borehole_b: ExtractedBorehole
     A borehole's own printed name is stronger evidence of identity than the layer text or depth
     heuristics used elsewhere in this module: if both pages name their borehole and the names don't
     match, they must be different boreholes, regardless of what those other heuristics conclude.
-    Names are short identifiers (e.g. "KB12" vs "KB13"), not prose, so unlike the fuzzy material
-    description matching elsewhere in this module, a single differing digit is a real conflict, not
-    noise - comparing for exact equality (after the same normalization) is the correct check here.
 
     Args:
         borehole_a (ExtractedBorehole): One of the two boreholes being considered for a merge.

--- a/src/extraction/features/stratigraphy/layer/layer.py
+++ b/src/extraction/features/stratigraphy/layer/layer.py
@@ -4,11 +4,12 @@ from dataclasses import dataclass
 
 import pymupdf
 
+from extraction.features.metadata.borehole_name_extraction import BoreholeName
 from extraction.features.stratigraphy.interval.interval import Interval
 from extraction.features.stratigraphy.layer.page_bounding_boxes import PageBoundingBoxes
 from swissgeol_doc_processing.geometry.geometry_dataclasses import RectWithPage, RectWithPageMixin
 from swissgeol_doc_processing.text.textblock import MaterialDescription
-from swissgeol_doc_processing.utils.data_extractor import ExtractedFeature
+from swissgeol_doc_processing.utils.data_extractor import ExtractedFeature, FeatureOnPage
 from swissgeol_doc_processing.utils.file_utils import parse_text
 
 
@@ -255,6 +256,9 @@ class ExtractedBorehole:
 
     predictions: list[Layer]
     bounding_boxes: list[PageBoundingBoxes]  # one for each page that the borehole spans
+    # the borehole's own printed name, if one was found near it on the page it was (re-)detected on;
+    # used as a cross-page merge signal, not part of the final output (that's matched separately)
+    name: FeatureOnPage[BoreholeName] | None = None
 
 
 class LayersInDocument:

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -13,6 +13,8 @@ from extraction.features.stratigraphy.layer.layer import ExtractedBorehole, Laye
 logger = logging.getLogger(__name__)
 
 MAX_BOUNDARY_LAYERS_TO_DROP = 2
+DEPTH_VALUE_TOLERANCE = 0.05
+MIN_DEPTH_OVERLAP_MATCHES = 2
 
 
 @dataclass
@@ -157,7 +159,7 @@ def find_split_by_convolution(
         if result is not None and _is_trustworthy_retry_match(result, layers_curr):
             return result
 
-    return None
+    return _find_depth_reset_overlap(layers_prev, layers_curr)
 
 
 def _is_trustworthy_retry_match(result: OverlapResult, trimmed_curr: list[Layer]) -> bool:
@@ -181,6 +183,63 @@ def _is_trustworthy_retry_match(result: OverlapResult, trimmed_curr: list[Layer]
         return True
     matched_layer = trimmed_curr[0]
     return bool(matched_layer.depths and matched_layer.depths.start and matched_layer.depths.end)
+
+
+def _collect_depth_values(layers: list[Layer]) -> list[float]:
+    """Collect all known depth boundary values (layer starts and ends), in top-to-bottom order.
+
+    Args:
+        layers (list[Layer]): Layers to collect boundary values from.
+
+    Returns:
+        list[float]: The depth values, in the order they appear.
+    """
+    values = []
+    for layer in layers:
+        if not layer.depths:
+            continue
+        if layer.depths.start and layer.depths.start.value is not None:
+            values.append(layer.depths.start.value)
+        if layer.depths.end and layer.depths.end.value is not None:
+            values.append(layer.depths.end.value)
+    return values
+
+
+def _find_depth_reset_overlap(layers_prev: list[Layer], layers_curr: list[Layer]) -> OverlapResult | None:
+    """Find an overlap by depth values alone, for boundaries where the OCR'd text can't be trusted.
+
+    Some scans have a physical ruler or fold obscuring the material description text right where a
+    borehole continues onto the next page, so the text-based matches above find nothing there. When
+    that happens, the current page's depths restart lower than the previous page's last depth -
+    looking like a new, shallower borehole - but several of those depth values are the exact same
+    ones already seen on the previous page. That repetition is strong evidence that this is a
+    re-scanned duplicate of already-seen content, not a new borehole.
+
+    Args:
+        layers_prev (list[Layer]): Layers from the previous page, ordered top to bottom.
+        layers_curr (list[Layer]): Layers from the current page, ordered top to bottom.
+
+    Returns:
+        OverlapResult | None: indices that define the overlapping layers, or None if no overlap.
+    """
+    prev_values = _collect_depth_values(layers_prev)
+    if not prev_values:
+        return None
+    prev_max = max(prev_values)
+
+    lower_id = 0
+    matches = 0
+    for layer in layers_curr:
+        end = layer.depths.end.value if layer.depths and layer.depths.end else None
+        if end is None or end > prev_max + DEPTH_VALUE_TOLERANCE:
+            break
+        if any(math.isclose(end, value, abs_tol=DEPTH_VALUE_TOLERANCE) for value in prev_values):
+            matches += 1
+        lower_id += 1
+
+    if matches < MIN_DEPTH_OVERLAP_MATCHES:
+        return None
+    return OverlapResult(upper_id=len(layers_prev), lower_id=lower_id)
 
 
 def _find_longest_overlap(

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -2,6 +2,8 @@
 
 import logging
 import math
+import re
+import unicodedata
 from dataclasses import dataclass
 
 import Levenshtein
@@ -9,6 +11,8 @@ import Levenshtein
 from extraction.features.stratigraphy.layer.layer import ExtractedBorehole, Layer
 
 logger = logging.getLogger(__name__)
+
+MAX_BOUNDARY_LAYERS_TO_DROP = 2
 
 
 @dataclass
@@ -56,7 +60,7 @@ def select_boreholes_with_overlap(
 def are_layers_similar(
     layer_prev: Layer,
     layer_curr: Layer,
-    material_threshold: float = 0.95,
+    material_threshold: float = 0.90,
     is_extremity: bool = False,
 ) -> bool:
     """Check if two layers are similar based on material description and optional depth matching.
@@ -69,7 +73,7 @@ def are_layers_similar(
     Args:
         layer_prev (Layer): The layer from the previous page.
         layer_curr (Layer): The layer from the current page.
-        material_threshold (float): Minimum similarity threshold for material descriptions. Defaults to 0.95.
+        material_threshold (float): Minimum similarity threshold for material descriptions. Defaults to 0.90.
         is_extremity (bool, optional): Whether this layer is at the boundary of the overlap. Defaults to False.
 
     Returns:
@@ -118,6 +122,72 @@ def find_split_by_convolution(
 ) -> OverlapResult | None:
     """Find the extent of overlap between consecutive page layers.
 
+    Tries a plain match first. `_find_longest_overlap`'s window always starts its comparison at
+    `layers_curr[0]` (and ends at `layers_prev[-1]`), so a boundary layer that doesn't compare well to
+    its counterpart - e.g. because table/OCR parsing collapsed several real rows into it, or
+    truncated/paraphrased its text - blocks every window from aligning, hiding a genuine overlap in
+    the rest of the page. If the plain match fails, retry with up to `MAX_BOUNDARY_LAYERS_TO_DROP`
+    layers dropped from either end.
+
+    Args:
+        layers_prev (list[Layer]): Layers from the previous page, ordered top to bottom.
+        layers_curr (list[Layer]): Layers from the current page, ordered top to bottom.
+        matching_params (dict): Configuration dict with keys.
+
+    Returns:
+        OverlapResult | None: indices that define the overlapping layers, or None if no overlap.
+    """
+    result = _find_longest_overlap(layers_prev, layers_curr, matching_params)
+    if result is not None:
+        return result
+
+    for drop in range(1, MAX_BOUNDARY_LAYERS_TO_DROP + 1):
+        if len(layers_curr) <= drop:
+            break
+        trimmed_curr = layers_curr[drop:]
+        result = _find_longest_overlap(layers_prev, trimmed_curr, matching_params)
+        if result is not None and _is_trustworthy_retry_match(result, trimmed_curr):
+            return OverlapResult(upper_id=result.upper_id, lower_id=result.lower_id + drop)
+
+    for drop in range(1, MAX_BOUNDARY_LAYERS_TO_DROP + 1):
+        if len(layers_prev) <= drop:
+            break
+        trimmed_prev = layers_prev[:-drop]
+        result = _find_longest_overlap(trimmed_prev, layers_curr, matching_params)
+        if result is not None and _is_trustworthy_retry_match(result, layers_curr):
+            return result
+
+    return None
+
+
+def _is_trustworthy_retry_match(result: OverlapResult, trimmed_curr: list[Layer]) -> bool:
+    """Guard against accepting a boundary-drop retry on a single coincidental text match.
+
+    Dropping boundary layers to force an alignment is inherently speculative - unlike a match found
+    without dropping anything, it discards content to make things fit. A match spanning several
+    layers is trustworthy regardless of depth info (consistent with the plain, undropped search). A
+    match of just one layer needs the extra corroboration of a real, matching depth interval - text
+    similarity alone on a single row is too easy to hit by coincidence (e.g. a short, generic
+    description repeated elsewhere in the document).
+
+    Args:
+        result (OverlapResult): The result from `_find_longest_overlap` on the trimmed layers.
+        trimmed_curr (list[Layer]): The (already boundary-trimmed) current-page layers that were matched.
+
+    Returns:
+        bool: True if the match is trustworthy enough to accept.
+    """
+    if result.lower_id > 1:
+        return True
+    matched_layer = trimmed_curr[0]
+    return bool(matched_layer.depths and matched_layer.depths.start and matched_layer.depths.end)
+
+
+def _find_longest_overlap(
+    layers_prev: list[Layer], layers_curr: list[Layer], matching_params: dict
+) -> OverlapResult | None:
+    """Find the extent of overlap between consecutive page layers.
+
     Determines the maximum number of consecutive layers from the bottom of the previous
     page that match the top layers of the current page.
 
@@ -143,12 +213,19 @@ def find_split_by_convolution(
                 material_threshold=material_threshold,
                 is_extremity=(j == 0 or j == i - 1),  # Indicate to function that one layer might be cut (extremities)
             ):
-                if layer_prev.depths and layer_prev.depths.start and layer_prev.depths.end:
+                if (
+                    layer_prev.depths
+                    and layer_prev.depths.start
+                    and layer_prev.depths.end
+                    and layer_curr.depths
+                    and layer_curr.depths.start
+                    and layer_curr.depths.end
+                ):
                     match_with_depths_count += 1
                 else:
                     match_with_depths_count = 0
             else:
-                if match_with_depths_count >= 2:
+                if match_with_depths_count >= 1:
                     # allow the overlap, even though not all layers match
                     return OverlapResult(upper_id=len(layers_prev) - i + j, lower_id=j)
                 # no valid overlap; break inner loop and go to next value for i
@@ -158,6 +235,25 @@ def find_split_by_convolution(
         # all layers matched
         if match_ok:
             return OverlapResult(upper_id=len(layers_prev), lower_id=i)
+
+
+def _normalize_for_comparison(text: str) -> str:
+    """Fold accents and collapse punctuation/whitespace noise so independent OCR passes compare as equal.
+
+    Two scans of the same physical row commonly disagree only on comma placement, spacing, or an
+    accented character (e.g. "MERGEL, DUNKELGRÜN" vs "MERGEL DUNKELGRUN") - noise that otherwise drops
+    the Levenshtein ratio just below the similarity threshold.
+
+    Args:
+        text (str): The raw material description text.
+
+    Returns:
+        str: Lowercased text with accents folded to their base letter and punctuation/whitespace collapsed.
+    """
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(char for char in text if not unicodedata.combining(char))
+    text = re.sub(r"[^\w\s]", " ", text)
+    return re.sub(r"\s+", " ", text).strip().lower()
 
 
 def _is_duplicate(cur_text: str, prev_text: str, threshold: float, is_extremity: bool) -> bool:
@@ -179,8 +275,8 @@ def _is_duplicate(cur_text: str, prev_text: str, threshold: float, is_extremity:
     Returns:
         bool: True if the layers are considered duplicates, False otherwise.
     """
-    cur_text = cur_text.lower()
-    prev_text = prev_text.lower()
+    cur_text = _normalize_for_comparison(cur_text)
+    prev_text = _normalize_for_comparison(prev_text)
 
     if is_extremity:
         min_length = min(len(cur_text), len(prev_text))

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -13,7 +13,6 @@ from extraction.features.stratigraphy.layer.layer import ExtractedBorehole, Laye
 logger = logging.getLogger(__name__)
 
 MAX_BOUNDARY_LAYERS_TO_DROP = 2
-DEPTH_VALUE_TOLERANCE = 0.05
 MIN_DEPTH_OVERLAP_MATCHES = 2
 
 
@@ -231,9 +230,9 @@ def _find_depth_reset_overlap(layers_prev: list[Layer], layers_curr: list[Layer]
     matches = 0
     for layer in layers_curr:
         end = layer.depths.end.value if layer.depths and layer.depths.end else None
-        if end is None or end > prev_max + DEPTH_VALUE_TOLERANCE:
+        if end is None or end > prev_max and not math.isclose(end, prev_max):
             break
-        if any(math.isclose(end, value, abs_tol=DEPTH_VALUE_TOLERANCE) for value in prev_values):
+        if any(math.isclose(end, value) for value in prev_values):
             matches += 1
         lower_id += 1
 

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -226,15 +226,15 @@ def _find_depth_reset_overlap(layers_prev: list[Layer], layers_curr: list[Layer]
         return None
     prev_max = max(prev_values)
 
-    lower_id = 0
     matches = 0
-    for layer in layers_curr:
+    for lower_id, layer in enumerate(layers_curr):  # noqa: B007
         end = layer.depths.end.value if layer.depths and layer.depths.end else None
         if end is None or end > prev_max and not math.isclose(end, prev_max):
             break
         if any(math.isclose(end, value) for value in prev_values):
             matches += 1
-        lower_id += 1
+    else:
+        lower_id = len(layers_curr)
 
     if matches < MIN_DEPTH_OVERLAP_MATCHES:
         return None

--- a/src/extraction/features/stratigraphy/layer/overlap_detection.py
+++ b/src/extraction/features/stratigraphy/layer/overlap_detection.py
@@ -123,13 +123,6 @@ def find_split_by_convolution(
 ) -> OverlapResult | None:
     """Find the extent of overlap between consecutive page layers.
 
-    Tries a plain match first. `_find_longest_overlap`'s window always starts its comparison at
-    `layers_curr[0]` (and ends at `layers_prev[-1]`), so a boundary layer that doesn't compare well to
-    its counterpart - e.g. because table/OCR parsing collapsed several real rows into it, or
-    truncated/paraphrased its text - blocks every window from aligning, hiding a genuine overlap in
-    the rest of the page. If the plain match fails, retry with up to `MAX_BOUNDARY_LAYERS_TO_DROP`
-    layers dropped from either end.
-
     Args:
         layers_prev (list[Layer]): Layers from the previous page, ordered top to bottom.
         layers_curr (list[Layer]): Layers from the current page, ordered top to bottom.
@@ -138,26 +131,38 @@ def find_split_by_convolution(
     Returns:
         OverlapResult | None: indices that define the overlapping layers, or None if no overlap.
     """
+    # try the finding a match in the untouched lists first; return immediately if that alone finds an overlap.
     result = _find_longest_overlap(layers_prev, layers_curr, matching_params)
     if result is not None:
         return result
 
+    # In some cases, the first layer on the current page is distorted and doesn't match the last layer on the
+    # previous page. In that case, we can try dropping the first layer of the current page and see if a match is found
+    # with the next layer down.
+    # --> Retry ignoring the current page's leading layers, in case a distorted first layer is blocking the match.
     for drop in range(1, MAX_BOUNDARY_LAYERS_TO_DROP + 1):
         if len(layers_curr) <= drop:
             break
         trimmed_curr = layers_curr[drop:]
         result = _find_longest_overlap(layers_prev, trimmed_curr, matching_params)
         if result is not None and _is_trustworthy_retry_match(result, trimmed_curr):
+            # lower_id was computed against trimmed_curr, so shift it back to index into the real layers_curr.
             return OverlapResult(upper_id=result.upper_id, lower_id=result.lower_id + drop)
 
+    # If the last layer on the previous page is distorted, we can try dropping it and see if a match is found with
+    # the next-to-last layer.
+    # --> Retry ignoring the previous page's trailing layers, in case a distorted last layer is blocking the match.
     for drop in range(1, MAX_BOUNDARY_LAYERS_TO_DROP + 1):
         if len(layers_prev) <= drop:
             break
         trimmed_prev = layers_prev[:-drop]
         result = _find_longest_overlap(trimmed_prev, layers_curr, matching_params)
         if result is not None and _is_trustworthy_retry_match(result, layers_curr):
+            # Dropping from the end of layers_prev doesn't renumber what's left, and layers_curr wasn't
+            # touched at all, so both indices already match the original lists.
             return result
 
+    # No text-based match at all; fall back to matching on repeated depth values alone.
     return _find_depth_reset_overlap(layers_prev, layers_curr)
 
 

--- a/src/swissgeol_doc_processing/config/matching_params.yml
+++ b/src/swissgeol_doc_processing/config/matching_params.yml
@@ -4,7 +4,7 @@
 block_line_ratio: 0.20
 min_block_clearance: 10
 left_line_length_threshold: 7
-duplicate_layer_threshold: 0.95
+duplicate_layer_threshold: 0.90
 min_num_layers: 2
 protocol_min_num_layers: 1
 protocol_great_match_threshold: 0.1

--- a/tests/test_continuation_detection.py
+++ b/tests/test_continuation_detection.py
@@ -2,6 +2,7 @@
 
 import pymupdf
 
+from extraction.features.metadata.borehole_name_extraction import BoreholeName
 from extraction.features.stratigraphy.layer.continuation_detection import merge_boreholes
 from extraction.features.stratigraphy.layer.layer import (
     ExtractedBorehole,
@@ -13,10 +14,17 @@ from extraction.features.stratigraphy.layer.overlap_detection import OverlapResu
 from extraction.features.stratigraphy.layer.page_bounding_boxes import PageBoundingBoxes
 from swissgeol_doc_processing.geometry.geometry_dataclasses import BoundingBox
 from swissgeol_doc_processing.text.textblock import MaterialDescription
+from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 
 
 def _depth(value: float, page: int) -> LayerDepthsEntry:
     return LayerDepthsEntry(value=value, rect=None, page_number=page)
+
+
+def _name(text: str, confidence: float = 1.0) -> FeatureOnPage[BoreholeName]:
+    return FeatureOnPage(
+        feature=BoreholeName(name=text, confidence=confidence), rect=pymupdf.Rect(0, 0, 10, 10), page=1
+    )
 
 
 def _page_bbox(page: int) -> PageBoundingBoxes:
@@ -118,3 +126,59 @@ def test_merge_boreholes_does_not_merge_when_neither_side_has_depths(monkeypatch
     )
 
     assert len(merged_boreholes) == 2
+
+
+def test_merge_boreholes_name_conflict_blocks_depth_fallback_merge(monkeypatch):
+    """Test name conflict.
+
+    A confidently detected, disagreeing name on both sides must block a merge, even when the
+    depth-continuity fallback heuristic would otherwise merge them.
+    """
+    previous_borehole = ExtractedBorehole(
+        predictions=[_layer("Sandstein", 10.0, 20.0, 1)],
+        bounding_boxes=[_page_bbox(1)],
+        name=_name("KB12"),
+    )
+    current_borehole = ExtractedBorehole(
+        predictions=[_layer("Mergel", 20.0, 30.0, 2)],
+        bounding_boxes=[_page_bbox(2)],
+        name=_name("KB13"),
+    )
+
+    monkeypatch.setattr(
+        "extraction.features.stratigraphy.layer.continuation_detection.select_boreholes_with_overlap",
+        lambda previous_page_boreholes, current_page_boreholes, matching_params: (None, None, None),
+    )
+
+    merged_boreholes = merge_boreholes(
+        boreholes_per_page=[[previous_borehole], [current_borehole]],
+        matching_params={},
+    )
+
+    assert len(merged_boreholes) == 2
+
+
+def test_merge_boreholes_low_confidence_name_does_not_block_merge(monkeypatch):
+    """A disagreeing name must not block a merge if either side's detection is low-confidence."""
+    previous_borehole = ExtractedBorehole(
+        predictions=[_layer("Sandstein", 10.0, 20.0, 1)],
+        bounding_boxes=[_page_bbox(1)],
+        name=_name("KB12", confidence=0.2),
+    )
+    current_borehole = ExtractedBorehole(
+        predictions=[_layer("Mergel", 20.0, 30.0, 2)],
+        bounding_boxes=[_page_bbox(2)],
+        name=_name("KB13"),
+    )
+
+    monkeypatch.setattr(
+        "extraction.features.stratigraphy.layer.continuation_detection.select_boreholes_with_overlap",
+        lambda previous_page_boreholes, current_page_boreholes, matching_params: (None, None, None),
+    )
+
+    merged_boreholes = merge_boreholes(
+        boreholes_per_page=[[previous_borehole], [current_borehole]],
+        matching_params={},
+    )
+
+    assert len(merged_boreholes) == 1

--- a/tests/test_continuation_detection.py
+++ b/tests/test_continuation_detection.py
@@ -1,5 +1,7 @@
 """Test suite for merge boreholes in continuation detection."""
 
+import pymupdf
+
 from extraction.features.stratigraphy.layer.continuation_detection import merge_boreholes
 from extraction.features.stratigraphy.layer.layer import (
     ExtractedBorehole,
@@ -8,11 +10,22 @@ from extraction.features.stratigraphy.layer.layer import (
     LayerDepthsEntry,
 )
 from extraction.features.stratigraphy.layer.overlap_detection import OverlapResult
+from extraction.features.stratigraphy.layer.page_bounding_boxes import PageBoundingBoxes
+from swissgeol_doc_processing.geometry.geometry_dataclasses import BoundingBox
 from swissgeol_doc_processing.text.textblock import MaterialDescription
 
 
 def _depth(value: float, page: int) -> LayerDepthsEntry:
     return LayerDepthsEntry(value=value, rect=None, page_number=page)
+
+
+def _page_bbox(page: int) -> PageBoundingBoxes:
+    return PageBoundingBoxes(
+        sidebar_bbox=None,
+        depth_column_entry_bboxes=[],
+        material_description_bbox=BoundingBox(pymupdf.Rect(0, 0, 10, 10)),
+        page=page,
+    )
 
 
 def _layer(text: str, start: float | None, end: float | None, page: int) -> Layer:
@@ -77,3 +90,31 @@ def test_merge_boreholes_reconciles_duplicated_boundary_layer(monkeypatch):
     assert merged.predictions[2].material_description.text == "grauer siltiger Ton, wenig Kies"
     assert merged.predictions[2].depths.start.value == 108.0
     assert merged.predictions[2].depths.end.value == 140.0
+
+
+def test_merge_boreholes_does_not_merge_when_neither_side_has_depths(monkeypatch):
+    """Without any depth values to compare, two boreholes must not be merged.
+
+    Regression test: previously, when depths couldn't be compared, the continuation check
+    defaulted to accepting the merge, welding unrelated boreholes together (issue seen in 3384.pdf).
+    """
+    previous_borehole = ExtractedBorehole(
+        predictions=[_layer("Humus, Sand", None, None, 1)],
+        bounding_boxes=[_page_bbox(1)],
+    )
+    current_borehole = ExtractedBorehole(
+        predictions=[_layer("Humus, Kies", None, None, 2)],
+        bounding_boxes=[_page_bbox(2)],
+    )
+
+    monkeypatch.setattr(
+        "extraction.features.stratigraphy.layer.continuation_detection.select_boreholes_with_overlap",
+        lambda previous_page_boreholes, current_page_boreholes, matching_params: (None, None, None),
+    )
+
+    merged_boreholes = merge_boreholes(
+        boreholes_per_page=[[previous_borehole], [current_borehole]],
+        matching_params={},
+    )
+
+    assert len(merged_boreholes) == 2

--- a/tests/test_overlap_detection.py
+++ b/tests/test_overlap_detection.py
@@ -140,7 +140,11 @@ def test_find_last_duplicate_ocr_error(create_layer):
 
 
 def test_find_last_duplicate_full_duplicates(create_layer):
-    """Test when the number of duplicated layers of the current page exceeds the number of layer in the previous."""
+    """Test when the current page has one new leading layer before the full duplicated block.
+
+    The plain window search can't align "Layer A" against anything in prev, but dropping it reveals
+    that the rest of the page (B, C, D) is a full duplicate of prev.
+    """
     prev_layers = [create_layer("Layer B"), create_layer("Layer C"), create_layer("Layer D")]
 
     current_layers_correct = [
@@ -150,6 +154,79 @@ def test_find_last_duplicate_full_duplicates(create_layer):
         create_layer("Layer D"),
     ]
     overlap_result = find_split_by_convolution(prev_layers, current_layers_correct, matching_params)
+    assert overlap_result.upper_id == 3
+    assert overlap_result.lower_id == 4
+
+
+def test_find_last_duplicate_unmatched_boundary_layer(create_elevation_layer):
+    """A boundary layer that doesn't compare well to its counterpart must not block detection.
+
+    Regression test inspired by 3384.pdf: the current page's first layer's text was OCR-truncated
+    enough that it no longer matched its counterpart in prev, which used to prevent the sliding
+    window from ever aligning with the real duplicate content right after it.
+    """
+    prev_layers = [
+        create_elevation_layer("dito grau", (26.1, 27.4)),
+        create_elevation_layer("Lehm mit Sandstein", (27.4, 27.95)),
+        create_elevation_layer("Mergel grau, fest, braun bis rotlich", (27.95, 28.75)),
+        create_elevation_layer("Sandstein zerbrockelt", (28.75, 29.95)),
+    ]
+    current_layers = [
+        create_elevation_layer("fest braun bis rotlich", (None, 28.75)),  # truncated, doesn't match prev's layer
+        create_elevation_layer("Sandstein zerbrockelt", (28.75, 29.95)),
+        create_elevation_layer("Mergel bunt", (29.95, 31.6)),
+    ]
+
+    overlap_result = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert overlap_result is not None
+    assert overlap_result.upper_id == 4
+    assert overlap_result.lower_id == 2
+
+
+def test_find_split_by_convolution_depth_reset_overlap(create_elevation_layer):
+    """Test depth reset overlap.
+
+    A ruler blocking the OCR text at the page boundary breaks text matching, but the current page's
+    depths restart lower while reproducing several exact depth values from the previous page - this
+    must still be detected as an overlap of the re-scanned section, not a new borehole.
+    """
+    prev_layers = [
+        create_elevation_layer("Sandstein grau", (11.3, 11.55)),
+        create_elevation_layer("Sandstein hart", (11.55, 12.6)),
+        create_elevation_layer("Mergel bunt", (12.6, 13.6)),
+        create_elevation_layer("Mergel bunt Fortsetzung", (13.6, 16.15)),
+    ]
+    current_layers = [
+        create_elevation_layer("XXXX unlesbar unter Lineal", (11.3, 11.55)),
+        create_elevation_layer("XXXX unlesbar unter Lineal", (11.55, 12.6)),
+        create_elevation_layer("XXXX unlesbar unter Lineal", (12.6, 13.6)),
+        create_elevation_layer("XXXX unlesbar unter Lineal", (13.6, 16.15)),
+        create_elevation_layer("Sandstein neu", (16.15, 18.1)),
+    ]
+
+    overlap_result = find_split_by_convolution(prev_layers, current_layers, matching_params)
+    assert overlap_result is not None
+    assert overlap_result.upper_id == 4
+    assert overlap_result.lower_id == 4
+
+
+def test_find_split_by_convolution_depth_reset_no_overlap(create_elevation_layer):
+    """A current page that genuinely starts a new, shallower borehole must not be merged in.
+
+    Only one depth value coincides with the previous borehole (12.6) - not enough evidence of a
+    real re-scanned overlap.
+    """
+    prev_layers = [
+        create_elevation_layer("Sandstein grau", (11.3, 11.55)),
+        create_elevation_layer("Sandstein hart", (11.55, 12.6)),
+    ]
+    current_layers = [
+        create_elevation_layer("Humus", (0.0, 0.5)),
+        create_elevation_layer("Lehm", (0.5, 3.0)),
+        create_elevation_layer("Kies", (3.0, 12.6)),
+    ]
+
+    overlap_result = find_split_by_convolution(prev_layers, current_layers, matching_params)
     assert overlap_result is None
 
 


### PR DESCRIPTION
closes #466

The continuation detection error described in #466 were mostly considered out of scope as described in the comment under the issue description. The error are due to OCR errors and bad geometry scores. 

Nevertheless, I wanted to use this issue to address a part of #505 
--> This PR proposed a more robust continuation detection which resolves almost all detected continuation detection problems in the huge 3348.pdf file, while keeping the side effects on zurich and geoquat/val reasonable. 

## Main changes 
- Borehole-name cross-check: extract borehole names per page and attach the nearest one to each extracted borehole; if two boreholes across a page break both have a confidently-detected but disagreeing name, block the merge —> direct evidence they're different boreholes, overriding the text/depth heuristics.
- Fix false-positive merge when depths are missing: `_is_continuation` previously defaulted to merge when neither side had depth values to compare; now it defaults to not merge without evidence.
- Wider overlap detection window: if the plain boundary match fails (e.g. an OCR-truncated first/last layer blocks alignment), retry after dropping up to 2 layers from either end of the current/previous page's layers, with a guard requiring depth corroboration for single-layer matches.
- New depth-reset fallback: when boundary text is unreadable (e.g. obscured by a ruler), detect overlap purely from repeated depth values shared between the two pages.
- Loosened thresholds: `duplicate_layer_threshold` / `material_threshold` lowered 0.95 → 0.90, and partial-overlap acceptance now needs only 1 (not 2) consecutive depth-matched layers.
- Text normalization for comparison: fold accents and collapse punctuation/whitespace before Levenshtein comparison, so independent OCR passes of the same row (accents, comma placement) compare as equal.
- 
## File 3348 

### Errors continuation detection

**False positives** 

- 71-72 unmerged
- 108 - 109  unmerged
- 139-140-141 unmerged
- 147-148 unmerged
- 162-163 unmerged
- 169-170 unmerged
- 177-178 unmerged
- 187-188-189  unmerged
- 191-192 unmerged
- 212-213 unmerged ( wrong sidebar detected though fallback which allows merge when the depth in creases )
- 217-218-219-220-221 unmerged
- 240-241 unmerged
- 246-247 unmerged

**False negative** 

- 132 -133 merged
- 135-136 merged
- 138-139 merged
- 149-150 merged
- 161-162 merged
- 165 -166 / 167 - 168 - 169(166 and 167 are the same thing just that on 167 is no ruler anymore) merged
- 179-180 merged
- 181-182 merged
- 186-187 merged
- 195-196 merged

**True positives** 

- 137-138
- 151-152
- 170-171-172
- 173-174
- 176-177-
- 193-194
- 221-222


### Side effects 
Zurich : 
positive: 
- 684252058-bp.pdf —> continuation correctly detected and merged

negative: 
- 267124180-bp.pdf false borehole name discovered on page 2 which reverts the previous correct merge


Geoquat 
positive:
- 10088, B366—> FP continuation removed

negative:
- B147 —> FP continuation detection (page 1 and 2 falsely merged)

Zurich | layer_f1 | depth_intervall_f1 | Material_description_f1 | elevation_f1 | coordinates_f1 | Borehole_name_f1
-- | -- | -- | -- | -- | -- | --
develop | 0.844 | 0.895 | 0.884 | 0.829 | 0.705 | 0.748
branch | 0.847 | 0.895 | 0.886 | 0.829 | 0.705 | 0.741


Geoquat | layer_f1 | depth_intervall_f1 | Material_description_f1 | elevation_f1 | coordinates_f1 | Borehole_name_f1
-- | -- | -- | -- | -- | -- | --
develop | 0.488 |0.636 | 0.6398 | 0.607 |  0.478 | 0.608
branch | 0.497 | 0.635 | 0.648 | 0.607 | 0.476 | 0.603