### PR TITLE
Smarter splitting of TextLines based on vertical lines in detected table structures

### DIFF
--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -100,35 +100,7 @@ class BoreholeExtractor:
         self.line_detection_params = line_detection_params
         self.analytics = analytics
         self.matching_params = matching_params
-
-        processed_lines = []
-        for text_line in self.lines:
-            text_middle_line = middle_line(text_line.rect)
-            partition = [text_line.words]
-
-            for structure in table_structures:
-                for line in structure.vertical_lines:
-                    if line.intersects_with(text_middle_line):
-                        new_partition = []
-                        for words in partition:
-                            words_left = []
-                            words_right = []
-                            for word in words:
-                                if (word.rect.x0 + word.rect.x1) / 2 < (line.start.x + line.end.x) / 2:
-                                    words_left.append(word)
-                                else:
-                                    words_right.append(word)
-
-                            if len(words_left) > 0:
-                                new_partition.append(words_left)
-                            if len(words_right) > 0:
-                                new_partition.append(words_right)
-                        partition = new_partition
-
-            for words in partition:
-                text_line = TextLine(words, text_angle=text_line.text_angle)
-                processed_lines.append(text_line)
-        self.processed_lines = processed_lines
+        self.processed_lines = _split_text_lines_by_table_structures(lines, table_structures)
 
     def process_page(self) -> list[ExtractedBorehole]:
         """Process a single page of a pdf.
@@ -730,3 +702,38 @@ class BoreholeExtractor:
         # below the actual scanned page) --> this mechanism could/should be optimized in the future!
         largest_table = max(self.table_structures, key=lambda t: t.bounding_rect.height)
         return (largest_table.bounding_rect.height / max(self.page_height, 1e-16)) >= min_table_height_ratio
+
+
+def _split_text_lines_by_table_structures(
+    text_lines: list[TextLine], table_structures: list[TableStructure]
+) -> list[TextLine]:
+    """Split certain text lines into multiple lines based on intersecting vertical table structure lines."""
+    processed_lines = []
+    for text_line in text_lines:
+        text_middle_line = middle_line(text_line.rect)
+        partition = [text_line.words]
+
+        for structure in table_structures:
+            for line in structure.vertical_lines:
+                if line.intersects_with(text_middle_line):
+                    new_partition = []
+                    for words in partition:
+                        words_left = []
+                        words_right = []
+                        for word in words:
+                            if (word.rect.x0 + word.rect.x1) / 2 < (line.start.x + line.end.x) / 2:
+                                words_left.append(word)
+                            else:
+                                words_right.append(word)
+
+                        if len(words_left) > 0:
+                            new_partition.append(words_left)
+                        if len(words_right) > 0:
+                            new_partition.append(words_right)
+                    partition = new_partition
+
+        for words in partition:
+            text_line = TextLine(words, text_angle=text_line.text_angle)
+            processed_lines.append(text_line)
+
+        return processed_lines

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -103,6 +103,36 @@ class BoreholeExtractor:
         self.analytics = analytics
         self.matching_params = matching_params
 
+        processed_lines = []
+        for text_line in self.lines:
+            text_line_left = (text_line.rect.top_left + text_line.rect.bottom_left) / 2
+            text_line_right = (text_line.rect.top_right + text_line.rect.bottom_right) / 2
+            partition = [text_line.words]
+
+            for structure in table_structures:
+                for line in structure.vertical_lines:
+                    if line.intersects_with(Line(text_line_left, text_line_right)):
+                        new_partition = []
+                        for words in partition:
+                            words_left = []
+                            words_right = []
+                            for word in words:
+                                if (word.rect.x0 + word.rect.x1) / 2 < (line.start.x + line.end.x) / 2:
+                                    words_left.append(word)
+                                else:
+                                    words_right.append(word)
+
+                            if len(words_left) > 0:
+                                new_partition.append(words_left)
+                            if len(words_right) > 0:
+                                new_partition.append(words_right)
+                        partition = new_partition
+
+            for words in partition:
+                text_line = TextLine(words, text_angle=text_line.text_angle)
+                processed_lines.append(text_line)
+        self.processed_lines = processed_lines
+
     def process_page(self) -> list[ExtractedBorehole]:
         """Process a single page of a pdf.
 
@@ -193,7 +223,7 @@ class BoreholeExtractor:
         Returns:
             list[IntervalBlockPair]: The interval block pairs.
         """
-        description_lines = get_description_lines(self.lines, material_description_rect)
+        description_lines = get_description_lines(self.processed_lines, material_description_rect)
 
         if sidebar is not None:
             # remove description words that are already part of the sidebar
@@ -336,7 +366,9 @@ class BoreholeExtractor:
         """
         if sidebar:
             above_sidebar = [
-                line for line in self.lines if x_overlap(line.rect, sidebar.rect) and line.rect.y0 < sidebar.rect.y0
+                line
+                for line in self.processed_lines
+                if x_overlap(line.rect, sidebar.rect) and line.rect.y0 < sidebar.rect.y0
             ]
 
             min_y0 = max(line.rect.y0 for line in above_sidebar) if above_sidebar else -1
@@ -350,7 +382,7 @@ class BoreholeExtractor:
 
         horizontal_text_lines = [
             line
-            for line in self.lines
+            for line in self.processed_lines
             if abs(line.text_angle) < 10 and not re.fullmatch(r"[\d\s.,\-/]+", line.text.strip())
         ]
         candidate_description = [line for line in horizontal_text_lines if check_y0_condition(line.rect.y0)]

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -49,9 +49,7 @@ from swissgeol_doc_processing.text.textline import TextLine
 from swissgeol_doc_processing.text.textline_affinity import get_line_affinity
 from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 from swissgeol_doc_processing.utils.strip_log_detection import StripLog
-from swissgeol_doc_processing.utils.table_detection import (
-    TableStructure,
-)
+from swissgeol_doc_processing.utils.table_detection import TableStructure, middle_line
 
 logger = logging.getLogger(__name__)
 
