### PR TITLE
Extract line breaks in material descriptions

### DIFF
--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -531,7 +531,7 @@ class LayerMaterialDescriptionSchema(BaseModel):
         cls, prediction: MaterialDescription, pdf_img_scalings: list[tuple[float]]
     ) -> "LayerMaterialDescriptionSchema":
         return cls(
-            text=prediction.text,
+            text=prediction.text_with_line_breaks,
             bounding_boxes=[
                 BoundingBoxWithPage(
                     page_number=line_feature.page_number,

--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -531,7 +531,7 @@ class LayerMaterialDescriptionSchema(BaseModel):
         cls, prediction: MaterialDescription, pdf_img_scalings: list[tuple[float]]
     ) -> "LayerMaterialDescriptionSchema":
         return cls(
-            text=prediction.text_with_line_breaks,
+            text=prediction.text,
             bounding_boxes=[
                 BoundingBoxWithPage(
                     page_number=line_feature.page_number,

--- a/src/extraction/annotations/draw.py
+++ b/src/extraction/annotations/draw.py
@@ -250,6 +250,13 @@ class PageDrawer:
                     fill=pymupdf.utils.getColor(color),
                     width=0,
                 )
+                if line.feature.text.endswith("\n"):
+                    self.shape.draw_line(
+                        line.rect.top_right * self.page.derotation_matrix,
+                        line.rect.bottom_right * self.page.derotation_matrix,
+                    )
+                    self.shape.finish(color=pymupdf.utils.getColor("blue"), stroke_opacity=0.5, width=2)
+
                 self._draw_correctness_line(
                     start=pymupdf.Point(line.rect.top_left.x - 6, line.rect.top_left.y),
                     end=pymupdf.Point(line.rect.bottom_left.x - 6, line.rect.bottom_left.y),

--- a/src/extraction/core/extract.py
+++ b/src/extraction/core/extract.py
@@ -82,6 +82,35 @@ def open_pdf(
     doc.close()
 
 
+def _apply_reference_line_width(layers_with_bb_in_document: LayersInDocument) -> None:
+    """Stamp the width of each borehole's longest description line onto its MaterialDescriptions.
+
+    `MaterialDescription.text_with_line_breaks` uses this as a reference for how long a line can get
+    before the layout wraps it. Scoped per borehole (not per file): different boreholes, even across
+    pages of the same file, can have differently sized description columns.
+    """
+    new_boreholes = []
+    for borehole in layers_with_bb_in_document.boreholes_layers_with_bb:
+        line_widths = [line.rect.width for layer in borehole.predictions for line in layer.material_description.lines]
+        max_line_width = max(line_widths, default=None)
+
+        new_boreholes.append(
+            dataclasses.replace(
+                borehole,
+                predictions=[
+                    dataclasses.replace(
+                        layer,
+                        material_description=dataclasses.replace(
+                            layer.material_description, max_line_width=max_line_width
+                        ),
+                    )
+                    for layer in borehole.predictions
+                ],
+            )
+        )
+    layers_with_bb_in_document.boreholes_layers_with_bb = new_boreholes
+
+
 def extract(
     file: Path | BytesIO,
     filename: str,
@@ -177,6 +206,7 @@ def extract(
 
         # Merge detections if possible
         layers_with_bb_in_document = LayersInDocument(merge_boreholes(boreholes_per_page, matching_params), filename)
+        _apply_reference_line_width(layers_with_bb_in_document)
 
         # create list of BoreholePrediction objects with all the separate lists
         borehole_predictions_list: list[BoreholePredictions] = BoreholeListBuilder(

--- a/src/extraction/core/extract.py
+++ b/src/extraction/core/extract.py
@@ -20,7 +20,7 @@ from extraction.features.predictions.borehole_predictions import BoreholePredict
 from extraction.features.predictions.file_predictions import FilePredictions
 from extraction.features.predictions.predictions import BoreholeListBuilder
 from extraction.features.stratigraphy.layer.continuation_detection import merge_boreholes
-from extraction.features.stratigraphy.layer.layer import LayersInDocument
+from extraction.features.stratigraphy.layer.layer import ExtractedBorehole, LayersInDocument
 from swissgeol_doc_processing.geometry.geometry_dataclasses import Line
 from swissgeol_doc_processing.geometry.line_detection import extract_lines
 from swissgeol_doc_processing.text.extract_text import extract_text_lines
@@ -82,33 +82,15 @@ def open_pdf(
     doc.close()
 
 
-def _apply_reference_line_width(layers_with_bb_in_document: LayersInDocument) -> None:
-    """Stamp the width of each borehole's longest description line onto its MaterialDescriptions.
+def _reference_line_width(borehole: ExtractedBorehole) -> float | None:
+    """Return the width of each borehole's longest description line.
 
-    `MaterialDescription.text_with_line_breaks` uses this as a reference for how long a line can get
+    `MaterialDescription.insert_line_breaks` uses this as a reference for how long a line can get
     before the layout wraps it. Scoped per borehole (not per file): different boreholes, even across
     pages of the same file, can have differently sized description columns.
     """
-    new_boreholes = []
-    for borehole in layers_with_bb_in_document.boreholes_layers_with_bb:
-        line_widths = [line.rect.width for layer in borehole.predictions for line in layer.material_description.lines]
-        max_line_width = max(line_widths, default=None)
-
-        new_boreholes.append(
-            dataclasses.replace(
-                borehole,
-                predictions=[
-                    dataclasses.replace(
-                        layer,
-                        material_description=dataclasses.replace(
-                            layer.material_description, max_line_width=max_line_width
-                        ),
-                    )
-                    for layer in borehole.predictions
-                ],
-            )
-        )
-    layers_with_bb_in_document.boreholes_layers_with_bb = new_boreholes
+    line_widths = [line.rect.width for layer in borehole.predictions for line in layer.material_description.lines]
+    return max(line_widths, default=None)
 
 
 def extract(
@@ -206,7 +188,11 @@ def extract(
 
         # Merge detections if possible
         layers_with_bb_in_document = LayersInDocument(merge_boreholes(boreholes_per_page, matching_params), filename)
-        _apply_reference_line_width(layers_with_bb_in_document)
+
+        for borehole in layers_with_bb_in_document.boreholes_layers_with_bb:
+            max_line_width = _reference_line_width(borehole)
+            for layer in borehole.predictions:
+                layer.material_description.insert_line_breaks(max_line_width)
 
         # create list of BoreholePrediction objects with all the separate lists
         borehole_predictions_list: list[BoreholePredictions] = BoreholeListBuilder(

--- a/src/swissgeol_doc_processing/text/textblock.py
+++ b/src/swissgeol_doc_processing/text/textblock.py
@@ -40,7 +40,6 @@ class MaterialDescription(ExtractedFeature):
 
     text: str
     lines: list[FeatureOnPage[MaterialDescriptionLine]]
-    max_line_width: float | None = None
 
     @property
     def rects_with_pages(self) -> list[RectWithPage]:
@@ -69,8 +68,7 @@ class MaterialDescription(ExtractedFeature):
         """Get the bounding rectangle for a specific page."""
         return next((p_rect.rect for p_rect in self.rects_with_pages if p_rect.page_number == page_number), None)
 
-    @property
-    def text_with_line_breaks(self) -> str:
+    def insert_line_breaks(self, max_line_width: float | None) -> MaterialDescription:
         """Rejoin description lines with inferred line breaks, for display purposes only.
 
         Compares each line's width against `max_line_width` - the widest description line seen anywhere
@@ -84,9 +82,9 @@ class MaterialDescription(ExtractedFeature):
         criteria apply.
         """
         if not self.lines:
-            return self.text
-        reference_width = self.max_line_width or max((line.rect.width for line in self.lines), default=0)
-        parts = [self.lines[0].feature.text]
+            return self
+        reference_width = max_line_width or max((line.rect.width for line in self.lines), default=0)
+
         for prev_line, line in zip(self.lines, self.lines[1:], strict=False):
             gap_ratio = (reference_width - prev_line.rect.width) / reference_width if reference_width else 0.0
             prev_text = prev_line.feature.text.rstrip()
@@ -100,13 +98,16 @@ class MaterialDescription(ExtractedFeature):
             # tuned, works well enough so far
             has_large_vertical_gap = not new_page and vertical_gap > 0.5 * prev_line.rect.height
             is_break = new_page or ends_with_break_punct or gap_ratio > 0.3 or has_large_vertical_gap
-            parts.append(("\n" if is_break else " ") + line.feature.text)
-        return "".join(parts)
+            if is_break:
+                prev_line.feature.text += "\n"
+
+        self.text = "".join([line.feature.text for line in self.lines])
+        return self
 
     def to_json(self) -> dict:
         """Convert the MaterialDescription object to a JSON serializable dictionary."""
         return {
-            "text": self.text_with_line_breaks,
+            "text": self.text,
             "lines": [line.to_json() for line in self.lines],
             "is_correct": self.is_correct,
         }

--- a/src/swissgeol_doc_processing/text/textblock.py
+++ b/src/swissgeol_doc_processing/text/textblock.py
@@ -79,7 +79,9 @@ class MaterialDescription(ExtractedFeature):
         intentional line break rather than a layout wrap. A trailing period doesn't count as sentence-final
         punctuation when it's part of a known abbreviation (e.g. "ca.", "bzw.") - such lines only break via
         the length-based signal. Falls back to this description's own widest line when no borehole-wide
-        reference was provided.
+        reference was provided. A vertical gap to the next line that's noticeably larger than the line's
+        own height (e.g. a blank line in the layout) is also treated as a break, even if none of the other
+        criteria apply.
         """
         if not self.lines:
             return self.text
@@ -93,9 +95,11 @@ class MaterialDescription(ExtractedFeature):
                 prev_text.endswith(".") and not ends_with_abbreviation
             )
             new_page = line.page_number != prev_line.page_number
-            # TODO: 30% relative-to-longest-line threshold picked by eye, not tuned
-            # yet; revisit once you've looked at a batch of extracted descriptions.
-            is_break = new_page or ends_with_break_punct or gap_ratio > 0.3
+            vertical_gap = line.rect.y0 - prev_line.rect.y1
+            # TODO: 30% relative-to-longest-line and 1x-line-height thresholds picked by eye, not
+            # tuned, works well enough so far
+            has_large_vertical_gap = not new_page and vertical_gap > 1 * prev_line.rect.height
+            is_break = new_page or ends_with_break_punct or gap_ratio > 0.3 or has_large_vertical_gap
             parts.append(("\n" if is_break else " ") + line.feature.text)
         return "".join(parts)
 

--- a/src/swissgeol_doc_processing/text/textblock.py
+++ b/src/swissgeol_doc_processing/text/textblock.py
@@ -87,17 +87,12 @@ class MaterialDescription(ExtractedFeature):
 
         for prev_line, line in zip(self.lines, self.lines[1:], strict=False):
             gap_ratio = (reference_width - prev_line.rect.width) / reference_width if reference_width else 0.0
-            prev_text = prev_line.feature.text.rstrip()
-            ends_with_abbreviation = prev_text.endswith(_ABBREVIATIONS_ENDING_IN_PERIOD)
-            ends_with_break_punct = prev_text.endswith((":", ";")) or (
-                prev_text.endswith(".") and not ends_with_abbreviation
-            )
             new_page = line.page_number != prev_line.page_number
             vertical_gap = line.rect.y0 - prev_line.rect.y1
             # TODO: 30% relative-to-longest-line and 0.5x-line-height thresholds picked by eye, not
             # tuned, works well enough so far
             has_large_vertical_gap = not new_page and vertical_gap > 0.5 * prev_line.rect.height
-            is_break = new_page or ends_with_break_punct or gap_ratio > 0.3 or has_large_vertical_gap
+            is_break = new_page or gap_ratio > 0.3 or has_large_vertical_gap
             if is_break:
                 prev_line.feature.text += "\n"
 

--- a/src/swissgeol_doc_processing/text/textblock.py
+++ b/src/swissgeol_doc_processing/text/textblock.py
@@ -14,6 +14,9 @@ from swissgeol_doc_processing.utils.data_extractor import (
     FeatureOnPage,
 )
 
+# fixed list of German abbreviations spotted in practice, not exhaustive; add more as you find them.
+_ABBREVIATIONS_ENDING_IN_PERIOD = ("max.", "z.T.", "bzw.", "ca.", "etc.", "z.B.")
+
 
 @dataclass
 class MaterialDescriptionLine(ExtractedFeature):
@@ -37,6 +40,7 @@ class MaterialDescription(ExtractedFeature):
 
     text: str
     lines: list[FeatureOnPage[MaterialDescriptionLine]]
+    max_line_width: float | None = None
 
     @property
     def rects_with_pages(self) -> list[RectWithPage]:
@@ -65,10 +69,41 @@ class MaterialDescription(ExtractedFeature):
         """Get the bounding rectangle for a specific page."""
         return next((p_rect.rect for p_rect in self.rects_with_pages if p_rect.page_number == page_number), None)
 
+    @property
+    def text_with_line_breaks(self) -> str:
+        """Rejoin description lines with inferred line breaks, for display purposes only.
+
+        Compares each line's width against `max_line_width` - the widest description line seen anywhere
+        in this borehole - as a proxy for "how long a line can get before the layout wraps it": a line
+        ending well short of that reference, or ending in sentence-final punctuation, is treated as an
+        intentional line break rather than a layout wrap. A trailing period doesn't count as sentence-final
+        punctuation when it's part of a known abbreviation (e.g. "ca.", "bzw.") - such lines only break via
+        the length-based signal. Falls back to this description's own widest line when no borehole-wide
+        reference was provided.
+        """
+        if not self.lines:
+            return self.text
+        reference_width = self.max_line_width or max((line.rect.width for line in self.lines), default=0)
+        parts = [self.lines[0].feature.text]
+        for prev_line, line in zip(self.lines, self.lines[1:], strict=False):
+            gap_ratio = (reference_width - prev_line.rect.width) / reference_width if reference_width else 0.0
+            prev_text = prev_line.feature.text.rstrip()
+            ends_with_abbreviation = prev_text.endswith(_ABBREVIATIONS_ENDING_IN_PERIOD)
+            ends_with_break_punct = prev_text.endswith((":", ";")) or (
+                prev_text.endswith(".") and not ends_with_abbreviation
+            )
+            new_page = line.page_number != prev_line.page_number
+            # TODO: 30% relative-to-longest-line threshold picked by eye, not tuned
+            # yet; revisit once you've looked at a batch of extracted descriptions.
+            is_break = new_page or ends_with_break_punct or gap_ratio > 0.3
+            parts.append(("\n" if is_break else " ") + line.feature.text)
+        return "".join(parts)
+
     def to_json(self) -> dict:
         """Convert the MaterialDescription object to a JSON serializable dictionary."""
         return {
             "text": self.text,
+            "text_with_line_breaks": self.text_with_line_breaks,
             "lines": [line.to_json() for line in self.lines],
             "is_correct": self.is_correct,
         }

--- a/src/swissgeol_doc_processing/text/textblock.py
+++ b/src/swissgeol_doc_processing/text/textblock.py
@@ -102,8 +102,7 @@ class MaterialDescription(ExtractedFeature):
     def to_json(self) -> dict:
         """Convert the MaterialDescription object to a JSON serializable dictionary."""
         return {
-            "text": self.text,
-            "text_with_line_breaks": self.text_with_line_breaks,
+            "text": self.text_with_line_breaks,
             "lines": [line.to_json() for line in self.lines],
             "is_correct": self.is_correct,
         }

--- a/src/swissgeol_doc_processing/text/textblock.py
+++ b/src/swissgeol_doc_processing/text/textblock.py
@@ -96,9 +96,9 @@ class MaterialDescription(ExtractedFeature):
             )
             new_page = line.page_number != prev_line.page_number
             vertical_gap = line.rect.y0 - prev_line.rect.y1
-            # TODO: 30% relative-to-longest-line and 1x-line-height thresholds picked by eye, not
+            # TODO: 30% relative-to-longest-line and 0.5x-line-height thresholds picked by eye, not
             # tuned, works well enough so far
-            has_large_vertical_gap = not new_page and vertical_gap > 1 * prev_line.rect.height
+            has_large_vertical_gap = not new_page and vertical_gap > 0.5 * prev_line.rect.height
             is_break = new_page or ends_with_break_punct or gap_ratio > 0.3 or has_large_vertical_gap
             parts.append(("\n" if is_break else " ") + line.feature.text)
         return "".join(parts)


### PR DESCRIPTION
Closes #524 

## Changes
 The field `text` in `predictions.json` now includes exlicit line breaks `\n`
(I am not sure if the `\n` line break is "renderable" by the application)

**What was already there:** 
- A line break is inserted between two consecutive description lines whenever the earlier line ends in a page change, a :/;, or a . 

**New:** 
- a point is only a line break indicator if that isn't part of a known abbreviation (ca., bzw., etc.) —> these are treated as unconditional, forced breaks. Otherwise, it's inserted if that line's width falls more than 30% short of the widest line seen anywhere in the same borehole, on the assumption that a genuinely full line would come close to that borehole's longest observed line and only a "short" one signals an intentional break rather than a layout wrap.
- a vertical gap between tow lines as big as 0.5x line height also indicates a line break 
The vertical gap catches some examples which would have remain undetected otherwise, e.g. 

**267123080**

"Mittelkies, sandig, schwach feinkiesig, schwach siltig, mit vereinzelten Steinen, grau bis bunt, feucht bis nass (Feinsand-/Siltlinsen: 3.9 m - 4.0 m, 4.45 m - 4.5 m) Wasserzutritte ins Bohrloch ab 3.8 m bis 4.8 m”

Mittelkies, sandig, schwach feinkiesig, schwach siltig, mit vereinzelten Steinen, grau bis bunt, feucht bis nass (Feinsand-/Siltlinsen: 3.9 m - 4.0 m, 4.45 m - 4.5 m)\nWasserzutritte ins Bohrloch ab 3.8 m bis 4.8 m

**267122002**

“Kiessand mit Steinen, z.T. leicht siltig, kompakt\n17.3 - 17.7 siltreiche Lage (0226) 21.0 - 23.0 leicht siltig (0127)”

"Kiessand mit Steinen, z.T. leicht siltig, kompakt\n17.3 - 17.7 siltreiche Lage (0226)\n21.0 - 23.0 leicht siltig (0127)",

**268125447**

"beiger, schwach lehmiger Silt-Feinsand, wenig Kies grauer, schwach siltiger Kies mit reichlich Sand, vereinzelt Steine”

"beiger, schwach lehmiger Silt-Feinsand, wenig Kies\ngrauer, schwach siltiger Kies mit reichlich Sand, vereinzelt Steine”
