### PR TITLE
insert single whitespace between wrapped lines (where no newline is inserted)

### DIFF
--- a/src/swissgeol_doc_processing/text/textblock.py
+++ b/src/swissgeol_doc_processing/text/textblock.py
@@ -92,6 +92,8 @@ class MaterialDescription(ExtractedFeature):
             is_break = new_page or gap_ratio > 0.3 or has_large_vertical_gap
             if is_break:
                 prev_line.feature.text += "\n"
+            else:
+                prev_line.feature.text += " "
 
         self.text = "".join([line.feature.text for line in self.lines])
         return self


### PR DESCRIPTION
Fixes a small mistake in https://github.com/swisstopo/swissgeol-boreholes-dataextraction/pull/544 : when there is no line break detected, the text lines should be joined with a single whitespace in between, rather that joining the last word of the previous line and the first word of the next line in to a single mangled word.