@@ -105,13 +103,12 @@ class BoreholeExtractor:
 
         processed_lines = []
         for text_line in self.lines:
-            text_line_left = (text_line.rect.top_left + text_line.rect.bottom_left) / 2
-            text_line_right = (text_line.rect.top_right + text_line.rect.bottom_right) / 2
+            text_middle_line = middle_line(text_line.rect)
             partition = [text_line.words]
 
             for structure in table_structures:
                 for line in structure.vertical_lines:
-                    if line.intersects_with(Line(text_line_left, text_line_right)):
+                    if line.intersects_with(text_middle_line):
                         new_partition = []
                         for words in partition:
                             words_left = []

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -3,7 +3,6 @@
 import logging
 import re
 
-import fastquadtree
 import pymupdf
 
 from extraction.features.stratigraphy.borehole_candidate import BoreholeCandidate
@@ -47,6 +46,7 @@ from swissgeol_doc_processing.text.textblock import (
 )
 from swissgeol_doc_processing.text.textline import TextLine
 from swissgeol_doc_processing.text.textline_affinity import get_line_affinity
+from swissgeol_doc_processing.text.textline_rtree import TextLineRTree
 from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 from swissgeol_doc_processing.utils.strip_log_detection import StripLog
 from swissgeol_doc_processing.utils.table_detection import TableStructure, middle_line
@@ -294,13 +294,7 @@ class BoreholeExtractor:
         if not self.lines:
             return []
 
-        min_x = min([line.rect.x0 for line in self.lines])
-        max_x = max([line.rect.x1 for line in self.lines])
-        min_y = min([line.rect.y0 for line in self.lines])
-        max_y = max([line.rect.y1 for line in self.lines])
-        line_rtree = fastquadtree.RectQuadTreeObjects((min_x, min_y, max_x, max_y), capacity=8)
-        for line in self.lines:
-            line_rtree.insert((line.rect.x0, line.rect.y0, line.rect.x1, line.rect.y1), obj=line)
+        line_rtree = TextLineRTree(self.lines)
 
         # create sidebars with noise count
         spulprobe_sidebars = SpulprobeSidebarExtractor.find_in_lines(self.lines, self.table_structures)

