### PR TITLE
Consider position when evaluating layers

### DIFF
--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -9,6 +9,7 @@ import Levenshtein
 from core.benchmark_utils import Metrics
 from core.ground_truth import GroundTruthBorehole, GroundTruthLayer
 from extraction.features.predictions.borehole_predictions import (
+    BoreholePredictions,
     BoreholePredictionsWithGroundTruth,
     FileLayersWithGroundTruth,
 )
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 MATERIAL_DESCRIPTION_SIMILARITY_THRESHOLD = 0.9
 MAX_DEPTH_SCORE = 1.0
+BOREHOLE_ORDER_BONUS_WEIGHT = 0.4  # tune, revisit, if necessary
 
 
 class LayerEvaluator:
@@ -214,7 +216,9 @@ class LayerEvaluator:
         """Match predicted boreholes to ground truth boreholes.
 
         This method compares the predicted boreholes with the ground truth boreholes and establishes a mapping
-            between them based on their similarity.
+            between them based on their similarity, with a bonus for agreeing on page position (reading order)
+            to break close, ambiguous ties --> ground truth is usually, but not always, annotated in reading order
+            (see `BOREHOLE_ORDER_BONUS_WEIGHT`).
 
         Args:
             file_predictions (FilePredictions): all predictions for the file
@@ -223,17 +227,24 @@ class LayerEvaluator:
         Returns:
             list[BoreholePredictionsWithGroundTruth]: A list of matched borehole predictions with their ground truth.
         """
-        all_ground_truth_layers = {
-            idx: borehole_data.layers for idx, borehole_data in enumerate(ground_truth_for_file)
-        }
-        borehole_layers = [bh.layers_in_borehole for bh in file_predictions.borehole_predictions_list]
+        predictions = file_predictions.borehole_predictions_list
+        reading_rank = {id(pred): rank for rank, pred in enumerate(_boreholes_in_reading_order(predictions))}
+        # using position as a tie-breaker when there are multiple boreholes in a file
+        bonus_weight = BOREHOLE_ORDER_BONUS_WEIGHT if len(predictions) > 1 and len(ground_truth_for_file) > 1 else 0.0
+
+        def relative_position(rank: int, count: int) -> float:
+            return rank / (count - 1) if count > 1 else 0.0
+
         pred_vs_gt_matching_score = defaultdict(dict)
-        for gt_idx, ground_truth_layers in all_ground_truth_layers.items():
-            for pred_idx, predicted_layers in enumerate(borehole_layers):
-                matching_score, _ = LayerEvaluator.compute_borehole_affinity_and_mapping(
-                    ground_truth_layers, predicted_layers.layers, score_layer
+        for gt_idx, ground_truth_borehole in enumerate(ground_truth_for_file):
+            gt_position = relative_position(gt_idx, len(ground_truth_for_file))
+            for pred_idx, prediction in enumerate(predictions):
+                content_score, _ = LayerEvaluator.compute_borehole_affinity_and_mapping(
+                    ground_truth_borehole.layers, prediction.layers_in_borehole.layers, score_layer
                 )
-                pred_vs_gt_matching_score[gt_idx][pred_idx] = matching_score
+                pred_position = relative_position(reading_rank[id(prediction)], len(predictions))
+                order_bonus = bonus_weight * (1 - abs(pred_position - gt_position))
+                pred_vs_gt_matching_score[gt_idx][pred_idx] = content_score + order_bonus
 
         # matching of all the boreholes detected to a borehole in the ground truth
         matched_boreholes = []
@@ -248,16 +259,14 @@ class LayerEvaluator:
 
             gt_best_idx, pred_best_idx = best_matches
             matched_boreholes.append(
-                BoreholePredictionsWithGroundTruth(
-                    file_predictions.borehole_predictions_list[pred_best_idx], ground_truth_for_file[gt_best_idx]
-                )
+                BoreholePredictionsWithGroundTruth(predictions[pred_best_idx], ground_truth_for_file[gt_best_idx])
             )
             assigned_preds.add(pred_best_idx)  # Mark this pred_idx as used
 
             # Remove the matched gt_idx from consideration
             del pred_vs_gt_matching_score[gt_best_idx]
 
-            if len(assigned_preds) == len(borehole_layers):
+            if len(assigned_preds) == len(predictions):
                 # all preds have been assigned
                 break
 
@@ -268,7 +277,7 @@ class LayerEvaluator:
             )
 
         # add entries with missing ground truth for all unmatched prediction boreholes (will count as false positives)
