### PR TITLE
feat(classify): remove main class from secondary predictions

### DIFF
--- a/src/app/api/v1/endpoints/classify_all.py
+++ b/src/app/api/v1/endpoints/classify_all.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from app.common.schemas import ClassifyRequest, ClassifyResponse
+from classification.utils.datasets import ExistingClassificationSystems
 from classification.utils.datasets.classification import ClassificationTask
+from classification.utils.datasets.en_main import ENMainSystem
 
 if TYPE_CHECKING:
     from classification.models.model import BertModel
@@ -79,6 +81,21 @@ def load_models() -> dict[str, BertModel]:
     return models
 
 
+def _update_main_secondary_consistency(
+    main: ENMainSystem.ENMainClasses, secondary: list[ENMainSystem.ENMainClasses]
+) -> list[ENMainSystem.ENMainClasses]:
+    """Drop the main class from the secondary predictions to avoid redundance.
+
+    Args:
+        main: Predicted main lithology class.
+        secondary: Predicted secondary lithology classes (ranked).
+
+    Returns:
+        The secondary classes with entry matching `main` removed.
+    """
+    return [sec for sec in secondary if sec != main]
+
+
 def classify(request: ClassifyRequest, bert_models: dict[str, BertModel]) -> ClassifyResponse:
     """Classify a description across all relevant tasks via a two-step backbone pass.
 
@@ -122,6 +139,17 @@ def classify(request: ClassifyRequest, bert_models: dict[str, BertModel]) -> Cla
             classes
             if model.classification_system.classification_task() != ClassificationTask.single_label
             else classes[0]
+        )
+
+    # Step 3: en_main and en_secondary are predicted independently, so the same class can appear
+    # in both; remove it from en_secondary to keep the two predictions mutually exclusive.
+    if (
+        ExistingClassificationSystems.en_secondary.name in predictions
+        and ExistingClassificationSystems.en_main.name in predictions
+    ):
+        predictions[ExistingClassificationSystems.en_secondary.name] = _update_main_secondary_consistency(
+            main=predictions[ExistingClassificationSystems.en_main.name],
+            secondary=predictions[ExistingClassificationSystems.en_secondary.name],
         )
 
     return ClassifyResponse(**predictions)

--- a/src/app/api/v1/endpoints/classify_all.py
+++ b/src/app/api/v1/endpoints/classify_all.py
@@ -147,9 +147,10 @@ def classify(request: ClassifyRequest, bert_models: dict[str, BertModel]) -> Cla
         ExistingClassificationSystems.en_secondary.name in predictions
         and ExistingClassificationSystems.en_main.name in predictions
     ):
-        predictions[ExistingClassificationSystems.en_secondary.name] = _update_main_secondary_consistency(
-            main=predictions[ExistingClassificationSystems.en_main.name],
-            secondary=predictions[ExistingClassificationSystems.en_secondary.name],
-        )
+        predictions[ExistingClassificationSystems.en_secondary.name] = [
+            sec
+            for sec in predictions[ExistingClassificationSystems.en_secondary.name]
+            if sec != predictions[ExistingClassificationSystems.en_main.name]
+        ]
 
     return ClassifyResponse(**predictions)

--- a/src/app/api/v1/endpoints/classify_all.py
+++ b/src/app/api/v1/endpoints/classify_all.py
@@ -84,14 +84,14 @@ def load_models() -> dict[str, BertModel]:
 def _update_main_secondary_consistency(
     main: ENMainSystem.ENMainClasses, secondary: list[ENMainSystem.ENMainClasses]
 ) -> list[ENMainSystem.ENMainClasses]:
-    """Drop the main class from the secondary predictions to avoid redundance.
+    """Drop the main class from the secondary predictions to avoid redundancy.
 
     Args:
         main: Predicted main lithology class.
         secondary: Predicted secondary lithology classes (ranked).
 
     Returns:
-        The secondary classes with entry matching `main` removed.
+        The secondary classes with the entry matching `main` removed.
     """
     return [sec for sec in secondary if sec != main]
 


### PR DESCRIPTION
Closes #555 

Avoid redundancy of main component in secondary

## Before
<img width="1303" height="409" alt="Screenshot 2026-08-27 at 15 14 11" src="https://github.com/user-attachments/assets/b03f1983-848d-4067-a6d9-1675bb6fb3ab" />
## After
<img width="1306" height="393" alt="Screenshot 2026-08-27 at 15 12 44" src="https://github.com/user-attachments/assets/4c791221-dca8-4cd9-98f2-68ea31d29087" />


