### PR TITLE
Properly disable MLFlow in Pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Pytest configuration file."""
 
+import os
+
 import boto3
 import pytest
 from fastapi.testclient import TestClient
@@ -10,6 +12,11 @@ from app.common.config import config
 from app.main import app
 
 TEST_BUCKET_NAME = "test-bucket"
+
+
+def pytest_configure(config):
+    """Enforce MLFlow tracking to False before importing modules."""
+    os.environ["MLFLOW_TRACKING"] = "False"
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_extraction_io.py
+++ b/tests/test_extraction_io.py
@@ -1,14 +1,10 @@
 """Tests for the main extraction pipeline."""
 
-import os
 from io import BytesIO
 from pathlib import Path
 
 import pymupdf
 import pytest
-
-# Enforce MLFlow tracking to False before importing modules
-os.environ["MLFLOW_TRACKING"] = "False"
 
 from extraction.evaluation.benchmark.spec import BenchmarkSpec
 from extraction.runner import ExtractionBenchmarkRunner, ExtractionOptions, ExtractionPipelineRunner, extract


### PR DESCRIPTION
Previously, when running the specific tests `pytest tests/test_extraction_io.py`, the `MLFLOW_TRACKING` env variable was correctly overriden and MLFlow disabled.

However, when running all the unit tests with a simple `pytest` command, the test runs where actually still logged to MLFlow. The most likely cause was that MLFlow was already loaded in `mlflow_tracking.py` as a dependency in other unit tests, before the env variable override from `tests/test_extraction_io.py` was applied.

This PR fixes this by moving the disabling of MLFlow for unit tests to the `conftest.py` file, ensuring that it is correctly applied, both when running individual unit tests as well as when bulk executing all unit tests.