--- a/src/extraction/features/extract.py
+++ b/src/extraction/features/extract.py
@@ -736,4 +736,4 @@ def _split_text_lines_by_table_structures(
             text_line = TextLine(words, text_angle=text_line.text_angle)
             processed_lines.append(text_line)
 
-        return processed_lines
+    return processed_lines

--- a/src/extraction/features/stratigraphy/sidebar/classes/sidebar.py
+++ b/src/extraction/features/stratigraphy/sidebar/classes/sidebar.py
@@ -7,7 +7,6 @@ import math
 from dataclasses import dataclass, field
 from typing import ClassVar, Generic, TypeVar
 
-import fastquadtree
 import pymupdf
 
 from extraction.features.stratigraphy.interval.interval import IntervalBlockPair, IntervalZone
@@ -16,6 +15,7 @@ from swissgeol_doc_processing.geometry.util import x_overlap_significant_smalles
 from swissgeol_doc_processing.text.textblock import TextBlock
 from swissgeol_doc_processing.text.textline import TextLine
 from swissgeol_doc_processing.text.textline_affinity import Affinity
+from swissgeol_doc_processing.text.textline_rtree import TextLineRTree
 from swissgeol_doc_processing.utils.file_utils import read_params
 
 EntryT = TypeVar("EntryT", bound=SidebarEntry)
@@ -178,18 +178,20 @@ class SidebarQualityMetrics:
     best_sidebar_score: float
 
 
-def noise_count(sidebar: Sidebar, line_rtree: fastquadtree.RectQuadTreeObjects) -> int:
+def noise_count(sidebar: Sidebar, line_rtree: TextLineRTree) -> int:
     """Counts the number of text lines that intersect with the Sidebar entries.
 
     Args:
         sidebar (Sidebar): Sidebar object for which the noise count is calculated.
-        line_rtree (fastquadtree.RectQuadTreeObjects): Pre-built R-tree of all text lines on page for spatial queries.
+        line_rtree (TextLineRTree): Pre-built R-tree of all text lines on page for spatial queries.
 
     Returns:
         int: The number of text lines that intersect with the Sidebar entries but are not part of it.
     """
     sidebar_rect = sidebar.rect
-    intersecting_lines = _get_intersecting_lines(line_rtree, sidebar_rect)
+
+    intersecting_lines = line_rtree.query(sidebar_rect)
+    intersecting_lines = [line for line in intersecting_lines if any(char.isalnum() for char in line.text)]
 
     def significant_intersection(line: TextLine) -> bool:
         line_rect = line.rect
@@ -202,9 +204,3 @@ def noise_count(sidebar: Sidebar, line_rtree: fastquadtree.RectQuadTreeObjects) 
         return not any(line_rect.intersects(entry.rect) for entry in sidebar.all_entries)
 
     return sum(1 for line in intersecting_lines if significant_intersection(line) and not_in_entries(line))
-
-
-def _get_intersecting_lines(line_rtree: fastquadtree.RectQuadTreeObjects, rect: pymupdf.Rect) -> list[TextLine]:
-    """Retrieve all words from the page intersecting with Sidebar bounding box."""
-    intersecting_lines = [item.obj for item in line_rtree.query((rect.x0, rect.y0, rect.x1, rect.y1))]
-    return [line for line in intersecting_lines if any(char.isalnum() for char in line.text)]

--- a/src/extraction/features/stratigraphy/sidebar/extractor/a_above_b_sidebar_extractor.py
+++ b/src/extraction/features/stratigraphy/sidebar/extractor/a_above_b_sidebar_extractor.py
@@ -2,7 +2,6 @@
 
 import statistics
 
-import fastquadtree
 import pymupdf
 
 from extraction.features.stratigraphy.interval.depth_column_entry_extractor import DepthColumnEntryExtractor
@@ -13,6 +12,7 @@ from extraction.features.stratigraphy.sidebar.utils.cluster import Cluster
 from extraction.features.stratigraphy.sidebar.utils.entries_per_table import TableEntries
 from extraction.features.stratigraphy.sidebarentry.depth_column_entry import DepthColumnEntry
 from swissgeol_doc_processing.text.textline import TextWord
+from swissgeol_doc_processing.text.textline_rtree import TextLineRTree
 from swissgeol_doc_processing.utils.table_detection import TableStructure
 
 
@@ -68,7 +68,7 @@ class AAboveBSidebarExtractor:
     @staticmethod
     def find_in_words(
         all_words: list[TextWord],
-        line_rtree: fastquadtree.RectQuadTreeObjects,
+        line_rtree: TextLineRTree,
         table_structures: list[TableStructure],
         used_entry_rects: list[pymupdf.Rect],
         sidebar_params: dict,
@@ -77,7 +77,7 @@ class AAboveBSidebarExtractor:
 
         Args:
             all_words (list[TextWord]): All words in the page.
-            line_rtree (rtree.index.Index): Pre-built R-tree for spatial queries.
+            line_rtree (TextLineRTree): Pre-built R-tree for spatial queries.
             table_structures (list[TableStructure]): List of identified table-like structures on the page.
             used_entry_rects (list[pymupdf.Rect]): Part of the document to ignore.
             sidebar_params (dict): Parameters for the AAboveBSidebar objects.

--- a/src/extraction/features/stratigraphy/sidebar/extractor/protocol_sidebar_extractor.py
+++ b/src/extraction/features/stratigraphy/sidebar/extractor/protocol_sidebar_extractor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import fastquadtree
 import pymupdf
 
 from extraction.features.stratigraphy.interval.depth_column_entry_extractor import DepthColumnEntryExtractor
@@ -13,6 +12,7 @@ from extraction.features.stratigraphy.sidebar.utils.entries_per_table import Tab
 from extraction.features.stratigraphy.sidebarentry.depth_column_entry import DepthColumnEntry
 from swissgeol_doc_processing.geometry.util import x_overlap_significant_smallest
 from swissgeol_doc_processing.text.textline import TextLine, TextWord
+from swissgeol_doc_processing.text.textline_rtree import TextLineRTree
 from swissgeol_doc_processing.utils.table_detection import TableStructure
 
 
@@ -23,7 +23,7 @@ class ProtocolSidebarExtractor:
     def find_in_words(
         all_words: list[TextWord],
         lines: list[TextLine],
-        line_rtree: fastquadtree.RectQuadTreeObjects,
+        line_rtree: TextLineRTree,
         used_entry_rects: list[pymupdf.Rect],
         table_structures: list[TableStructure],
         sidebar_params: dict,
@@ -33,7 +33,7 @@ class ProtocolSidebarExtractor:
         Args:
             all_words (list[TextWord]): All words in the page.
             lines (list[TextLine]): All text lines in the page.
-            line_rtree (fastquadtree.RectQuadTreeObjects): Pre-built R-tree for spatial queries.
+            line_rtree (TextLineRTree): Pre-built R-tree for spatial queries.
             used_entry_rects (list[pymupdf.Rect]): Part of the document to ignore.
             table_structures: list[TableStructure]:  List of table structures.
             sidebar_params (dict): Parameters for the ProtocolSidebar objects.

--- a/src/extraction/features/stratigraphy/sidebar/utils/a_above_b_sidebar_validator.py
+++ b/src/extraction/features/stratigraphy/sidebar/utils/a_above_b_sidebar_validator.py
@@ -2,10 +2,9 @@
 
 import dataclasses
 
-import fastquadtree
-
 from extraction.features.stratigraphy.sidebar.classes.a_above_b_sidebar import AAboveBSidebar
 from extraction.features.stratigraphy.sidebar.classes.sidebar import SidebarNoise, noise_count
+from swissgeol_doc_processing.text.textline_rtree import TextLineRTree
 
 
 @dataclasses.dataclass
@@ -61,7 +60,7 @@ class AAboveBSidebarValidator:
         return corr_coef and corr_coef > corr_coef_threshold
 
     def reduce_until_valid(
-        self, sidebar_noise: SidebarNoise[AAboveBSidebar], line_rtree: fastquadtree.RectQuadTreeObjects
+        self, sidebar_noise: SidebarNoise[AAboveBSidebar], line_rtree: TextLineRTree
     ) -> SidebarNoise | None:
         """Removes entries from the depth column until it fulfills the is_valid condition.
 
@@ -70,7 +69,7 @@ class AAboveBSidebarValidator:
 
         Args:
             sidebar_noise (SidebarNoise): The SidebarNoise wrapping the AAboveBSidebar to validate.
-            line_rtree (rtree.index.Index): Pre-built R-tree of all text lines on page for spatial queries.
+            line_rtree (TextLineRTree): Pre-built R-tree of all text lines on page for spatial queries.
 
         Returns:
             sidebar_noise | None : The current SidebarNoise with entries removed from Sidebar until it is valid

--- a/src/swissgeol_doc_processing/text/extract_text.py
+++ b/src/swissgeol_doc_processing/text/extract_text.py
@@ -37,7 +37,7 @@ def extract_text_lines_from_bbox(page: pymupdf.Page, bbox: pymupdf.Rect | None) 
     Returns:
         list[TextLine]: A list of text lines.
     """
-    raw_lines = []
+    lines = []
     for block in page.get_text("rawdict", clip=bbox)["blocks"]:
         if "lines" in block:
             for line in block["lines"]:
@@ -59,22 +59,7 @@ def extract_text_lines_from_bbox(page: pymupdf.Page, bbox: pymupdf.Rect | None) 
                     if len(word_text) > 0:
                         words.append(TextWord(word_rect, word_text, page.number + 1))
 
-                raw_lines.append(TextLine(words, text_angle))
-
-    lines = []
-    current_line_words = []
-    for line_index, raw_line in enumerate(raw_lines):
-        for word_index, word in enumerate(raw_line.words):
-            remaining_line = TextLine(raw_line.words[word_index:], raw_line.text_angle)
-            # Check if the remaining words of the line should be treated as a separate text line, even if they are
-            # only a tailing segment of the "raw line" as it was extracted from the PDF.
-            if len(current_line_words) > 0 and remaining_line.is_line_start(lines, raw_lines[line_index + 1 :]):
-                lines.append(TextLine(current_line_words, raw_line.text_angle))
-                current_line_words = []
-            current_line_words.append(word)
-        if current_line_words:
-            lines.append(TextLine(current_line_words, raw_line.text_angle))
-            current_line_words = []
+                lines.append(TextLine(words, text_angle))
 
     return lines
 

--- a/src/swissgeol_doc_processing/text/textline.py
+++ b/src/swissgeol_doc_processing/text/textline.py
@@ -7,7 +7,6 @@ import re
 import pymupdf
 
 from swissgeol_doc_processing.geometry.geometry_dataclasses import RectWithPage, RectWithPageMixin
-from swissgeol_doc_processing.geometry.util import x_overlap_significant_largest
 from swissgeol_doc_processing.text.matching_params_analytics import MatchingParamsAnalytics
 from swissgeol_doc_processing.text.stemmer import find_matching_expressions
 
@@ -86,59 +85,6 @@ class TextLine(RectWithPageMixin):
         split_threshold = parameters.get("compound_split_threshold", 0.4)
 
         return find_matching_expressions(patterns, split_threshold, text_tokens, language, analytics, search_excluding)
-
-    def is_line_start(self, raw_lines_before: list[TextLine], raw_lines_after: list[TextLine]) -> bool:
-        """Determine whether this line can be considered the start of a properly aligned text block.
-
-        This method checks whether the line's x0-coordinate (left margin) aligns with surrounding
-        lines above and below. If enough nearby lines share the same left margin (within a tolerance),
-        the current line is assumed to belong to the same column and can be trusted as the start
-        of a valid text segment.
-
-        The check is necessary because PDF text extraction sometimes merges or splits lines in a way
-        that spans multiple columns. This heuristic helps ensure column consistency, though it is
-        not fully robust until line detection is integrated more directly.
-
-        Args:
-            raw_lines_before (list[TextLine]): Neighboring lines before this line.
-            raw_lines_after (list[TextLine]): Neighboring lines after this line.
-
-        Returns:
-            bool: True if the line aligns consistently with its neighbors and can be trusted
-                as the start of a column, False otherwise.
-        """
-
-        def significant_overlap(line: TextLine) -> bool:
-            return x_overlap_significant_largest(line.rect, self.rect, 0.5)
-
-        matching_lines_before = [line for line in raw_lines_before if significant_overlap(line)]
-        matching_lines_after = [line for line in raw_lines_after if significant_overlap(line)]
-
-        def count_points(lines: list[TextLine]) -> tuple[int, int]:
-            exact_points = 0
-            indentation_points = 0
-            for other in lines:
-                line_height = self.rect.height
-                if max(other.rect.y0 - self.rect.y1, self.rect.y0 - other.rect.y1) > 5 * line_height:
-                    # too far away vertically
-                    return exact_points, indentation_points
-
-                if abs(other.rect.x0 - self.rect.x0) < 0.2 * line_height:
-                    exact_points += 1
-                elif 0 < other.rect.x0 - self.rect.x0 < 2 * line_height:
-                    indentation_points += 1
-                else:
-                    # other line is more to the left, and significantly more to the right (allowing for indentation)
-                    return exact_points, indentation_points
-            return exact_points, indentation_points
-
-        # three lines before and three lines after
-        exact_points_1, indentation_points_1 = count_points(matching_lines_before[:-4:-1])
-        exact_points_2, indentation_points_2 = count_points(matching_lines_after[:3])
-        exact_points = exact_points_1 + exact_points_2
-        indentation_points = indentation_points_1 + indentation_points_2
-
-        return exact_points >= 3 or (exact_points >= 2 and indentation_points >= 1)
 
     def to_json(self) -> dict:
         """Convert the TextLine object to a JSON serializable dictionary."""

--- a/src/swissgeol_doc_processing/text/textline_rtree.py
+++ b/src/swissgeol_doc_processing/text/textline_rtree.py
@@ -1,4 +1,4 @@
-"""This module provides an efficient spacial index for text lines."""
+"""This module provides an efficient spatial index for text lines."""
 
 import fastquadtree
 import pymupdf

--- a/src/swissgeol_doc_processing/text/textline_rtree.py
+++ b/src/swissgeol_doc_processing/text/textline_rtree.py
@@ -1,0 +1,22 @@
+"""This module provides an efficient spacial index for text lines."""
+
+import fastquadtree
+import pymupdf
+
+from swissgeol_doc_processing.text.textline import TextLine
+
+
+class TextLineRTree:
+    """Small wrapper around fastquadtree.RectQuadTreeObjects for text lines collections."""
+
+    def __init__(self, text_lines: list[TextLine]):
+        min_x = min([line.rect.x0 for line in text_lines])
+        max_x = max([line.rect.x1 for line in text_lines])
+        min_y = min([line.rect.y0 for line in text_lines])
+        max_y = max([line.rect.y1 for line in text_lines])
+        self.text_line_rtree = fastquadtree.RectQuadTreeObjects((min_x, min_y, max_x, max_y), capacity=8)
+        for line in text_lines:
+            self.text_line_rtree.insert((line.rect.x0, line.rect.y0, line.rect.x1, line.rect.y1), obj=line)
+
+    def query(self, rect: pymupdf.Rect) -> list[TextLine]:
+        return [item.obj for item in self.text_line_rtree.query((rect.x0, rect.y0, rect.x1, rect.y1))]

--- a/src/swissgeol_doc_processing/text/textline_rtree.py
+++ b/src/swissgeol_doc_processing/text/textline_rtree.py
@@ -23,4 +23,5 @@ class TextLineRTree:
             self.text_line_rtree.insert((line.rect.x0, line.rect.y0, line.rect.x1, line.rect.y1), obj=line)
 
     def query(self, rect: pymupdf.Rect) -> list[TextLine]:
+        """Efficiently finds all text lines whose bounding box intersects with the given rectangle."""
         return [item.obj for item in self.text_line_rtree.query((rect.x0, rect.y0, rect.x1, rect.y1))]

--- a/src/swissgeol_doc_processing/text/textline_rtree.py
+++ b/src/swissgeol_doc_processing/text/textline_rtree.py
@@ -10,11 +10,15 @@ class TextLineRTree:
     """Small wrapper around fastquadtree.RectQuadTreeObjects for text lines collections."""
 
     def __init__(self, text_lines: list[TextLine]):
-        min_x = min([line.rect.x0 for line in text_lines])
-        max_x = max([line.rect.x1 for line in text_lines])
-        min_y = min([line.rect.y0 for line in text_lines])
-        max_y = max([line.rect.y1 for line in text_lines])
-        self.text_line_rtree = fastquadtree.RectQuadTreeObjects((min_x, min_y, max_x, max_y), capacity=8)
+        if text_lines:
+            min_x = min([line.rect.x0 for line in text_lines])
+            max_x = max([line.rect.x1 for line in text_lines])
+            min_y = min([line.rect.y0 for line in text_lines])
+            max_y = max([line.rect.y1 for line in text_lines])
+            bounds = (min_x, min_y, max_x, max_y)
+        else:
+            bounds = (0, 0, 1, 1)
+        self.text_line_rtree = fastquadtree.RectQuadTreeObjects(bounds, capacity=8)
         for line in text_lines:
             self.text_line_rtree.insert((line.rect.x0, line.rect.y0, line.rect.x1, line.rect.y1), obj=line)
 

--- a/src/swissgeol_doc_processing/utils/table_detection.py
+++ b/src/swissgeol_doc_processing/utils/table_detection.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 
 import pymupdf
 
-from swissgeol_doc_processing.geometry.geometry_dataclasses import Line
+from swissgeol_doc_processing.geometry.geometry_dataclasses import Line, Point
 from swissgeol_doc_processing.text.textline import TextLine
 
 logger = logging.getLogger(__name__)
@@ -26,23 +26,44 @@ class TableStructure:
 
 
 def detect_structure_lines(
-    geometric_lines: list[Line], table_detection_params: dict, filter_lines=True
+    geometric_lines: list[Line], text_lines: list[TextLine], table_detection_params: dict
 ) -> list[StructureLine]:
     """Detect significant horizonal and vertical lines in a document.
 
     Args:
         geometric_lines (list[Line]): Geometric lines (e.g., from layout analysis).
-        filter_lines (bool, optional): Whether to filter lines before classification. Defaults to True.
+        text_lines (list[TextLine]): The text lines on the page, to filter out geometric lines that intersect with text
+            lines.
         table_detection_params (dict): Table detection parameters.
 
     Returns:
         List of detected structure lines
     """
     # Filter and classify lines
-    final_lines = (
-        _filter_significant_lines(geometric_lines, table_detection_params) if filter_lines else geometric_lines
-    )
+    final_lines = _filter_significant_lines(geometric_lines, table_detection_params)
+
+    final_lines = [
+        line
+        for line in final_lines
+        if not any(
+            middle_line(text_word.rect).intersects_with(line)
+            for text_line in text_lines
+            for text_word in text_line.words
+        )
+    ]
     return _separate_by_orientation(final_lines, table_detection_params)
+
+
+def middle_line(rect: pymupdf.Rect) -> Line:
+    """Returns a horizontal line through the middle of the rectangle.
+
+    Keep a small margin of 25% of the rectangle's height to the left and right edges.
+    """
+    x_middle = (rect.x0 + rect.x1) / 2
+    y_middle = (rect.y0 + rect.y1) / 2
+    left = min(rect.x0 + 0.25 * rect.height, x_middle)
+    right = max(rect.x1 - 0.25 * rect.height, x_middle)
+    return Line(Point(left, y_middle), Point(right, y_middle))
 
 
 def detect_table_structures(
@@ -64,7 +85,7 @@ def detect_table_structures(
     Returns:
         List of detected table structures
     """
-    structure_lines = detect_structure_lines(geometric_lines, table_detection_params)
+    structure_lines = detect_structure_lines(geometric_lines, text_lines, table_detection_params)
     table_candidates = _find_table_structures(
         structure_lines, table_detection_params, page_width, page_height, text_lines
     )

--- a/src/swissgeol_doc_processing/utils/table_detection.py
+++ b/src/swissgeol_doc_processing/utils/table_detection.py
@@ -29,7 +29,7 @@ class TableStructure:
 def detect_structure_lines(
     geometric_lines: list[Line], text_line_rtree: TextLineRTree, table_detection_params: dict
 ) -> list[StructureLine]:
-    """Detect significant horizonal and vertical lines in a document.
+    """Detect significant horizontal and vertical lines in a document.
 
     We ignore vertical lines that significantly intersect with any word, since these are likely to be
     grid lines, not lines from a table structure.
@@ -44,23 +44,28 @@ def detect_structure_lines(
     """
     # Filter and classify lines
     signficant_lines = _filter_significant_lines(geometric_lines, table_detection_params)
+    structure_lines = _separate_by_orientation(signficant_lines, table_detection_params)
 
     final_lines = []
-    for line in signficant_lines:
-        bbox = pymupdf.Rect(
-            min(line.start.x, line.end.x),
-            min(line.start.y, line.end.y),
-            max(line.start.x, line.end.x),
-            max(line.start.y, line.end.y),
-        )
-        if not any(
-            middle_line(text_word.rect).intersects_with(line)
-            for text_line in text_line_rtree.query(bbox)
-            for text_word in text_line.words
-        ):
-            final_lines.append(line)
+    for structure_line in structure_lines:
+        if structure_line.is_vertical:
+            line = structure_line.line
+            bbox = pymupdf.Rect(
+                min(line.start.x, line.end.x),
+                min(line.start.y, line.end.y),
+                max(line.start.x, line.end.x),
+                max(line.start.y, line.end.y),
+            )
+            if not any(
+                middle_line(text_word.rect).intersects_with(line)
+                for text_line in text_line_rtree.query(bbox)
+                for text_word in text_line.words
+            ):
+                final_lines.append(structure_line)
+        else:
+            final_lines.append(structure_line)
 
-    return _separate_by_orientation(final_lines, table_detection_params)
+    return final_lines
 
 
 def middle_line(rect: pymupdf.Rect) -> Line:

--- a/src/swissgeol_doc_processing/utils/table_detection.py
+++ b/src/swissgeol_doc_processing/utils/table_detection.py
@@ -10,6 +10,7 @@ import pymupdf
 
 from swissgeol_doc_processing.geometry.geometry_dataclasses import Line, Point
 from swissgeol_doc_processing.text.textline import TextLine
+from swissgeol_doc_processing.text.textline_rtree import TextLineRTree
 
 logger = logging.getLogger(__name__)
 
@@ -26,31 +27,39 @@ class TableStructure:
 
 
 def detect_structure_lines(
-    geometric_lines: list[Line], text_lines: list[TextLine], table_detection_params: dict
+    geometric_lines: list[Line], text_line_rtree: TextLineRTree, table_detection_params: dict
 ) -> list[StructureLine]:
     """Detect significant horizonal and vertical lines in a document.
 
+    We ignore vertical lines that significantly intersect with any word, since these are likely to be
+    grid lines, not lines from a table structure.
+
     Args:
         geometric_lines (list[Line]): Geometric lines (e.g., from layout analysis).
-        text_lines (list[TextLine]): The text lines on the page, to filter out geometric lines that intersect with text
-            lines.
+        text_line_rtree (TextLineRTree): Pre-built R-tree of all text lines on page for spatial queries.
         table_detection_params (dict): Table detection parameters.
 
     Returns:
         List of detected structure lines
     """
     # Filter and classify lines
-    final_lines = _filter_significant_lines(geometric_lines, table_detection_params)
+    signficant_lines = _filter_significant_lines(geometric_lines, table_detection_params)
 
-    final_lines = [
-        line
-        for line in final_lines
+    final_lines = []
+    for line in signficant_lines:
+        bbox = pymupdf.Rect(
+            min(line.start.x, line.end.x),
+            min(line.start.y, line.end.y),
+            max(line.start.x, line.end.x),
+            max(line.start.y, line.end.y),
+        )
         if not any(
             middle_line(text_word.rect).intersects_with(line)
-            for text_line in text_lines
+            for text_line in text_line_rtree.query(bbox)
             for text_word in text_line.words
-        )
-    ]
+        ):
+            final_lines.append(line)
+
     return _separate_by_orientation(final_lines, table_detection_params)
 
 
@@ -85,10 +94,13 @@ def detect_table_structures(
     Returns:
         List of detected table structures
     """
-    structure_lines = detect_structure_lines(geometric_lines, text_lines, table_detection_params)
+    text_line_rtree = TextLineRTree(text_lines)
+
+    structure_lines = detect_structure_lines(geometric_lines, text_line_rtree, table_detection_params)
     table_candidates = _find_table_structures(
-        structure_lines, table_detection_params, page_width, page_height, text_lines
+        structure_lines, table_detection_params, page_width, page_height, text_line_rtree
     )
+
     table_candidates = [
         table
         for table in table_candidates
@@ -157,9 +169,9 @@ class StructureLine:
 def _find_table_structures(
     lines: list[StructureLine],
     table_detection_params: dict,
-    page_width: float = None,
-    page_height: float = None,
-    text_lines: list = None,
+    page_width: float,
+    page_height: float,
+    text_line_rtree: TextLineRTree,
 ) -> list[TableStructure]:
     """Find multiple non-intersecting table structures using region-based detection.
 
@@ -168,7 +180,7 @@ def _find_table_structures(
         table_detection_params: Configuration parameters
         page_width: Page width
         page_height: Page height
-        text_lines: List of text lines for content analysis
+        text_line_rtree (TextLineRTree): All text lines on the page as an RTree for efficient spacial querying.
 
     Returns:
         List of table structures
@@ -184,7 +196,7 @@ def _find_table_structures(
 
         # Create table structure for this region
         table = _create_table_from_region(
-            region_h_lines, region_v_lines, table_detection_params, page_width, page_height, text_lines
+            region_h_lines, region_v_lines, table_detection_params, page_width, page_height, text_line_rtree
         )
         if table.confidence >= table_detection_params["tables"]["min_confidence"]:
             detected_tables.append(table)
@@ -291,9 +303,9 @@ def _create_table_from_region(
     horizontal_lines: list[Line],
     vertical_lines: list[Line],
     table_detection_params: dict,
-    page_width: float = None,
-    page_height: float = None,
-    text_lines: list = None,
+    page_width: float,
+    page_height: float,
+    text_line_rtree: TextLineRTree,
 ) -> TableStructure | None:
     """Create a table structure from a region of connected lines.
 
@@ -303,7 +315,7 @@ def _create_table_from_region(
         table_detection_params: Configuration parameters
         page_width: Page width
         page_height: Page height
-        text_lines: Text lines for content analysis
+        text_line_rtree (TextLineRTree): All text lines on the page as an RTree for efficient spacial querying.
 
     Returns:
         TableStructure object or None
@@ -327,7 +339,13 @@ def _create_table_from_region(
     line_density = len(horizontal_lines + vertical_lines) / (area / 10000) if area > 0 else 0
 
     confidence = _calculate_structure_confidence(
-        bounding_rect, horizontal_lines, vertical_lines, table_detection_params, page_width, page_height, text_lines
+        bounding_rect,
+        horizontal_lines,
+        vertical_lines,
+        table_detection_params,
+        page_width,
+        page_height,
+        text_line_rtree,
     )
 
     return TableStructure(
@@ -344,9 +362,9 @@ def _calculate_structure_confidence(
     h_lines: list[Line],
     v_lines: list[Line],
     table_detection_params: dict,
-    page_width: float = None,
-    page_height: float = None,
-    text_lines: list = None,
+    page_width: float,
+    page_height: float,
+    text_line_rtree: TextLineRTree,
 ) -> float:
     """Calculate confidence score for the table structure.
 
@@ -357,7 +375,7 @@ def _calculate_structure_confidence(
         table_detection_params: Configuration parameters
         page_width: Page width
         page_height: Page height
-        text_lines: List of text lines for content analysis
+        text_line_rtree (TextLineRTree): All text lines on the page as an RTree for efficient spacial querying.
 
     Returns:
         Confidence score between 0 and 1
@@ -382,8 +400,8 @@ def _calculate_structure_confidence(
 
     # Text bonus score - bonus for text content within the table structure
     text_bonus = 0.0
-    if text_lines:
-        text_within = [line for line in text_lines if rect.intersects(line.rect)]
+    if text_line_rtree:
+        text_within = text_line_rtree.query(rect)
         if text_within:
             text_scoring = table_config.get("text_scoring", {})
             text_bonus = min(

--- a/src/swissgeol_doc_processing/utils/table_detection.py
+++ b/src/swissgeol_doc_processing/utils/table_detection.py
@@ -43,8 +43,8 @@ def detect_structure_lines(
         List of detected structure lines
     """
     # Filter and classify lines
-    signficant_lines = _filter_significant_lines(geometric_lines, table_detection_params)
-    structure_lines = _separate_by_orientation(signficant_lines, table_detection_params)
+    significant_lines = _filter_significant_lines(geometric_lines, table_detection_params)
+    structure_lines = _separate_by_orientation(significant_lines, table_detection_params)
 
     final_lines = []
     for structure_line in structure_lines:
@@ -185,7 +185,7 @@ def _find_table_structures(
         table_detection_params: Configuration parameters
         page_width: Page width
         page_height: Page height
-        text_line_rtree (TextLineRTree): All text lines on the page as an RTree for efficient spacial querying.
+        text_line_rtree (TextLineRTree): All text lines on the page as an RTree for efficient spatial querying.
 
     Returns:
         List of table structures
@@ -320,7 +320,7 @@ def _create_table_from_region(
         table_detection_params: Configuration parameters
         page_width: Page width
         page_height: Page height
-        text_line_rtree (TextLineRTree): All text lines on the page as an RTree for efficient spacial querying.
+        text_line_rtree (TextLineRTree): All text lines on the page as an RTree for efficient spatial querying.
 
     Returns:
         TableStructure object or None
@@ -380,7 +380,7 @@ def _calculate_structure_confidence(
         table_detection_params: Configuration parameters
         page_width: Page width
         page_height: Page height
-        text_line_rtree (TextLineRTree): All text lines on the page as an RTree for efficient spacial querying.
+        text_line_rtree (TextLineRTree): All text lines on the page as an RTree for efficient spatial querying.
 
     Returns:
         Confidence score between 0 and 1
@@ -405,13 +405,9 @@ def _calculate_structure_confidence(
 
     # Text bonus score - bonus for text content within the table structure
     text_bonus = 0.0
-    if text_line_rtree:
-        text_within = text_line_rtree.query(rect)
-        if text_within:
-            text_scoring = table_config.get("text_scoring", {})
-            text_bonus = min(
-                text_scoring.get("text_weights"), len(text_within) * text_scoring.get("text_presence_weight")
-            )
+    if text_within := text_line_rtree.query(rect):
+        text_scoring = table_config.get("text_scoring", {})
+        text_bonus = min(text_scoring.get("text_weights"), len(text_within) * text_scoring.get("text_presence_weight"))
 
     # Weighted combination
     total_confidence = size_score + line_score + text_bonus

--- a/tests/test_find_sidebar.py
+++ b/tests/test_find_sidebar.py
@@ -1,6 +1,5 @@
 """Test suite for the find_depth_columns module."""
 
-import fastquadtree
 import pymupdf
 import pytest
 
@@ -13,6 +12,7 @@ from extraction.features.stratigraphy.sidebar.extractor.a_to_b_sidebar_extractor
     AToBSidebarExtractor,
 )
 from swissgeol_doc_processing.text.textline import TextLine, TextWord
+from swissgeol_doc_processing.text.textline_rtree import TextLineRTree
 
 PAGE_NUMBER = 1
 
@@ -92,9 +92,7 @@ def test_aabovebsidebarextractor_arithmetic_progression():  # noqa: D103
         TextWord(pymupdf.Rect(0, 6, 5, 7), "40.0", PAGE_NUMBER),
         TextWord(pymupdf.Rect(0, 8, 5, 9), "50.0", PAGE_NUMBER),
     ]
-    word_rtree = fastquadtree.RectQuadTreeObjects((0, 0, 10, 10), capacity=8)
-    for word in all_words:
-        word_rtree.insert((word.rect.x0, word.rect.y0, word.rect.x1, word.rect.y1))
+    word_rtree = TextLineRTree([TextLine([word]) for word in all_words])
     """Test the AAboveBSidebarExtractor with an arithmetic progression."""
     sidebars_noise = AAboveBSidebarExtractor.find_in_words(
         all_words,
@@ -116,9 +114,7 @@ def test_aabovebsidebarextractor():  # noqa: D103
         TextWord(pymupdf.Rect(0, 6, 5, 7), "40.0", PAGE_NUMBER),
         TextWord(pymupdf.Rect(0, 8, 5, 9), "50.0", PAGE_NUMBER),
     ]
-    word_rtree = fastquadtree.RectQuadTreeObjects((0, 0, 10, 10), capacity=8)
-    for word in all_words:
-        word_rtree.insert((word.rect.x0, word.rect.y0, word.rect.x1, word.rect.y1), obj=word)
+    word_rtree = TextLineRTree([TextLine([word]) for word in all_words])
     sidebars_noise = AAboveBSidebarExtractor.find_in_words(
         all_words,
         word_rtree,
@@ -151,9 +147,7 @@ def test_aabovebsidebarextractor_two_column():  # noqa: D103
         TextWord(pymupdf.Rect(20, 8, 25, 9), "50.0", PAGE_NUMBER),
         TextWord(pymupdf.Rect(20, 10, 25, 11), "61.0", PAGE_NUMBER),
     ]
-    word_rtree = fastquadtree.RectQuadTreeObjects((0, 0, 30, 30), capacity=8)
-    for word in all_words:
-        word_rtree.insert((word.rect.x0, word.rect.y0, word.rect.x1, word.rect.y1), obj=word)
+    word_rtree = TextLineRTree([TextLine([word]) for word in all_words])
     sidebars_noise = AAboveBSidebarExtractor.find_in_words(
         all_words,
         word_rtree,


### PR DESCRIPTION
The legacy method of splitting `TextLine`s based on the `is_line_start` method was intended to detect where text was extracted as a single text line from a PDF file, even though the correct interpretation would be to treat the words as two or more adjacent lines.

E.g. in this example (ZH `267122002-bp.pdf`), the numbers 85 and 10 should ideally be treated separately, and not considered to be part of the line `"... m.10%Steinen,komp.8510"`.

<img width="374" height="56" alt="image" src="https://github.com/user-attachments/assets/27ab47ce-58fa-43ca-8010-09ba17758cff" />

The existing logic was purely based on the positioning of the text lines, and did not work in a very robust way. For example, it splits text lines too aggressively on several Geoquat dataset inputs (see improvements listed below).

Moreover, sometimes this would split the borehole name into two lines, preventing accurate name extraction. For example, this affects two SBB profiles from https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/525, namely `45295.pdf` (where "Kernbohrung Kb 02/4" used to be split into "Kernbohrung Kb" and "02/4") and `45456.pdf` (where "RB 1/01/P" used to be split into "RB" and "1/01/P").


We replace it with a new logic, where text lines are only split later on, based on the detected structure lines from the table-like structures.

## Dealing with grid lines

The main challenge with this approach are documents that contain grid lines, which might lead to excessive splitting. Examples:
- ZH `267125223-bp.pdf`
- ZH `267125334-bp.pdf`
- ZH `267125338-bp.pdf`
- ZH `267125339-bp.pdf`
- ZH `268124125-bp.pdf`
- ZH `268124375-bp.pdf`
- ZH `677259003-bp.pdf`

The proposed implementation solves most of these cases by rejecting vertical lines that clearly intersect words, already when constructing the table-like structures.

There are still many grid lines that become part of `TableStructure` objects, and it would be cleaner to somehow detect and remove all of them. However, that is beyond the scope of this issue. For the time being, I would say that the proposed approach works well enough.

## Impact on runtime

 While we reduce the computation that is necessary in `extract_text.py`, we increase the computation required to construct `TableStructures`, as well as adding a new method `_split_text_lines_by_table_structures` to `extract.py`.

This involves a nested loop to check for intersections between words and vertical lines. I was able to make this sufficiently efficient by using an RTree structure for efficient spacial indexing of text lines in `table_detection.py`. This is not entirely new, it was already used elsewhere (e.g. for computing the sidebar noise count), but I've now created a dedicated `TextLineRTree` wrapper class for it, in order to make usage slightly easier.

Overall, on my machine, this seems to make the entire pipeline slightly faster if anything, thought the change is hardly significant.

## Impact on benchmarking

The proposed implementation has only a small impact (in the region of +/- 0.1%) on the benchmarking metrics.

If it were not for two other issues that interfere on a few files, there would have been a measurable improvement on the Geoquat benchmark.

In detail:

**Zurich**
- Minor decrease of material description F1 on `268124125-bp.pdf` (incorrect split due to grid lines)
- Minor decrease of groundwater F1 on `268124635-bp.pdf` (additional incorrect groundwater measurement)

Line splitting behaviour is preserved without changes on `267122002-bp.pdf`. 

**Geoquat validation**
- Worse on `12327.pdf` (`AAboveBSidebar` incorrectly selected over `LayerIndicatorSidebar` -> https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/545)
- Better on `1506.pdf` (`LayerIndicatorSidebar` correctly selected)
- Slightly worse on `680.pdf` (incorrect `LayerIndicatorSidebar` selected on page 2 -> https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/545)
- Slightly worse on `7317.pdf` (`AToBSidebar` selected instead of `LayerIndicatorSidebar`, both are reasonable)
- Better on `A11363.pdf` (additional good text line split)
- Better on `A218.pdf` (lost a false positive text line split)
- Better on `A337.pdf` (lost a false positive text line split)
- Better on `A356.pdf` (lost a false positive text line split)
- Better on `A430.pdf` (lost a false positive text line split)
- Better on `A8384.pdf` (low quality scan, not sure what is happening)
- Worse on `AKB_137.pdf` (worse `AAboveBSidebar` selected -> https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/545 and https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/546)
- Worse on `B147.pdf` (incorrect text splits due to grid lines on page 2)
- Better on `B156.pdf` (additional good text line splits)
- Worse on `V13.pdf` (actually we get an additional good text line split, but unfortunately this makes space for an entirely new false positive borehole -> https://github.com/swisstopo/swissgeol-boreholes-dataextraction/issues/546 )
- Slightly worse on `V69.pdf` (a useful text line split is now no longer applied)

Line splitting behaviour is preserved without changes on several additional borehole profiles, including `A11300.pdf`, `A11363.pdf`, `A11394.pdf`, `A11436.pdf`, `A1183.pdf` and `A263.pdf`. 