-        for index, pred in enumerate(file_predictions.borehole_predictions_list):
+        for index, pred in enumerate(predictions):
             if index not in assigned_preds:
                 matched_boreholes.append(BoreholePredictionsWithGroundTruth(predictions=pred, ground_truth=None))
         return matched_boreholes
@@ -334,3 +343,32 @@ def score_depths(layer: Layer, ground_truth: GroundTruthLayer) -> float:
 def score_layer(layer: Layer, ground_truth: GroundTruthLayer) -> float:
     """Scores how well the full layer matches the ground truth on a scale from 0 to 1."""
     return (score_material_descriptions(layer, ground_truth) + score_depths(layer, ground_truth)) / 2
+
+
+def _borehole_position(prediction: BoreholePredictions) -> tuple[int, float, float, float]:
+    """Return (page, y0, y1, x0) of a borehole's first page, used to order it by reading position."""
+    if not prediction.bounding_boxes:
+        return (0, 0.0, 0.0, 0.0)
+    rect = prediction.bounding_boxes[0].get_outer_rect()
+    return (prediction.bounding_boxes[0].page, rect.y0, rect.y1, rect.x0)
+
+
+def _boreholes_in_reading_order(predictions: list[BoreholePredictions]) -> list[BoreholePredictions]:
+    """Sort boreholes into page reading order: top-to-bottom by row, then left-to-right within a row."""
+    positioned = sorted(
+        ((_borehole_position(prediction), prediction) for prediction in predictions), key=lambda item: item[0][:2]
+    )
+
+    # positioned is sorted by (page, y0)
+    rows = []
+    current_page, row_bottom = None, None
+    for position, prediction in positioned:
+        page, y0, y1, _ = position
+        if page != current_page or y0 >= row_bottom:
+            rows.append([])
+            current_page, row_bottom = page, y1
+        else:
+            row_bottom = max(row_bottom, y1)
+        rows[-1].append((position, prediction))
+
+    return [prediction for row in rows for _, prediction in sorted(row, key=lambda item: item[0][3])]

--- a/src/extraction/evaluation/layer_evaluator.py
+++ b/src/extraction/evaluation/layer_evaluator.py
@@ -3,6 +3,7 @@
 import logging
 from collections import defaultdict
 from collections.abc import Callable
+from typing import NamedTuple
 
 import Levenshtein
 
