### PR TITLE
feat(api): add classification_tasks field to classify response

### DIFF
--- a/src/app/api/v1/endpoints/classify_all.py
+++ b/src/app/api/v1/endpoints/classify_all.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from app.common.schemas import ClassificationTasksClasses, ClassifyRequest, ClassifyResponse
+from app.common.schemas import ClassificationConsolidationClasses, ClassifyRequest, ClassifyResponse
 from classification.utils.datasets.classification import ClassificationTask
 
 if TYPE_CHECKING:
@@ -92,7 +92,7 @@ def classify(request: ClassifyRequest, bert_models: dict[str, BertModel]) -> Cla
         bert_models: Models loaded at startup via the lifespan, keyed by task name.
 
     Returns:
-        ClassifyResponse with `classification_tasks` set to the inferred rock type (consolidated or
+        ClassifyResponse with `consolidation` set to the inferred rock type (consolidated or
         unconsolidated), plus the predicted class (or classes, for multi-label/rank tasks) for every task
         relevant to that rock type; irrelevant tasks are left as `None`.
     """
@@ -126,8 +126,8 @@ def classify(request: ClassifyRequest, bert_models: dict[str, BertModel]) -> Cla
         )
 
     return ClassifyResponse(
-        classification_tasks=ClassificationTasksClasses.unconsolidated
+        consolidation=ClassificationConsolidationClasses.unconsolidated
         if is_unconsolidated
-        else ClassificationTasksClasses.consolidated,
+        else ClassificationConsolidationClasses.consolidated,
         **predictions,
     )

--- a/src/app/api/v1/endpoints/classify_all.py
+++ b/src/app/api/v1/endpoints/classify_all.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from app.common.schemas import ClassifyRequest, ClassifyResponse
+from app.common.schemas import ClassificationTasksClasses, ClassifyRequest, ClassifyResponse
 from classification.utils.datasets.classification import ClassificationTask
 
 if TYPE_CHECKING:
@@ -124,4 +124,9 @@ def classify(request: ClassifyRequest, bert_models: dict[str, BertModel]) -> Cla
             else classes[0]
         )
 
-    return ClassifyResponse(**predictions)
+    return ClassifyResponse(
+        classification_tasks=ClassificationTasksClasses.unconsolidated
+        if is_unconsolidated
+        else ClassificationTasksClasses.consolidated,
+        **predictions,
+    )

--- a/src/app/api/v1/endpoints/classify_all.py
+++ b/src/app/api/v1/endpoints/classify_all.py
@@ -154,7 +154,6 @@ def classify(request: ClassifyRequest, bert_models: dict[str, BertModel]) -> Cla
             if sec != predictions[ExistingClassificationSystems.en_main.name]
         ]
 
-
     return ClassifyResponse(
         consolidation=ClassificationConsolidationClasses.unconsolidated
         if is_unconsolidated

--- a/src/app/api/v1/endpoints/classify_all.py
+++ b/src/app/api/v1/endpoints/classify_all.py
@@ -92,8 +92,9 @@ def classify(request: ClassifyRequest, bert_models: dict[str, BertModel]) -> Cla
         bert_models: Models loaded at startup via the lifespan, keyed by task name.
 
     Returns:
-        ClassifyResponse with the predicted class (or classes, for multi-label/rank tasks) for every task
-        relevant to the inferred rock type; irrelevant tasks are left as `None`.
+        ClassifyResponse with `classification_tasks` set to the inferred rock type (consolidated or
+        unconsolidated), plus the predicted class (or classes, for multi-label/rank tasks) for every task
+        relevant to that rock type; irrelevant tasks are left as `None`.
     """
     from classification.utils.datasets.lithology import LithologySystem
 

--- a/src/app/api/v1/router.py
+++ b/src/app/api/v1/router.py
@@ -56,7 +56,7 @@ _CLASSIFY_RESPONSE_EXAMPLES = {
     "unconsolidated_silt": {
         "summary": "Unconsolidated sediment (silt)",
         "value": {
-            "classification_tasks": "unconsolidated",
+            "consolidation": "unconsolidated",
             "en_main": "si",
             "en_secondary": ["si", "cl", "gr"],
             "uscs": "not_specified",
@@ -70,7 +70,7 @@ _CLASSIFY_RESPONSE_EXAMPLES = {
     "consolidated_limestone": {
         "summary": "Consolidated rock (limestone)",
         "value": {
-            "classification_tasks": "consolidated",
+            "consolidation": "consolidated",
             "lithology": "limestone",
             "alteration_degree_consolidated": "not_specified",
             "cementation": "not_specified",
@@ -306,7 +306,7 @@ def post_classify(
       brau-beige, Komponenten vorw. eckig"`).
 
     ### Returns
-    - **classification_tasks**: `"consolidated"` or `"unconsolidated"`, as determined by the lithology head;
+    - **consolidation**: `"consolidated"` or `"unconsolidated"`, as determined by the lithology head;
       indicates which of the fields are populated.
     - One field per classification task. A field is `null` if that task isn't relevant to the inferred
       rock type; otherwise it holds the predicted class name (single-label tasks, e.g. `en_main`, `uscs`,

--- a/src/app/api/v1/router.py
+++ b/src/app/api/v1/router.py
@@ -304,10 +304,12 @@ def post_classify(
       brau-beige, Komponenten vorw. eckig"`).
 
     ### Returns
-    One field per classification task. A field is `null` if that task isn't relevant to the inferred
-    rock type; otherwise it holds the predicted class name (single-label tasks, e.g. `en_main`, `uscs`,
-    `color`) or class names (multi-label/rank tasks, e.g. `en_secondary`, `grain_angularity`, `grain_shape`,
-    `organic_components`, `accessory_components`, `debris`, `mineral_components`).
+    - **classification_tasks**: `"consolidated"` or `"unconsolidated"`, as determined by the lithology head;
+      indicates which of the fields are populated.
+    - One field per classification task. A field is `null` if that task isn't relevant to the inferred
+      rock type; otherwise it holds the predicted class name (single-label tasks, e.g. `en_main`, `uscs`,
+      `color`) or class names (multi-label/rank tasks, e.g. `en_secondary`, `grain_angularity`, `grain_shape`,
+      `organic_components`, `accessory_components`, `debris`, `mineral_components`).
 
     ### Consolidated rock tasks
     `lithology`, `alteration_degree_consolidated`, `cementation`, `color`, `mineral_components`, `accessory_components`

--- a/src/app/api/v1/router.py
+++ b/src/app/api/v1/router.py
@@ -56,6 +56,7 @@ _CLASSIFY_RESPONSE_EXAMPLES = {
     "unconsolidated_silt": {
         "summary": "Unconsolidated sediment (silt)",
         "value": {
+            "classification_tasks": "unconsolidated",
             "en_main": "si",
             "en_secondary": ["si", "cl", "gr"],
             "uscs": "not_specified",
@@ -69,6 +70,7 @@ _CLASSIFY_RESPONSE_EXAMPLES = {
     "consolidated_limestone": {
         "summary": "Consolidated rock (limestone)",
         "value": {
+            "classification_tasks": "consolidated",
             "lithology": "limestone",
             "alteration_degree_consolidated": "not_specified",
             "cementation": "not_specified",

--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -36,7 +36,7 @@ from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 
 
 class ClassificationTasksClasses(StrEnum):
-    """Rock type inferred by the lithology head, determining which classification tasks apply."""
+    """Rock category inferred by the lithology head."""
 
     consolidated = "consolidated"
     unconsolidated = "unconsolidated"
@@ -869,9 +869,12 @@ def enum_as_name(enum_cls: type[Enum]) -> type:
 class ClassifyResponse(BaseModel):
     """Response schema for the unified `/classify` endpoint.
 
-    Each field corresponds to one classification task. A field is `None` if that task wasn't run for the
-    inferred rock type; otherwise it holds the predicted class (single-label tasks) or classes (multi-label
-    tasks: accessory_components, debris, grain_angularity, grain_shape, mineral_components,
+    `classification_tasks` indicates whether the lithology head classified the material as consolidated
+    rock or unconsolidated sediment, which determines which of the remaining fields are populated.
+
+    Each remaining field corresponds to one classification task. A field is `None` if that task wasn't run
+    for the inferred rock type; otherwise it holds the predicted class (single-label tasks) or classes
+    (multi-label tasks: accessory_components, debris, grain_angularity, grain_shape, mineral_components,
     organic_components; rank tasks: en_secondary).
 
     Consolidated rock tasks: lithology, alteration_degree_consolidated, cementation, color, mineral_components,
@@ -880,11 +883,6 @@ class ClassifyResponse(BaseModel):
         organic_components.
     """
 
-    classification_tasks: ClassificationTasksClasses | None = Field(
-        default=None,
-        description="Whether the lithology head classified the material as consolidated rock or "
-        "unconsolidated sediment; determines which of the other fields are populated.",
-    )
     accessory_components: list[enum_as_name(AccessoryComponentsSystem.AccessoryComponentsClasses)] | None = Field(
         default=None,
         description="Predicted accessory component classes (consolidated rock only).",
@@ -898,6 +896,11 @@ class ClassifyResponse(BaseModel):
     cementation: enum_as_name(CementationSystem.CementationClasses) | None = Field(
         default=None,
         description="Predicted cementation class (consolidated rock only).",
+    )
+    classification_tasks: ClassificationTasksClasses | None = Field(
+        default=None,
+        description="Whether the lithology head classified the material as consolidated rock or "
+        "unconsolidated sediment; determines which of the other fields are populated.",
     )
     color: enum_as_name(ColorSystem.ColorClasses) | None = Field(
         default=None,

--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -9,7 +9,7 @@ as well as a patch version with all fields optional for patch operations.
 ########################################################################################################################
 
 from abc import ABC, abstractmethod
-from enum import Enum
+from enum import Enum, StrEnum
 from pathlib import Path
 from typing import Annotated
 
@@ -33,6 +33,13 @@ from extraction.features.groundwater.groundwater_extraction import Groundwater
 from extraction.features.stratigraphy.layer.layer import Layer, LayerDepthsEntry
 from swissgeol_doc_processing.text.textblock import MaterialDescription
 from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
+
+
+class ClassificationTasksClasses(StrEnum):
+    """Rock type inferred by the lithology head, determining which classification tasks apply."""
+
+    consolidated = "consolidated"
+    unconsolidated = "unconsolidated"
 
 
 def validate_filename(value: str) -> str:
@@ -873,6 +880,11 @@ class ClassifyResponse(BaseModel):
         organic_components.
     """
 
+    classification_tasks: ClassificationTasksClasses | None = Field(
+        default=None,
+        description="Whether the lithology head classified the material as consolidated rock or "
+        "unconsolidated sediment; determines which of the other fields are populated.",
+    )
     accessory_components: list[enum_as_name(AccessoryComponentsSystem.AccessoryComponentsClasses)] | None = Field(
         default=None,
         description="Predicted accessory component classes (consolidated rock only).",

--- a/src/app/common/schemas.py
+++ b/src/app/common/schemas.py
@@ -35,7 +35,7 @@ from swissgeol_doc_processing.text.textblock import MaterialDescription
 from swissgeol_doc_processing.utils.data_extractor import FeatureOnPage
 
 
-class ClassificationTasksClasses(StrEnum):
+class ClassificationConsolidationClasses(StrEnum):
     """Rock category inferred by the lithology head."""
 
     consolidated = "consolidated"
@@ -869,7 +869,7 @@ def enum_as_name(enum_cls: type[Enum]) -> type:
 class ClassifyResponse(BaseModel):
     """Response schema for the unified `/classify` endpoint.
 
-    `classification_tasks` indicates whether the lithology head classified the material as consolidated
+    `consolidation` indicates whether the lithology head classified the material as consolidated
     rock or unconsolidated sediment, which determines which of the remaining fields are populated.
 
     Each remaining field corresponds to one classification task. A field is `None` if that task wasn't run
@@ -897,7 +897,7 @@ class ClassifyResponse(BaseModel):
         default=None,
         description="Predicted cementation class (consolidated rock only).",
     )
-    classification_tasks: ClassificationTasksClasses | None = Field(
+    consolidation: ClassificationConsolidationClasses | None = Field(
         default=None,
         description="Whether the lithology head classified the material as consolidated rock or "
         "unconsolidated sediment; determines which of the other fields are populated.",

--- a/tests/api/v1/test_classify_all.py
+++ b/tests/api/v1/test_classify_all.py
@@ -21,7 +21,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api.v1.endpoints.classify_all import classify
-from app.common.schemas import ClassifyRequest
+from app.common.schemas import ClassificationTasksClasses, ClassifyRequest
 from app.main import app
 from classification.utils.datasets import ExistingClassificationSystems
 from classification.utils.datasets.cementation import CementationSystem
@@ -102,6 +102,7 @@ def test_classify_consolidated_rock_description(real_bert_models):
     """A real consolidated-rock description runs the lithology and cementation heads (both loaded)."""
     response = classify(ClassifyRequest(description=CONSOLIDATED_DESCRIPTION), real_bert_models)
 
+    assert response.classification_tasks == ClassificationTasksClasses.consolidated
     assert response.lithology == LithologySystem.LithologyClasses.limestone
     assert response.cementation == CementationSystem.CementationClasses.strongly_cemented
     # alteration_degree_consolidated/color/mineral_components/accessory_components are also
@@ -117,6 +118,7 @@ def test_classify_unconsolidated_sediment_description(real_bert_models, caplog):
     with caplog.at_level(logging.WARNING):
         response = classify(ClassifyRequest(description=UNCONSOLIDATED_DESCRIPTION), real_bert_models)
 
+    assert response.classification_tasks == ClassificationTasksClasses.unconsolidated
     assert response.grain_angularity == [
         GrainAngularitySystem.GrainAngularityClasses.angular,
         GrainAngularitySystem.GrainAngularityClasses.sub_angular,

--- a/tests/api/v1/test_classify_all.py
+++ b/tests/api/v1/test_classify_all.py
@@ -21,7 +21,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api.v1.endpoints.classify_all import classify
-from app.common.schemas import ClassificationTasksClasses, ClassifyRequest
+from app.common.schemas import ClassificationConsolidationClasses, ClassifyRequest
 from app.main import app
 from classification.utils.datasets import ExistingClassificationSystems
 from classification.utils.datasets.cementation import CementationSystem
@@ -102,7 +102,7 @@ def test_classify_consolidated_rock_description(real_bert_models):
     """A real consolidated-rock description runs the lithology and cementation heads (both loaded)."""
     response = classify(ClassifyRequest(description=CONSOLIDATED_DESCRIPTION), real_bert_models)
 
-    assert response.classification_tasks == ClassificationTasksClasses.consolidated
+    assert response.consolidation == ClassificationConsolidationClasses.consolidated
     assert response.lithology == LithologySystem.LithologyClasses.limestone
     assert response.cementation == CementationSystem.CementationClasses.strongly_cemented
     # alteration_degree_consolidated/color/mineral_components/accessory_components are also
@@ -118,7 +118,7 @@ def test_classify_unconsolidated_sediment_description(real_bert_models, caplog):
     with caplog.at_level(logging.WARNING):
         response = classify(ClassifyRequest(description=UNCONSOLIDATED_DESCRIPTION), real_bert_models)
 
-    assert response.classification_tasks == ClassificationTasksClasses.unconsolidated
+    assert response.consolidation == ClassificationConsolidationClasses.unconsolidated
     assert response.grain_angularity == [
         GrainAngularitySystem.GrainAngularityClasses.angular,
         GrainAngularitySystem.GrainAngularityClasses.sub_angular,


### PR DESCRIPTION
Closes #551 

## Summary

Adds a new `classification_tasks` field to the classify API response that indicates whether the material was classified as consolidated rock or unconsolidated sediment. This field is determined by the lithology head and helps clients understand which classification fields are populated in the response.

## API

<img width="1372" height="106" alt="Screenshot 2026-08-26 at 14 15 16" src="https://github.com/user-attachments/assets/901ba5f8-3adf-4307-94ac-9c8aa5ec3cf1" />