@@ -216,9 +217,10 @@ class LayerEvaluator:
         """Match predicted boreholes to ground truth boreholes.
 
         This method compares the predicted boreholes with the ground truth boreholes and establishes a mapping
-            between them based on their similarity, with a bonus for agreeing on page position (reading order)
-            to break close, ambiguous ties --> ground truth is usually, but not always, annotated in reading order
-            (see `BOREHOLE_ORDER_BONUS_WEIGHT`).
+            between them based on content similarity, plus an additive bonus (weighted by
+            `BOREHOLE_ORDER_BONUS_WEIGHT`) for agreeing on page position (reading order). The bonus applies to
+            every candidate pair, not only near-ties, since ground truth boreholes are usually, but not always,
+            annotated in reading order.
 
         Args:
             file_predictions (FilePredictions): all predictions for the file
@@ -235,15 +237,16 @@ class LayerEvaluator:
         def relative_position(rank: int, count: int) -> float:
             return rank / (count - 1) if count > 1 else 0.0
 
+        pred_positions = [relative_position(reading_rank[id(pred)], len(predictions)) for pred in predictions]
+
         pred_vs_gt_matching_score = defaultdict(dict)
         for gt_idx, ground_truth_borehole in enumerate(ground_truth_for_file):
             gt_position = relative_position(gt_idx, len(ground_truth_for_file))
-            for pred_idx, prediction in enumerate(predictions):
+            for pred_idx, pred in enumerate(predictions):
                 content_score, _ = LayerEvaluator.compute_borehole_affinity_and_mapping(
-                    ground_truth_borehole.layers, prediction.layers_in_borehole.layers, score_layer
+                    ground_truth_borehole.layers, pred.layers_in_borehole.layers, score_layer
                 )
-                pred_position = relative_position(reading_rank[id(prediction)], len(predictions))
-                order_bonus = bonus_weight * (1 - abs(pred_position - gt_position))
+                order_bonus = bonus_weight * (1 - abs(pred_positions[pred_idx] - gt_position))
                 pred_vs_gt_matching_score[gt_idx][pred_idx] = content_score + order_bonus
 
         # matching of all the boreholes detected to a borehole in the ground truth
@@ -277,8 +280,8 @@ class LayerEvaluator:
             )
 
         # add entries with missing ground truth for all unmatched prediction boreholes (will count as false positives)
-        for index, pred in enumerate(predictions):
-            if index not in assigned_preds:
+        for pred_idx, pred in enumerate(predictions):
+            if pred_idx not in assigned_preds:
                 matched_boreholes.append(BoreholePredictionsWithGroundTruth(predictions=pred, ground_truth=None))
         return matched_boreholes
 
@@ -345,25 +348,39 @@ def score_layer(layer: Layer, ground_truth: GroundTruthLayer) -> float:
     return (score_material_descriptions(layer, ground_truth) + score_depths(layer, ground_truth)) / 2
 
 
-def _borehole_position(prediction: BoreholePredictions) -> tuple[int, float, float, float]:
-    """Return (page, y0, y1, x0) of a borehole's first page, used to order it by reading position."""
+class _BoreholePosition(NamedTuple):
+    """Position of a borehole's first page, used to order it by reading position."""
+
+    page: int
+    y0: float
+    y1: float
+    x0: float
+
+
+def _borehole_position(prediction: BoreholePredictions) -> _BoreholePosition:
+    """Return the position of a borehole's first page, used to order it by reading position."""
     if not prediction.bounding_boxes:
-        return (0, 0.0, 0.0, 0.0)
+        logger.warning(
+            "Borehole %s has no bounding boxes; reading-order position defaults to page 0, top-left.",
+            prediction.borehole_index,
+        )
+        return _BoreholePosition(0, 0.0, 0.0, 0.0)
     rect = prediction.bounding_boxes[0].get_outer_rect()
-    return (prediction.bounding_boxes[0].page, rect.y0, rect.y1, rect.x0)
+    return _BoreholePosition(prediction.bounding_boxes[0].page, rect.y0, rect.y1, rect.x0)
 
 
 def _boreholes_in_reading_order(predictions: list[BoreholePredictions]) -> list[BoreholePredictions]:
     """Sort boreholes into page reading order: top-to-bottom by row, then left-to-right within a row."""
     positioned = sorted(
-        ((_borehole_position(prediction), prediction) for prediction in predictions), key=lambda item: item[0][:2]
+        ((_borehole_position(prediction), prediction) for prediction in predictions),
+        key=lambda item: (item[0].page, item[0].y0),
     )
 
     # positioned is sorted by (page, y0)
     rows = []
     current_page, row_bottom = None, None
     for position, prediction in positioned:
-        page, y0, y1, _ = position
+        page, y0, y1 = position.page, position.y0, position.y1
         if page != current_page or y0 >= row_bottom:
             rows.append([])
             current_page, row_bottom = page, y1
@@ -371,4 +388,4 @@ def _boreholes_in_reading_order(predictions: list[BoreholePredictions]) -> list[
             row_bottom = max(row_bottom, y1)
         rows[-1].append((position, prediction))
 
-    return [prediction for row in rows for _, prediction in sorted(row, key=lambda item: item[0][3])]
+    return [prediction for row in rows for _, prediction in sorted(row, key=lambda item: item[0].x0)]


### PR DESCRIPTION
Closes #528 

## Problem description

LayerEvaluator.match_boreholes_to_ground_truth (layer_evaluator.py:210-274) is purely content-based and position-blind — >it never looks at where a borehole physically sits on the page

```
pred (physically "104") vs GT "104": score = 0.429
pred (physically "104") vs GT "105": score = 0.543   ← wins, wrongly
```

**Extracted (predicted borehole, physically sitting under the printed "104" label):**

```
[0] (0.0–0.2)   'Humus Sand Ikies 22g siltiger Sand'
[1] (0.2–7.0)   'Sand/Kies'
[2] (7.0–12.0)  'Kies'
```

Only 3 layers were extracted — GT "104" actually has 5, so the extraction merged/lost 2 real layers (evident in that garbled first entry, which looks like it swallowed multiple original lines).

**Ground truth "104" (correct match, 5 layers):**

```
[0] (0.0–0.6)   'Humus'
[1] (0.6–1.2)   'Sand / Kies'
[2] (1.2–2.7)   'siltiger Sand'
[3] (2.7–7.0)   'Sand / Kies'
[4] (7.0–12.0)  'Kies'
```

**Ground truth "105" (wrong match, 4 layers):**
```
[0] (0.0–1.4)   'Humus mit Sand und Kies'
[1] (1.4–2.9)   'Sand, sandiger Silt'
[2] (2.9–7.0)   'sandiger Kies'
[3] (7.0–12.0)  'Kies'
```

Since 105 has Humus Sand and Kies in it in has a higher similarity with "Humus Sand Ikies 22g siltiger Sand" and additionally, since it has only 4 layers instead of 5 the denominator is smaller for 105 instead of 104 which leads to a better score of 0.543

## Idea / Solution 
Position could be taken into consideration. 
Fist tries/ implementations assumed a fixed, left to right reading as it is also often in the ground truth, but not always, e.g. 
675245009
    -->  on the page, reading left-to-right, "II" comes first and "3" comes second — but ground truth lists "3" first (index 0) and "II" second (index 1) 

So now, on top of the content similarity, each candidate match gets a small bonus if its position in that reading order lines up with where the ground truth borehole sits in the list. This nudges close, ambiguous calls toward the physically correct pairing.
So the position bonus only acts as a tiebreaker: it can tip a close call, but a genuinely strong content match can still win even if it goes against the expected page order.

This solves the comparison issue in the mentioned file. 
And also the performance increases. Even though `compute_borehole_affinity_and_mapping` was scoring the other borehole to match better, in fact, when choosing the correct borehole we end up with better material description metric.

per file metric 

|metric | before | now |
|---|---|---|
|precision | 0.909 | 0.939 |
|recall | 0.536 | 0.554 |
|f1 | 0.674 | 0.697 |


General metrics - no effects

Zurich | layer_f1 | depth_intervall_f1 | Material_description_f1 | elevation_f1 | coordinates_f1 | Borehole_name_f1 | gw_f1
-- | -- | -- | -- | -- | -- | --| --
develop | 0.846 | 0.894 | 0.885 | 0.829 | 0.699 | 0.746 | 0.372
branch | 0.846 | 0.894 | 0.885 | 0.829 | 0.699 | 0.746 | 0.372


Geoquat | layer_f1 | depth_intervall_f1 | Material_description_f1 | elevation_f1 | coordinates_f1 | Borehole_name_f1 | gw_f1
-- | -- | -- | -- | -- | -- | -- | --
develop | 0.496 |0.635 | 0.648 | 0.602 |  0.475 | 0.604 | 0.053
branch | 0.496 | 0.635 | 0.648 | 0.602 | 0.475 | 0.604 | 0.053

## Limitations 
Honestly speaking, these changes might be a pretty specific solution for the specific file mentioned --> value `BOREHOLE_ORDER_BONUS_WEIGHT = 0.4 ` was chosen so it works with this file, without harming others

Also, now that we understand the root cause of the problem, we might consider leaving the behavior as it is, which is choosing the borehole which matches best based on text similarity
 